### PR TITLE
Added tensor() and tensor_like() to Graph

### DIFF
--- a/frontend/include/hipdnn_frontend/graph.hpp
+++ b/frontend/include/hipdnn_frontend/graph.hpp
@@ -293,6 +293,24 @@ public:
 
         return out_0;
     }
+
+    static std::shared_ptr<Tensor_attributes> tensor_like(const std::shared_ptr<Tensor_attributes>& tensor,
+                                                          const std::string& name = "")
+    {
+        auto new_tensor = std::make_shared<Tensor_attributes>(*tensor);
+
+        new_tensor->clear_uid();
+        new_tensor->set_name(name);
+
+        return new_tensor;
+    }
+
+    static std::shared_ptr<Tensor_attributes> tensor(const Tensor_attributes& tensor)
+    {
+        auto new_tensor = std::make_shared<Tensor_attributes>(tensor);
+
+        return new_tensor;
+    }    
 };
 }
 }

--- a/frontend/include/hipdnn_frontend/graph.hpp
+++ b/frontend/include/hipdnn_frontend/graph.hpp
@@ -294,8 +294,8 @@ public:
         return out_0;
     }
 
-    static std::shared_ptr<Tensor_attributes> tensor_like(const std::shared_ptr<Tensor_attributes>& tensor,
-                                                          const std::string& name = "")
+    static std::shared_ptr<Tensor_attributes>
+        tensor_like(const std::shared_ptr<Tensor_attributes>& tensor, const std::string& name = "")
     {
         auto new_tensor = std::make_shared<Tensor_attributes>(*tensor);
 
@@ -310,7 +310,7 @@ public:
         auto new_tensor = std::make_shared<Tensor_attributes>(tensor);
 
         return new_tensor;
-    }    
+    }
 };
 }
 }

--- a/frontend/tests/test_graph.cpp
+++ b/frontend/tests/test_graph.cpp
@@ -863,7 +863,13 @@ TEST(GraphTests, TensorLikeGraphAttributes)
     EXPECT_EQ(tensor_like->get_name(), "TensorLike");
     EXPECT_NE(tensor_like->get_uid(), 100);
 
+    EXPECT_NE(tensor_like, tensor);
+
     auto tensor_like_noname = Graph::tensor_like(tensor_like);
     EXPECT_EQ(tensor_like_noname->get_name(), "");
+
+    EXPECT_EQ(tensor->get_name(), "TestTensor");
+    EXPECT_EQ(tensor->get_uid(), 100);
+    EXPECT_NE(tensor->get_uid(), tensor_like_noname->get_uid());
 }
 // NOLINTEND

--- a/frontend/tests/test_graph.cpp
+++ b/frontend/tests/test_graph.cpp
@@ -847,12 +847,12 @@ TEST(GraphTests, TensorGraphAttributes)
 TEST(GraphTests, TensorLikeGraphAttributes)
 {
     auto tensor = Graph::tensor(Tensor_attributes()
-                                         .set_name("TestTensor")
-                                         .set_uid(100)
-                                         .set_dim({1, 2, 3, 4})
-                                         .set_stride({5, 6, 7, 8})
-                                         .set_is_virtual(false)
-                                         .set_data_type(DataType_t::FLOAT));
+                                    .set_name("TestTensor")
+                                    .set_uid(100)
+                                    .set_dim({1, 2, 3, 4})
+                                    .set_stride({5, 6, 7, 8})
+                                    .set_is_virtual(false)
+                                    .set_data_type(DataType_t::FLOAT));
 
     auto tensor_like = Graph::tensor_like(tensor, "TensorLike");
 
@@ -865,6 +865,5 @@ TEST(GraphTests, TensorLikeGraphAttributes)
 
     auto tensor_like_noname = Graph::tensor_like(tensor_like);
     EXPECT_EQ(tensor_like_noname->get_name(), "");
-
 }
 // NOLINTEND

--- a/frontend/tests/test_graph.cpp
+++ b/frontend/tests/test_graph.cpp
@@ -823,4 +823,48 @@ TEST(GraphTests, BuildAndSerializePointwiseAndBatchnormBackwardGraph)
     EXPECT_EQ(deserialized_batchnorm_attributes->dscale, dscale->get_uid());
     EXPECT_EQ(deserialized_batchnorm_attributes->dbias, dbias->get_uid());
 }
+
+// Test graph.tensor()
+TEST(GraphTests, TensorGraphAttributes)
+{
+    auto tensor = Graph::tensor(Tensor_attributes()
+                                    .set_name("TestTensor")
+                                    .set_uid(100)
+                                    .set_stride({5, 6, 7, 8})
+                                    .set_data_type(DataType_t::FLOAT)
+                                    .set_is_virtual(false)
+                                    .set_dim({1, 2, 3, 4}));
+
+    EXPECT_EQ(tensor->get_data_type(), DataType_t::FLOAT);
+    EXPECT_FALSE(tensor->get_is_virtual());
+    EXPECT_EQ(tensor->get_dim(), std::vector<int64_t>({1, 2, 3, 4}));
+    EXPECT_EQ(tensor->get_stride(), std::vector<int64_t>({5, 6, 7, 8}));
+    EXPECT_EQ(tensor->get_name(), "TestTensor");
+    EXPECT_EQ(tensor->get_uid(), 100);
+}
+
+// Test graph.tensor_like()
+TEST(GraphTests, TensorLikeGraphAttributes)
+{
+    auto tensor = Graph::tensor(Tensor_attributes()
+                                         .set_name("TestTensor")
+                                         .set_uid(100)
+                                         .set_dim({1, 2, 3, 4})
+                                         .set_stride({5, 6, 7, 8})
+                                         .set_is_virtual(false)
+                                         .set_data_type(DataType_t::FLOAT));
+
+    auto tensor_like = Graph::tensor_like(tensor, "TensorLike");
+
+    EXPECT_EQ(tensor_like->get_data_type(), DataType_t::FLOAT);
+    EXPECT_FALSE(tensor_like->get_is_virtual());
+    EXPECT_EQ(tensor_like->get_dim(), std::vector<int64_t>({1, 2, 3, 4}));
+    EXPECT_EQ(tensor_like->get_stride(), std::vector<int64_t>({5, 6, 7, 8}));
+    EXPECT_EQ(tensor_like->get_name(), "TensorLike");
+    EXPECT_NE(tensor_like->get_uid(), 100);
+
+    auto tensor_like_noname = Graph::tensor_like(tensor_like);
+    EXPECT_EQ(tensor_like_noname->get_name(), "");
+
+}
 // NOLINTEND


### PR DESCRIPTION
## Proposed changes
Added tensor() and tensor_like() methods to the Graph frontend api.  The cuDNN version did a lot of internal tracking for the purposes of uid collision checking and validation, which we don't appear to need, so it simplified them enough that they could become static methods.  I left them on Graph for api compatibility.

## Checklist

- [x] I have added automated tests relevant to the introduced functionality
- [x] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [x] I have ran the tests, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [x] I have ran `make format` & `make check_format` to ensure the changes have been formatted
