### PR TITLE
Fix tests failing with logging env vars

### DIFF
--- a/backend/src/hipdnn_backend.cpp
+++ b/backend/src/hipdnn_backend.cpp
@@ -212,10 +212,19 @@ HIPDNN_BACKEND_EXPORT hipdnnStatus_t
                                   element_count,
                                   array_of_elements);
 
-        LOG_API_SUCCESS(api_name,
-                        "status={}, retrieved_element_count={}",
-                        hipdnn_backend::hipdnn_get_status_string(HIPDNN_STATUS_SUCCESS),
-                        *element_count);
+        if(element_count == nullptr)
+        {
+            LOG_API_SUCCESS(api_name,
+                            "status={}, element_count_ptr=nullptr",
+                            hipdnn_backend::hipdnn_get_status_string(HIPDNN_STATUS_SUCCESS));
+        }
+        else
+        {
+            LOG_API_SUCCESS(api_name,
+                            "status={}, retrieved_element_count={}",
+                            hipdnn_backend::hipdnn_get_status_string(HIPDNN_STATUS_SUCCESS),
+                            *element_count);
+        }
     });
 }
 

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ add_executable(hipdnn_sdk_tests
 )
 
 target_compile_definitions(hipdnn_sdk_tests PRIVATE
-    COMPONENT_NAME="sdk_tests"
+    COMPONENT_NAME="hipdnn_sdk_tests"
 )
 
 target_compile_options(hipdnn_sdk_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})


### PR DESCRIPTION
## Proposed changes

Quick fix for tests failing when logging env vars set (ALMIOPEN-99). Wasn't sure how easy this would be and it predated my other logging PR so did it separately. 

Also changed a wrong component name here since I don't want to restart CI for the other one.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [x] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [x] I have ran the tests, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [x] I have ran `make format` & `make check_format` to ensure the changes have been formatted
