### PR TITLE
corrected use of undeclared identifier 'miopenActivationPATHRU'

### DIFF
--- a/src/hcc_detail/hipDNN_miopen.cpp
+++ b/src/hcc_detail/hipDNN_miopen.cpp
@@ -369,7 +369,7 @@ hipdnnStatus_t miopenTohipActivationMode(miopenActivationMode_t in,
         *out = HIPDNN_ACTIVATION_TANH;
         break;
 
-    case miopenActivationPASTHRU:
+    case miopenActivationPATHTRU:
         *out = HIPDNN_ACTIVATION_PATHTRU;
         break;
 
@@ -412,7 +412,7 @@ hipdnnStatus_t hipTomiopenActivationMode(hipdnnActivationMode_t in,
 
     case HIPDNN_ACTIVATION_PATHTRU:
         HIPDNN_OPEN_LOG_M("HIPDNN_ACTIVATION_PATHTRU"  << std::flush);
-        *out = miopenActivationPASTHRU;
+        *out = miopenActivationPATHTRU;
         break;
 
     case HIPDNN_ACTIVATION_SOFTRELU:


### PR DESCRIPTION
**Errors encountered and corrected** 


src/hcc_detail/hipDNN_miopen.cpp:372:10: error: use of undeclared identifier 'miopenActivationPATHRU'; did you mean
      'miopenActivationPATHTRU'?
    case miopenActivationPATHRU:
         ^~~~~~~~~~~~~~~~~~~~~~
         miopenActivationPATHTRU
/opt/rocm/miopen/include/miopen/miopen.h:341:5: note: 'miopenActivationPATHTRU' declared here
    miopenActivationPATHTRU  = 0, /*!< No activation, pass through the data */
    ^
src/hcc_detail/hipDNN_miopen.cpp:415:16: error: use of undeclared identifier 'miopenActivationPATHRU'; did you mean
      'miopenActivationPATHTRU'?
        *out = miopenActivationPATHRU;
               ^~~~~~~~~~~~~~~~~~~~~~
               miopenActivationPATHTRU
/opt/rocm/miopen/include/miopen/miopen.h:341:5: note: 'miopenActivationPATHTRU' declared here
    miopenActivationPATHTRU  = 0, /*!< No activation, pass through the data */
    ^
2 errors generated.
src/hcc_detail/hipDNN_miopen.cpp:372:10: error: use of undeclared identifier 'miopenActivationPATHRU'; did you mean
      'miopenActivationPATHTRU'?
    case miopenActivationPATHRU:
         ^~~~~~~~~~~~~~~~~~~~~~
         miopenActivationPATHTRU
/opt/rocm/miopen/include/miopen/miopen.h:341:5: note: 'miopenActivationPATHTRU' declared here
    miopenActivationPATHTRU  = 0, /*!< No activation, pass through the data */
    ^
src/hcc_detail/hipDNN_miopen.cpp:415:16: error: use of undeclared identifier 'miopenActivationPATHRU'; did you mean
      'miopenActivationPATHTRU'?
        *out = miopenActivationPATHRU;
               ^~~~~~~~~~~~~~~~~~~~~~
               miopenActivationPATHTRU