### PR TITLE
Move callback implementation to private library

### DIFF
--- a/backend/src/hipdnn_backend.cpp
+++ b/backend/src/hipdnn_backend.cpp
@@ -13,7 +13,6 @@
 #include "logging/logging.hpp"
 #include "plugin/plugin_manager.hpp"
 #include <hipdnn_sdk/logging/callback_types.h>
-#include <spdlog/spdlog.h>
 
 #include <hipdnn_sdk/utilities/string_util.hpp>
 

--- a/backend/src/hipdnn_backend.cpp
+++ b/backend/src/hipdnn_backend.cpp
@@ -289,26 +289,5 @@ HIPDNN_BACKEND_EXPORT void hipdnnGetLastErrorString(char* message, size_t max_si
 
 HIPDNN_BACKEND_EXPORT void hipdnnLoggingCallback_ext(hipdnnSeverity_t severity, const char* msg)
 {
-    hipdnn_backend::logging::initialize();
-
-    if(auto logger = hipdnn_backend::logging::get_callback_receiver_logger())
-    {
-        switch(severity)
-        {
-        case HIPDNN_SEV_FATAL:
-            logger->critical(msg);
-            break;
-        case HIPDNN_SEV_ERROR:
-            logger->error(msg);
-            break;
-        case HIPDNN_SEV_WARN:
-            logger->warn(msg);
-            break;
-        case HIPDNN_SEV_OFF:
-            break;
-        default:
-            logger->info(msg);
-            break;
-        }
-    }
+    hipdnn_backend::logging::hipdnn_logging_callback(severity, msg);
 }

--- a/backend/src/logging/logging.cpp
+++ b/backend/src/logging/logging.cpp
@@ -135,9 +135,9 @@ std::shared_ptr<spdlog::logger> get_backend_logger()
 
 void hipdnn_logging_callback(hipdnnSeverity_t severity, const char* msg)
 {
-    hipdnn_backend::logging::initialize();
+    initialize();
 
-    if(auto logger = hipdnn_backend::logging::get_callback_receiver_logger())
+    if(auto logger = get_callback_receiver_logger())
     {
         switch(severity)
         {

--- a/backend/src/logging/logging.cpp
+++ b/backend/src/logging/logging.cpp
@@ -7,6 +7,7 @@
 #include <hipdnn_sdk/logging/formatting.hpp>
 #include <iostream>
 
+#include <hipdnn_sdk/logging/callback_types.h>
 #include <spdlog/async.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -130,6 +131,32 @@ std::shared_ptr<spdlog::logger> get_callback_receiver_logger()
 std::shared_ptr<spdlog::logger> get_backend_logger()
 {
     return spdlog::get(S_BACKEND_LOGGER_NAME);
+}
+
+void hipdnn_logging_callback(hipdnnSeverity_t severity, const char* msg)
+{
+    hipdnn_backend::logging::initialize();
+
+    if(auto logger = hipdnn_backend::logging::get_callback_receiver_logger())
+    {
+        switch(severity)
+        {
+        case HIPDNN_SEV_FATAL:
+            logger->critical(msg);
+            break;
+        case HIPDNN_SEV_ERROR:
+            logger->error(msg);
+            break;
+        case HIPDNN_SEV_WARN:
+            logger->warn(msg);
+            break;
+        case HIPDNN_SEV_OFF:
+            break;
+        default:
+            logger->info(msg);
+            break;
+        }
+    }
 }
 
 } // namespace logging

--- a/backend/src/logging/logging.hpp
+++ b/backend/src/logging/logging.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <hipdnn_sdk/logging/callback_types.h>
 #include <memory>
 #include <spdlog/spdlog.h>
 
@@ -37,6 +38,8 @@ void set_log_level(const std::string& level);
 std::shared_ptr<spdlog::logger> get_backend_logger();
 
 std::shared_ptr<spdlog::logger> get_callback_receiver_logger();
+
+void hipdnn_logging_callback(hipdnnSeverity_t severity, const char* msg);
 
 } // namespace logging
 } // namespace hipdnn_backend

--- a/backend/src/plugin/plugin_manager.cpp
+++ b/backend/src/plugin/plugin_manager.cpp
@@ -7,7 +7,6 @@
 #include "descriptors/engine_descriptor.hpp"
 #include "descriptors/engine_heuristic_descriptor.hpp"
 #include "fake_plugin.hpp"
-#include "hipdnn_backend.h"
 #include "hipdnn_exception.hpp"
 #include "plugin_manager.hpp"
 
@@ -22,7 +21,7 @@ void Plugin_manager::initialize()
 
     for(const auto& plugin : _plugins)
     {
-        plugin->set_logging_callback(hipdnnLoggingCallback_ext);
+        plugin->set_logging_callback(logging::hipdnn_logging_callback);
 
         for(const auto& engine_id : plugin->get_engines())
         {


### PR DESCRIPTION
## Proposed changes

Having the implementation in the shared library caused linker errors sometimes. This moves the implementation so that it can be used within the private library safely.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [x] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [x] I have ran the tests, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [x] I have ran `make format` & `make check_format` to ensure the changes have been formatted
