### PR TITLE
add apis for CTCLoss, test=develop

### DIFF
--- a/library/include/hipdnn.h
+++ b/library/include/hipdnn.h
@@ -1128,6 +1128,9 @@ hipdnnStatus_t
 hipdnnCreateDropoutDescriptor( hipdnnDropoutDescriptor_t *dropoutDesc);
 
 hipdnnStatus_t
+hipdnnDestroyDropoutDescriptor( hipdnnDropoutDescriptor_t dropoutDesc);
+
+hipdnnStatus_t
 hipdnnDropoutGetStatesSize(hipdnnHandle_t handle, size_t *sizeInBytes);
 
 hipdnnStatus_t
@@ -1139,7 +1142,12 @@ hipdnnSetDropoutDescriptor( hipdnnDropoutDescriptor_t dropoutDesc,
                             unsigned long long seed);
 
 hipdnnStatus_t
-hipdnnDestroyDropoutDescriptor( hipdnnDropoutDescriptor_t dropoutDesc);
+hipdnnRestoreDropoutDescriptor(hipdnnDropoutDescriptor_t dropoutDesc,
+                               hipdnnHandle_t handle,
+                               float dropout,
+                               void *states,
+                               size_t stateSizeInBytes,
+                               unsigned long long seed);
 
 //======================= Recurrent Neural Net =================================
 

--- a/library/include/hipdnn.h
+++ b/library/include/hipdnn.h
@@ -1053,22 +1053,24 @@ hipdnnStatus_t hipdnnDeriveBNTensorDescriptor(
                                          const hipdnnTensorDescriptor_t xDesc,
                                          hipdnnBatchNormMode_t mode);
 
-hipdnnStatus_t
-hipdnnBatchNormalizationForwardTraining( hipdnnHandle_t handle,
-                          hipdnnBatchNormMode_t mode,
-                          void *alpha, void *beta,
-                          const hipdnnTensorDescriptor_t xDesc,
-                          const void *x,
-                          const hipdnnTensorDescriptor_t yDesc,
-                          void *y,
-                          const hipdnnTensorDescriptor_t bnScaleBiasMeanVarDesc,
-                          void *bnScale, void *bnBias,
-                          double exponentialAverageFactor,
-                          void *resultRunningMean,
-                          void *resultRunningVariance,
-                          double epsilon,
-                          void *resultSaveMean,
-                          void *resultSaveInvVariance);
+hipdnnStatus_t hipdnnBatchNormalizationForwardTraining(
+    hipdnnHandle_t handle, 
+    hipdnnBatchNormMode_t mode, 
+    const void *alpha,
+    const void *beta,
+    const hipdnnTensorDescriptor_t xDesc, 
+    const void *x,
+    const hipdnnTensorDescriptor_t yDesc, 
+    void *y,
+    const hipdnnTensorDescriptor_t bnScaleBiasMeanVarDesc, 
+    const void *bnScale,
+    const void *bnBias, 
+    double exponentialAverageFactor, 
+    void *resultRunningMean,
+    void *resultRunningVariance, 
+    double epsilon, 
+    void *resultSaveMean,
+    void *resultSaveInvVariance);
 
 hipdnnStatus_t
 hipdnnnBatchNormalizationForwardInference( hipdnnHandle_t handle,

--- a/library/include/hipdnn.h
+++ b/library/include/hipdnn.h
@@ -367,6 +367,12 @@ typedef enum {
     HIPDNN_HORIZONTAL_FUSION = 1,
 } hipdnnFusionDirection_t;
 
+//--------------------------- CTCLoss datatypes ---------------------------------
+
+typedef enum {
+    HIPDNN_CTC_LOSS_ALGO_DETERMINISTIC = 0,
+} hipdnnCTCLossAlgo_t;
+
 //------------------------------- Opaque Pointers ------------------------------
 
 typedef void *hipdnnHandle_t;
@@ -402,6 +408,8 @@ typedef void *hipdnnFusionPlanDescriptor_t;
 typedef void *hipdnnFusionOpDescriptor_t;
 
 typedef void *hipdnnOperatorArgs_t;
+
+typedef void *hipdnnCTCLossDescriptor_t;
 
 //==============================================================================
 
@@ -613,6 +621,15 @@ hipdnnSetConvolutionNdDescriptor( hipdnnConvolutionDescriptor_t convDesc,
                                   const int dilationA[],
                                   hipdnnConvolutionMode_t mode,
                                   hipdnnDataType_t computeType);  /* convolution data type */
+hipdnnStatus_t
+hipdnnGetConvolutionNdDescriptor( hipdnnConvolutionDescriptor_t convDesc,
+                                  int requestedSpatialDim,
+                                  int* spatialDim,
+                                  int* padA,
+                                  int* strideA,
+                                  int* dilationA,
+                                  hipdnnConvolutionMode_t* mode,
+                                  hipdnnDataType_t* computeType);
 
 hipdnnStatus_t
 hipdnnDestroyConvolutionDescriptor( hipdnnConvolutionDescriptor_t convDesc);
@@ -1456,6 +1473,48 @@ hipdnnStatus_t hipdnnDestroyOperatorArgs( hipdnnOperatorArgs_t args);
 hipdnnStatus_t
 hipdnnDestroyFusionPlan( hipdnnFusionPlanDescriptor_t fusePlanDesc);
 
+//========================== CTCLoss API ========================================
+
+hipdnnStatus_t 
+hipdnnCreateCTCLossDescriptor(hipdnnCTCLossDescriptor_t *CTCLossDesc);
+
+hipdnnStatus_t 
+hipdnnDestroyCTCLossDescriptor(hipdnnCTCLossDescriptor_t CTCLossDesc);
+
+hipdnnStatus_t 
+hipdnnGetCTCLossDescriptor(hipdnnCTCLossDescriptor_t ctcLossDesc, 
+                           hipdnnDataType_t* dataType, 
+                           int* blank_label_id, 
+                           bool* apply_softmax_layer);
+hipdnnStatus_t 
+hipdnnSetCTCLossDescriptor(hipdnnCTCLossDescriptor_t ctcLossDesc, 
+                           hipdnnDataType_t dataType, 
+                           const int blank_label_id, 
+                           bool apply_softmax_layer);
+hipdnnStatus_t 
+hipdnnGetCTCLossWorkspaceSize(hipdnnHandle_t handle,
+                              const hipdnnTensorDescriptor_t probsDesc,
+                              const hipdnnTensorDescriptor_t gradientsDesc,
+                              const int* labels,
+                              const int* labelLengths,
+                              const int* inputLengths,
+                              hipdnnCTCLossAlgo_t algo,
+                              const hipdnnCTCLossDescriptor_t ctcLossDesc,
+                              size_t* workSpaceSize);
+
+hipdnnStatus_t hipdnnCTCLoss(hipdnnHandle_t handle,
+                             const hipdnnTensorDescriptor_t probsDesc,
+                             const void* probs,
+                             const int* labels,
+                             const int* labelLengths,
+                             const int* inputLengths,
+                             void* losses,
+                             const hipdnnTensorDescriptor_t gradientsDesc,
+                             void* gradients,
+                             hipdnnCTCLossAlgo_t algo,
+                             const hipdnnCTCLossDescriptor_t ctcLossDesc,
+                             void* workSpace,
+                             size_t workSpaceSize);
 //==============================================================================
 
 const char *hipdnnGetErrorString(hipdnnStatus_t status);

--- a/library/src/hcc_detail/hipdnn_miopen.cpp
+++ b/library/src/hcc_detail/hipdnn_miopen.cpp
@@ -3510,33 +3510,42 @@ hipdnnStatus_t hipdnnBatchNormalizationForwardInference(
 
 hipdnnStatus_t hipdnnCreateDropoutDescriptor(
     hipdnnDropoutDescriptor_t *dropoutDesc) {
-    HIPDNN_OPEN_LOG_E("hipdnnCreateDropoutDescriptor: NOT SUPPORTED."
-                      << std::flush);
-    return HIPDNN_STATUS_NOT_SUPPORTED;
+    CHECK_MIO(miopenCreateDropoutDescriptor((miopenDropoutDescriptor_t *)dropoutDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
+hipdnnStatus_t hipdnnDestroyDropoutDescriptor(
+    hipdnnDropoutDescriptor_t dropoutDesc) {
+    CHECK_MIO(miopenDestroyDropoutDescriptor((miopenDropoutDescriptor_t)dropoutDesc));
+    return HIPDNN_STATUS_SUCCESS;
 }
 
 hipdnnStatus_t hipdnnSetDropoutDescriptor(hipdnnDropoutDescriptor_t dropoutDesc,
                                           hipdnnHandle_t handle, float dropout,
                                           void *states, size_t stateSizeInBytes,
                                           unsigned long long seed) {
-    HIPDNN_OPEN_LOG_E("hipdnnSetDropoutDescriptor: NOT SUPPORTED."
-                      << std::flush);
-    return HIPDNN_STATUS_NOT_SUPPORTED;
+    CHECK_MIO(miopenSetDropoutDescriptor((miopenDropoutDescriptor_t)dropoutDesc,
+              (miopenHandle_t)handle, dropout, states, stateSizeInBytes, seed,
+              false, false, MIOPEN_RNG_PSEUDO_XORWOW));
+    return HIPDNN_STATUS_SUCCESS;
 }
 
 hipdnnStatus_t hipdnnDropoutGetStatesSize(hipdnnHandle_t handle,
                                           size_t *sizeInBytes) {
-    HIPDNN_OPEN_LOG_E("hipdnnDropoutGetStatesSize: NOT SUPPORTED."
-                      << std::endl
-                      << std::flush);
-    return HIPDNN_STATUS_NOT_SUPPORTED;
+    CHECK_MIO(miopenDropoutGetStatesSize((miopenHandle_t)handle, sizeInBytes));
+    return HIPDNN_STATUS_SUCCESS;
 }
 
-hipdnnStatus_t hipdnnDestroyDropoutDescriptor(
-    hipdnnDropoutDescriptor_t dropoutDesc) {
-    HIPDNN_OPEN_LOG_E("hipdnnDestroyDropoutDescriptor: NOT SUPPORTED."
-                      << std::flush);
-    return HIPDNN_STATUS_NOT_SUPPORTED;
+
+hipdnnStatus_t 
+hipdnnRestoreDropoutDescriptor(hipdnnDropoutDescriptor_t dropoutDesc,
+                               hipdnnHandle_t handle, float dropout,
+                               void *states, size_t stateSizeInBytes,
+                               unsigned long long seed) {
+    CHECK_MIO(miopenRestoreDropoutDescriptor((miopenDropoutDescriptor_t)dropoutDesc,
+              (miopenHandle_t)handle, dropout, states, stateSizeInBytes, seed,
+              false, false, MIOPEN_RNG_PSEUDO_XORWOW));
+    return HIPDNN_STATUS_SUCCESS;
 }
 
 hipdnnStatus_t hipdnnCreateReduceTensorDescriptor(

--- a/library/src/hcc_detail/hipdnn_miopen.cpp
+++ b/library/src/hcc_detail/hipdnn_miopen.cpp
@@ -2852,20 +2852,33 @@ hipdnnStatus_t hipdnnDeriveBNTensorDescriptor(
 //=============================================================================
 
 hipdnnStatus_t hipdnnBatchNormalizationForwardTraining(
-    hipdnnHandle_t handle, hipdnnBatchNormMode_t mode, void *alpha, void *beta,
-    const hipdnnTensorDescriptor_t xDesc, const void *x,
-    const hipdnnTensorDescriptor_t yDesc, void *y,
-    const hipdnnTensorDescriptor_t bnScaleBiasMeanVarDesc, void *bnScale,
-    void *bnBias, double exponentialAverageFactor, void *resultRunningMean,
-    void *resultRunningVariance, double epsilon, void *resultSaveMean,
+    hipdnnHandle_t handle, 
+    hipdnnBatchNormMode_t mode, 
+    const void *alpha,
+    const void *beta,
+    const hipdnnTensorDescriptor_t xDesc, 
+    const void *x,
+    const hipdnnTensorDescriptor_t yDesc, 
+    void *y,
+    const hipdnnTensorDescriptor_t bnScaleBiasMeanVarDesc, 
+    const void *bnScale,
+    const void *bnBias, 
+    double exponentialAverageFactor, 
+    void *resultRunningMean,
+    void *resultRunningVariance, 
+    double epsilon, 
+    void *resultSaveMean,
     void *resultSaveInvVariance) {
     HIPDNN_OPEN_LOG_C("Inside hipdnnBatchNormalizationForwardTraining");
     miopenBatchNormMode_t miBNMode;
     CHECK_HIPDNN(hipTomiopenBatchNormMode(mode, &miBNMode));
     CHECK_MIO(miopenBatchNormalizationForwardTraining(
-        (miopenHandle_t)handle, miBNMode, alpha, beta,
-        (miopenTensorDescriptor_t)xDesc, x, (miopenTensorDescriptor_t)yDesc, y,
-        (miopenTensorDescriptor_t)bnScaleBiasMeanVarDesc, bnScale, bnBias,
+        (miopenHandle_t)handle, miBNMode, 
+        const_cast<void*>(alpha), const_cast<void*>(beta),
+        (miopenTensorDescriptor_t)xDesc, x, 
+        (miopenTensorDescriptor_t)yDesc, y,
+        (miopenTensorDescriptor_t)bnScaleBiasMeanVarDesc, 
+        const_cast<void*>(bnScale), const_cast<void*>(bnBias),
         exponentialAverageFactor, resultRunningMean, resultRunningVariance,
         epsilon, resultSaveMean, resultSaveInvVariance));
     return HIPDNN_STATUS_SUCCESS;

--- a/library/src/nvcc_detail/hipdnn_cudnn.cpp
+++ b/library/src/nvcc_detail/hipdnn_cudnn.cpp
@@ -2307,6 +2307,12 @@ hipdnnCreateDropoutDescriptor(hipdnnDropoutDescriptor_t *dropoutDesc) {
     return HIPDNN_STATUS_SUCCESS;
 }
 
+hipdnnStatus_t
+hipdnnDestroyDropoutDescriptor(hipdnnDropoutDescriptor_t dropoutDesc) {
+    CHECK_CUDNN(cudnnDestroyDropoutDescriptor((cudnnDropoutDescriptor_t)dropoutDesc));
+    return HIPDNN_STATUS_SUCCESS;
+}
+
 hipdnnStatus_t hipdnnDropoutGetStatesSize(hipdnnHandle_t handle,
                                           size_t *sizeInBytes) {
     CHECK_CUDNN(cudnnDropoutGetStatesSize((cudnnHandle_t)handle, sizeInBytes));
@@ -2326,8 +2332,16 @@ hipdnnStatus_t hipdnnSetDropoutDescriptor(hipdnnDropoutDescriptor_t dropoutDesc,
 }
 
 hipdnnStatus_t
-hipdnnDestroyDropoutDescriptor(hipdnnDropoutDescriptor_t dropoutDesc) {
-    CHECK_CUDNN(cudnnDestroyDropoutDescriptor((cudnnDropoutDescriptor_t)dropoutDesc));
+hipdnnRestoreDropoutDescriptor(hipdnnDropoutDescriptor_t dropoutDesc,
+                               hipdnnHandle_t handle,
+                               float dropout,
+                               void *states,
+                               size_t stateSizeInBytes,
+                               unsigned long long seed) {
+    CHECK_CUDNN(cudnnRestoreDropoutDescriptor(
+        (cudnnDropoutDescriptor_t)dropoutDesc, (cudnnHandle_t)handle, dropout,
+        states, stateSizeInBytes, seed));
+
     return HIPDNN_STATUS_SUCCESS;
 }
 

--- a/library/src/nvcc_detail/hipdnn_cudnn.cpp
+++ b/library/src/nvcc_detail/hipdnn_cudnn.cpp
@@ -2208,12 +2208,22 @@ hipdnnDeriveBNTensorDescriptor(hipdnnTensorDescriptor_t derivedBnDesc,
 //=============================================================================
 
 hipdnnStatus_t hipdnnBatchNormalizationForwardTraining(
-    hipdnnHandle_t handle, hipdnnBatchNormMode_t mode, void *alpha, void *beta,
-    const hipdnnTensorDescriptor_t xDesc, const void *x,
-    const hipdnnTensorDescriptor_t yDesc, void *y,
-    const hipdnnTensorDescriptor_t bnScaleBiasMeanVarDesc, void *bnScale,
-    void *bnBias, double exponentialAverageFactor, void *resultRunningMean,
-    void *resultRunningVariance, double epsilon, void *resultSaveMean,
+    hipdnnHandle_t handle, 
+    hipdnnBatchNormMode_t mode, 
+    const void *alpha,
+    const void *beta,
+    const hipdnnTensorDescriptor_t xDesc, 
+    const void *x,
+    const hipdnnTensorDescriptor_t yDesc, 
+    void *y,
+    const hipdnnTensorDescriptor_t bnScaleBiasMeanVarDesc, 
+    const void *bnScale,
+    const void *bnBias, 
+    double exponentialAverageFactor, 
+    void *resultRunningMean,
+    void *resultRunningVariance, 
+    double epsilon, 
+    void *resultSaveMean,
     void *resultSaveInvVariance) {
     CHECK_CUDNN(cudnnBatchNormalizationForwardTraining(
         (cudnnHandle_t)handle, hipTocudnnBatchNormMode(mode), alpha, beta,


### PR DESCRIPTION
Add new apis and both implementation of cudnn and miopen:

- hipdnnGetConvolutionNdDescriptor
- hipdnnCreateCTCLossDescriptor
- hipdnnDestroyCTCLossDescriptor
- hipdnnGetCTCLossDescriptor
- hipdnnSetCTCLossDescriptor
- hipdnnGetCTCLossWorkspaceSize
- hipdnnCTCLoss

Also fix "hc::half" undefined in ROCM 3.5 with __half in <hip/hip_fp16.h>