### PR TITLE
Wrong  declaration of case "miopenActivationPATHTRU" . It should be "…

### DIFF
--- a/src/hcc_detail/hipDNN_miopen.cpp
+++ b/src/hcc_detail/hipDNN_miopen.cpp
@@ -371,7 +371,7 @@ hipdnnStatus_t miopenTohipActivationMode(miopenActivationMode_t in,
         *out = HIPDNN_ACTIVATION_TANH;
         break;
 
-    case miopenActivationPATHTRU:
+    case miopenActivationPASTHRU:
         *out = HIPDNN_ACTIVATION_PATHTRU;
         break;
 
@@ -414,7 +414,7 @@ hipdnnStatus_t hipTomiopenActivationMode(hipdnnActivationMode_t in,
 
     case HIPDNN_ACTIVATION_PATHTRU:
         HIPDNN_OPEN_LOG_M("HIPDNN_ACTIVATION_PATHTRU"  << std::flush);
-        *out = miopenActivationPATHTRU;
+        *out = miopenActivationPASTHRU;
         break;
 
     case HIPDNN_ACTIVATION_SOFTRELU:


### PR DESCRIPTION
…miopenActivationPASTHRU"


As per https://github.com/ROCmSoftwarePlatform/MIOpen/blob/master/include/miopen/miopen.h Line : 350.,
enum is defined as "miopenActivationPASTHRU" but in hipDNN , it is miopenActivationPATHTRU.
Due to this issue, hipDNN building is failing.

src/hcc_detail/hipDNN_miopen.cpp:374:10: error: use of undeclared identifier 'miopenActivationPATHTRU'; did you mean
      'miopenActivationPASTHRU'?
    case miopenActivationPATHTRU:
         ^~~~~~~~~~~~~~~~~~~~~~~
         miopenActivationPASTHRU
/opt/rocm/miopen/include/miopen/miopen.h:352:5: note: 'miopenActivationPASTHRU' declared here
    miopenActivationPASTHRU  = 0, /*!< No activation, pass through the data */
    ^
1 error generated.