### PR TITLE
Remove warning disables around the hip runtime API include

### DIFF
--- a/backend/include/hipdnn_backend.h
+++ b/backend/include/hipdnn_backend.h
@@ -3,14 +3,7 @@
 
 #pragma once
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wsign-conversion"
-#pragma clang diagnostic ignored "-Wold-style-cast"
-#pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
-#pragma clang diagnostic ignored "-Wnested-anon-types"
-
 #include <hip/hip_runtime_api.h>
-#pragma clang diagnostic pop
 
 // Cmake Generated export header.
 #include "hipdnn_backend_export.h"


### PR DESCRIPTION
## Proposed changes

Removing warning disables around hip runtime include to prevent issues with warnings getting remove in other components un-intentionally. 

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [X] I have added automated tests relevant to the introduced functionality
- [X] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [X] I have ran the tests, and they are all passing locally
- [X] I have added relevant documentation for the changes
- [X] I have removed the stale documentation which is no longer relevant after this pull request
- [X] I have ran `make format` & `make check_format` to ensure the changes have been formatted
