### PR TITLE
Initial commit of using CRTP to improve descriptor access

### DIFF
--- a/backend/src/CMakeLists.txt
+++ b/backend/src/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HIP_DNN_BACKEND_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}/hipdnn/back
 set(HIP_DNN_BACKEND_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(hipdnn_backend_private
+    descriptors/backend_descriptor.cpp
     descriptors/engine_config_descriptor.cpp
     descriptors/engine_descriptor.cpp
     descriptors/engine_heuristic_descriptor.cpp

--- a/backend/src/descriptors/backend_descriptor.cpp
+++ b/backend/src/descriptors/backend_descriptor.cpp
@@ -4,8 +4,6 @@
 #include "backend_descriptor.hpp"
 #include "error.hpp"
 
-using namespace hipdnn_backend;
-
 void hipdnnBackendDescriptor::finalize()
 {
     THROW_IF_TRUE(!_impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null _impl in finalize.");

--- a/backend/src/descriptors/backend_descriptor.cpp
+++ b/backend/src/descriptors/backend_descriptor.cpp
@@ -25,7 +25,8 @@ void hipdnnBackendDescriptor::get_attribute(hipdnnBackendAttributeName_t attribu
                                             void* array_of_elements) const
 {
     THROW_IF_TRUE(!impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null impl in get_attribute.");
-    impl->get_attribute(attribute_name, attribute_type, requested_element_count, element_count, array_of_elements);
+    impl->get_attribute(
+        attribute_name, attribute_type, requested_element_count, element_count, array_of_elements);
 }
 
 void hipdnnBackendDescriptor::set_attribute(hipdnnBackendAttributeName_t attribute_name,

--- a/backend/src/descriptors/backend_descriptor.cpp
+++ b/backend/src/descriptors/backend_descriptor.cpp
@@ -8,14 +8,14 @@ using namespace hipdnn_backend;
 
 void hipdnnBackendDescriptor::finalize()
 {
-    THROW_IF_TRUE(!impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null impl in finalize.");
-    impl->finalize();
+    THROW_IF_TRUE(!_impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null _impl in finalize.");
+    _impl->finalize();
 }
 
 bool hipdnnBackendDescriptor::is_finalized() const
 {
-    THROW_IF_TRUE(!impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null impl in is_finalized.");
-    return impl->is_finalized();
+    THROW_IF_TRUE(!_impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null _impl in is_finalized.");
+    return _impl->is_finalized();
 }
 
 void hipdnnBackendDescriptor::get_attribute(hipdnnBackendAttributeName_t attribute_name,
@@ -24,8 +24,8 @@ void hipdnnBackendDescriptor::get_attribute(hipdnnBackendAttributeName_t attribu
                                             int64_t* element_count,
                                             void* array_of_elements) const
 {
-    THROW_IF_TRUE(!impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null impl in get_attribute.");
-    impl->get_attribute(
+    THROW_IF_TRUE(!_impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null _impl in get_attribute.");
+    _impl->get_attribute(
         attribute_name, attribute_type, requested_element_count, element_count, array_of_elements);
 }
 
@@ -34,12 +34,22 @@ void hipdnnBackendDescriptor::set_attribute(hipdnnBackendAttributeName_t attribu
                                             int64_t element_count,
                                             const void* array_of_elements)
 {
-    THROW_IF_TRUE(!impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null impl in set_attribute.");
-    impl->set_attribute(attribute_name, attribute_type, element_count, array_of_elements);
+    THROW_IF_TRUE(!_impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null _impl in set_attribute.");
+    _impl->set_attribute(attribute_name, attribute_type, element_count, array_of_elements);
 }
 
 hipdnnBackendDescriptorType_t hipdnnBackendDescriptor::get_type() const
 {
-    THROW_IF_TRUE(!impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null impl in get_type.");
-    return impl->get_type();
+    THROW_IF_TRUE(!_impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null _impl in get_type.");
+    return _impl->get_type();
+}
+
+bool hipdnnBackendDescriptor::is_valid()
+{
+    return _impl && get_type() != hipdnnBackendDescriptorType_t::HIPDNN_INVALID_TYPE;
+}
+
+bool hipdnnBackendDescriptor::operator==(const hipdnnBackendDescriptor& other) const
+{
+    return _impl == other._impl;
 }

--- a/backend/src/descriptors/backend_descriptor.cpp
+++ b/backend/src/descriptors/backend_descriptor.cpp
@@ -1,0 +1,44 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "backend_descriptor.hpp"
+#include "error.hpp"
+
+using namespace hipdnn_backend;
+
+void hipdnnBackendDescriptor::finalize()
+{
+    THROW_IF_TRUE(!impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null impl in finalize.");
+    impl->finalize();
+}
+
+bool hipdnnBackendDescriptor::is_finalized() const
+{
+    THROW_IF_TRUE(!impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null impl in is_finalized.");
+    return impl->is_finalized();
+}
+
+void hipdnnBackendDescriptor::get_attribute(hipdnnBackendAttributeName_t attribute_name,
+                                            hipdnnBackendAttributeType_t attribute_type,
+                                            int64_t requested_element_count,
+                                            int64_t* element_count,
+                                            void* array_of_elements) const
+{
+    THROW_IF_TRUE(!impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null impl in get_attribute.");
+    impl->get_attribute(attribute_name, attribute_type, requested_element_count, element_count, array_of_elements);
+}
+
+void hipdnnBackendDescriptor::set_attribute(hipdnnBackendAttributeName_t attribute_name,
+                                            hipdnnBackendAttributeType_t attribute_type,
+                                            int64_t element_count,
+                                            const void* array_of_elements)
+{
+    THROW_IF_TRUE(!impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null impl in set_attribute.");
+    impl->set_attribute(attribute_name, attribute_type, element_count, array_of_elements);
+}
+
+hipdnnBackendDescriptorType_t hipdnnBackendDescriptor::get_type() const
+{
+    THROW_IF_TRUE(!impl, HIPDNN_STATUS_INTERNAL_ERROR, "Null impl in get_type.");
+    return impl->get_type();
+}

--- a/backend/src/descriptors/backend_descriptor.hpp
+++ b/backend/src/descriptors/backend_descriptor.hpp
@@ -27,11 +27,13 @@ struct Backend_descriptor_interface
                                hipdnnBackendAttributeType_t attribute_type,
                                int64_t requested_element_count,
                                int64_t* element_count,
-                               void* array_of_elements) const = 0;
+                               void* array_of_elements) const
+        = 0;
     virtual void set_attribute(hipdnnBackendAttributeName_t attribute_name,
                                hipdnnBackendAttributeType_t attribute_type,
                                int64_t element_count,
-                               const void* array_of_elements) = 0;
+                               const void* array_of_elements)
+        = 0;
 
     virtual hipdnnBackendDescriptorType_t get_type() const = 0;
 };
@@ -77,24 +79,35 @@ private:
 
 public:
     hipdnnBackendDescriptorImpl()
-    : _type(get_static_type())
+        : _type(get_static_type())
     {
     }
 
-    void finalize() override { _finalized = true; }
-    bool is_finalized() const override { return _finalized; }
+    void finalize() override
+    {
+        _finalized = true;
+    }
+    bool is_finalized() const override
+    {
+        return _finalized;
+    }
 
     void get_attribute(hipdnnBackendAttributeName_t attribute_name,
                        hipdnnBackendAttributeType_t attribute_type,
                        int64_t requested_element_count,
                        int64_t* element_count,
-                       void* array_of_elements) const override = 0;
+                       void* array_of_elements) const override
+        = 0;
     void set_attribute(hipdnnBackendAttributeName_t attribute_name,
                        hipdnnBackendAttributeType_t attribute_type,
                        int64_t element_count,
-                       const void* array_of_elements) override = 0;
+                       const void* array_of_elements) override
+        = 0;
 
-    hipdnnBackendDescriptorType_t get_type() const override { return _type; }
+    hipdnnBackendDescriptorType_t get_type() const override
+    {
+        return _type;
+    }
 
     static hipdnnBackendDescriptorType_t get_static_type()
     {
@@ -104,11 +117,9 @@ public:
 
 // Helper trait for static_assert
 template <typename Child_descriptor>
-constexpr bool is_valid_backend_child_descriptor_v =
-    std::is_base_of_v<
-        hipdnnBackendDescriptorImpl<std::remove_const_t<Child_descriptor>>,
-        std::remove_const_t<Child_descriptor>
-    >;
+constexpr bool is_valid_backend_child_descriptor_v
+    = std::is_base_of_v<hipdnnBackendDescriptorImpl<std::remove_const_t<Child_descriptor>>,
+                        std::remove_const_t<Child_descriptor>>;
 
 // Unpacks a hipdnnBackendDescriptor into a shared_ptr of the specified type.
 // Throws an exception if the descriptor is null.
@@ -126,8 +137,7 @@ inline std::shared_ptr<Child_descriptor> unpack_descriptor(
                 hipdnnStatus_t::HIPDNN_STATUS_BAD_PARAM,
                 "Unpacking hipdnnBackendDescriptor failed: Descriptor type mismatch.");
 
-    auto child_descriptor
-        = std::static_pointer_cast<Child_descriptor>(descriptor->impl);
+    auto child_descriptor = std::static_pointer_cast<Child_descriptor>(descriptor->impl);
 
     return child_descriptor;
 }
@@ -167,8 +177,7 @@ inline hipdnnBackendDescriptor*
 inline void pack_descriptor(const std::shared_ptr<const Backend_descriptor_interface>& impl,
                             void*& array_of_elements)
 {
-    *static_cast<hipdnnBackendDescriptor**>(array_of_elements)
-        = pack_descriptor(impl);
+    *static_cast<hipdnnBackendDescriptor**>(array_of_elements) = pack_descriptor(impl);
 }
 }
 //NOLINTEND(readability-identifier-naming)

--- a/backend/src/descriptors/backend_descriptor.hpp
+++ b/backend/src/descriptors/backend_descriptor.hpp
@@ -7,16 +7,6 @@
 #include "hipdnn_exception.hpp"
 #include <memory>
 
-//NOLINTBEGIN(readability-identifier-naming)
-
-namespace hipdnn_backend
-{
-template <typename Child_descriptor>
-std::shared_ptr<Child_descriptor> unpack_descriptor(const hipdnnBackendDescriptor* descriptor,
-                                                    hipdnnStatus_t error_status,
-                                                    const std::string& error_message);
-}
-
 struct Backend_descriptor_interface
 {
     virtual ~Backend_descriptor_interface() = default;
@@ -38,36 +28,7 @@ struct Backend_descriptor_interface
     virtual hipdnnBackendDescriptorType_t get_type() const = 0;
 };
 
-struct hipdnnBackendDescriptor : public Backend_descriptor_interface
-{
-    ~hipdnnBackendDescriptor() override = default;
-
-    void finalize() override;
-    bool is_finalized() const override;
-    void get_attribute(hipdnnBackendAttributeName_t attribute_name,
-                       hipdnnBackendAttributeType_t attribute_type,
-                       int64_t requested_element_count,
-                       int64_t* element_count,
-                       void* array_of_elements) const override;
-    void set_attribute(hipdnnBackendAttributeName_t attribute_name,
-                       hipdnnBackendAttributeType_t attribute_type,
-                       int64_t element_count,
-                       const void* array_of_elements) override;
-
-    std::shared_ptr<Backend_descriptor_interface> impl;
-
-    template <typename Child_descriptor>
-    std::shared_ptr<Child_descriptor> as_descriptor() const
-    {
-        return hipdnn_backend::unpack_descriptor<Child_descriptor>(
-            this,
-            HIPDNN_STATUS_INTERNAL_ERROR,
-            "Failed to cast backend descriptor: Null descriptor provided.");
-    }
-
-    hipdnnBackendDescriptorType_t get_type() const override;
-};
-
+//NOLINTBEGIN(readability-identifier-naming)
 namespace hipdnn_backend
 {
 template <typename T>
@@ -114,70 +75,110 @@ public:
         return T::get_static_type();
     }
 };
+}
 
-// Helper trait for static_assert
+namespace
+{
+// Helper trait for static_asserts in unpack.
 template <typename Child_descriptor>
-constexpr bool is_valid_backend_child_descriptor_v
-    = std::is_base_of_v<hipdnnBackendDescriptorImpl<std::remove_const_t<Child_descriptor>>,
-                        std::remove_const_t<Child_descriptor>>;
+constexpr bool is_valid_backend_child_descriptor_v = std::is_base_of_v<
+    hipdnn_backend::hipdnnBackendDescriptorImpl<std::remove_const_t<Child_descriptor>>,
+    std::remove_const_t<Child_descriptor>>;
+}
 
-// Unpacks a hipdnnBackendDescriptor into a shared_ptr of the specified type.
-// Throws an exception if the descriptor is null.
-template <typename Child_descriptor>
-inline std::shared_ptr<Child_descriptor> unpack_descriptor(
-    const hipdnnBackendDescriptor* descriptor, hipdnnStatus_t status, const std::string& message)
+struct hipdnnBackendDescriptor : public Backend_descriptor_interface
 {
-    static_assert(is_valid_backend_child_descriptor_v<Child_descriptor>,
-                  "Child_descriptor must inherit from hipdnnBackendDescriptorImpl");
+    ~hipdnnBackendDescriptor() override = default;
 
-    THROW_IF_NULL(descriptor, status, message);
-    THROW_IF_NULL(descriptor->impl, status, message);
-    THROW_IF_NE(descriptor->get_type(),
-                Child_descriptor::get_static_type(),
-                hipdnnStatus_t::HIPDNN_STATUS_BAD_PARAM,
-                "Unpacking hipdnnBackendDescriptor failed: Descriptor type mismatch.");
+    void finalize() override;
+    bool is_finalized() const override;
+    void get_attribute(hipdnnBackendAttributeName_t attribute_name,
+                       hipdnnBackendAttributeType_t attribute_type,
+                       int64_t requested_element_count,
+                       int64_t* element_count,
+                       void* array_of_elements) const override;
+    void set_attribute(hipdnnBackendAttributeName_t attribute_name,
+                       hipdnnBackendAttributeType_t attribute_type,
+                       int64_t element_count,
+                       const void* array_of_elements) override;
 
-    auto child_descriptor = std::static_pointer_cast<Child_descriptor>(descriptor->impl);
+    template <typename Child_descriptor>
+    std::shared_ptr<Child_descriptor> as_descriptor() const
+    {
+        return unpack_descriptor<Child_descriptor>(
+            this,
+            HIPDNN_STATUS_INTERNAL_ERROR,
+            "Failed to cast backend descriptor: Null descriptor provided.");
+    }
 
-    return child_descriptor;
-}
+    bool is_valid();
 
-// Unpacks a hipdnnBackendDescriptor from an array of elements.
-// The array of elements is expected to be a pointer to a hipdnnBackendDescriptor.
-// Throws an exception if the array of elements is null or if the descriptor cannot be unpacked.
-template <typename Child_descriptor>
-inline std::shared_ptr<Child_descriptor> unpack_descriptor(const void* array_of_elements,
-                                                           hipdnnStatus_t status,
-                                                           const std::string& message)
-{
-    static_assert(is_valid_backend_child_descriptor_v<Child_descriptor>,
-                  "Child_descriptor must inherit from hipdnnBackendDescriptorImpl");
+    hipdnnBackendDescriptorType_t get_type() const override;
 
-    THROW_IF_NULL(array_of_elements, status, message);
+    bool operator==(const hipdnnBackendDescriptor& other) const;
 
-    return unpack_descriptor<Child_descriptor>(
-        *static_cast<hipdnnBackendDescriptor* const*>(array_of_elements), status, message);
-}
+    // Unpacks a hipdnnBackendDescriptor into a shared_ptr of the specified type.
+    // Throws an exception if the descriptor is null.
+    template <typename Child_descriptor>
+    static std::shared_ptr<Child_descriptor>
+        unpack_descriptor(const hipdnnBackendDescriptor* descriptor,
+                          hipdnnStatus_t status,
+                          const std::string& message)
+    {
+        static_assert(is_valid_backend_child_descriptor_v<Child_descriptor>,
+                      "Child_descriptor must inherit from hipdnnBackendDescriptorImpl");
 
-// Packs a shared_ptr into a new hipdnnBackendDescriptor.
-// Note: Ownership of the descriptor is transferred to the caller,
-//       and it is the caller's responsibility to delete it.
-//       You can use Scoped_descriptor to manage the lifetime of the descriptor automatically.
-inline hipdnnBackendDescriptor*
-    pack_descriptor(const std::shared_ptr<const Backend_descriptor_interface>& impl)
-{
-    auto descriptor = new hipdnnBackendDescriptor();
-    descriptor->impl = std::const_pointer_cast<Backend_descriptor_interface>(impl);
-    return descriptor;
-}
+        THROW_IF_NULL(descriptor, status, message);
+        THROW_IF_NULL(descriptor->_impl, status, message);
+        THROW_IF_NE(descriptor->get_type(),
+                    Child_descriptor::get_static_type(),
+                    hipdnnStatus_t::HIPDNN_STATUS_BAD_PARAM,
+                    "Unpacking hipdnnBackendDescriptor failed: Descriptor type mismatch.");
 
-// Packs a shared_ptr into a new hipdnnBackendDescriptor, and stores it into a provided array_of_elements ptr.
-// Note: Ownership of the descriptor is transferred to the public API caller.
-//       It is the caller's responsibility to delete it.
-inline void pack_descriptor(const std::shared_ptr<const Backend_descriptor_interface>& impl,
-                            void*& array_of_elements)
-{
-    *static_cast<hipdnnBackendDescriptor**>(array_of_elements) = pack_descriptor(impl);
-}
-}
+        auto child_descriptor = std::static_pointer_cast<Child_descriptor>(descriptor->_impl);
+
+        return child_descriptor;
+    }
+
+    // Unpacks a hipdnnBackendDescriptor from an array of elements.
+    // The array of elements is expected to be a pointer to a hipdnnBackendDescriptor.
+    // Throws an exception if the array of elements is null or if the descriptor cannot be unpacked.
+    template <typename Child_descriptor>
+    static std::shared_ptr<Child_descriptor> unpack_descriptor(const void* array_of_elements,
+                                                               hipdnnStatus_t status,
+                                                               const std::string& message)
+    {
+        static_assert(is_valid_backend_child_descriptor_v<Child_descriptor>,
+                      "Child_descriptor must inherit from hipdnnBackendDescriptorImpl");
+
+        THROW_IF_NULL(array_of_elements, status, message);
+
+        return unpack_descriptor<Child_descriptor>(
+            *static_cast<hipdnnBackendDescriptor* const*>(array_of_elements), status, message);
+    }
+
+    // Packs a shared_ptr into a new hipdnnBackendDescriptor.
+    // Note: Ownership of the descriptor is transferred to the caller,
+    //       and it is the caller's responsibility to delete it.
+    //       You can use Scoped_descriptor to manage the lifetime of the descriptor automatically.
+    static hipdnnBackendDescriptor*
+        pack_descriptor(const std::shared_ptr<const Backend_descriptor_interface>& _impl)
+    {
+        auto descriptor = new hipdnnBackendDescriptor();
+        descriptor->_impl = std::const_pointer_cast<Backend_descriptor_interface>(_impl);
+        return descriptor;
+    }
+
+    // Packs a shared_ptr into a new hipdnnBackendDescriptor, and stores it into a provided array_of_elements ptr.
+    // Note: Ownership of the descriptor is transferred to the public API caller.
+    //       It is the caller's responsibility to delete it.
+    static void pack_descriptor(const std::shared_ptr<const Backend_descriptor_interface>& _impl,
+                                void*& array_of_elements)
+    {
+        *static_cast<hipdnnBackendDescriptor**>(array_of_elements) = pack_descriptor(_impl);
+    }
+
+private:
+    std::shared_ptr<Backend_descriptor_interface> _impl;
+};
 //NOLINTEND(readability-identifier-naming)

--- a/backend/src/descriptors/backend_descriptor.hpp
+++ b/backend/src/descriptors/backend_descriptor.hpp
@@ -53,18 +53,6 @@ public:
         return _finalized;
     }
 
-    void get_attribute(hipdnnBackendAttributeName_t attribute_name,
-                       hipdnnBackendAttributeType_t attribute_type,
-                       int64_t requested_element_count,
-                       int64_t* element_count,
-                       void* array_of_elements) const override
-        = 0;
-    void set_attribute(hipdnnBackendAttributeName_t attribute_name,
-                       hipdnnBackendAttributeType_t attribute_type,
-                       int64_t element_count,
-                       const void* array_of_elements) override
-        = 0;
-
     hipdnnBackendDescriptorType_t get_type() const override
     {
         return _type;

--- a/backend/src/descriptors/backend_descriptor.hpp
+++ b/backend/src/descriptors/backend_descriptor.hpp
@@ -11,17 +11,48 @@
 
 namespace hipdnn_backend
 {
-struct hipdnnPrivateBackendDescriptor;
-
 template <typename Child_descriptor>
 std::shared_ptr<Child_descriptor> unpack_descriptor(const hipdnnBackendDescriptor* descriptor,
                                                     hipdnnStatus_t error_status,
                                                     const std::string& error_message);
 }
 
-struct hipdnnBackendDescriptor
+struct Backend_descriptor_interface
 {
-    std::shared_ptr<hipdnn_backend::hipdnnPrivateBackendDescriptor> private_descriptor;
+    virtual ~Backend_descriptor_interface() = default;
+
+    virtual void finalize() = 0;
+    virtual bool is_finalized() const = 0;
+    virtual void get_attribute(hipdnnBackendAttributeName_t attribute_name,
+                               hipdnnBackendAttributeType_t attribute_type,
+                               int64_t requested_element_count,
+                               int64_t* element_count,
+                               void* array_of_elements) const = 0;
+    virtual void set_attribute(hipdnnBackendAttributeName_t attribute_name,
+                               hipdnnBackendAttributeType_t attribute_type,
+                               int64_t element_count,
+                               const void* array_of_elements) = 0;
+
+    virtual hipdnnBackendDescriptorType_t get_type() const = 0;
+};
+
+struct hipdnnBackendDescriptor : public Backend_descriptor_interface
+{
+    ~hipdnnBackendDescriptor() override = default;
+
+    void finalize() override;
+    bool is_finalized() const override;
+    void get_attribute(hipdnnBackendAttributeName_t attribute_name,
+                       hipdnnBackendAttributeType_t attribute_type,
+                       int64_t requested_element_count,
+                       int64_t* element_count,
+                       void* array_of_elements) const override;
+    void set_attribute(hipdnnBackendAttributeName_t attribute_name,
+                       hipdnnBackendAttributeType_t attribute_type,
+                       int64_t element_count,
+                       const void* array_of_elements) override;
+
+    std::shared_ptr<Backend_descriptor_interface> impl;
 
     template <typename Child_descriptor>
     std::shared_ptr<Child_descriptor> as_descriptor() const
@@ -31,40 +62,53 @@ struct hipdnnBackendDescriptor
             HIPDNN_STATUS_INTERNAL_ERROR,
             "Failed to cast backend descriptor: Null descriptor provided.");
     }
+
+    hipdnnBackendDescriptorType_t get_type() const override;
 };
 
 namespace hipdnn_backend
 {
-struct hipdnnPrivateBackendDescriptor
+template <typename T>
+class hipdnnBackendDescriptorImpl : public Backend_descriptor_interface
 {
 private:
     bool _finalized = false;
+    hipdnnBackendDescriptorType_t _type = HIPDNN_INVALID_TYPE;
 
 public:
-    virtual ~hipdnnPrivateBackendDescriptor() = default;
-    hipdnnBackendDescriptorType_t type = HIPDNN_INVALID_TYPE;
-    virtual void finalize()
+    hipdnnBackendDescriptorImpl()
+    : _type(get_static_type())
     {
-        _finalized = true;
     }
 
-    virtual bool is_finalized() const
-    {
-        return _finalized;
-    }
+    void finalize() override { _finalized = true; }
+    bool is_finalized() const override { return _finalized; }
 
-    virtual void get_attribute(hipdnnBackendAttributeName_t attribute_name,
-                               hipdnnBackendAttributeType_t attribute_type,
-                               int64_t requested_element_count,
-                               int64_t* element_count,
-                               void* array_of_elements) const
-        = 0;
-    virtual void set_attribute(hipdnnBackendAttributeName_t attribute_name,
-                               hipdnnBackendAttributeType_t attribute_type,
-                               int64_t element_count,
-                               const void* array_of_elements)
-        = 0;
+    void get_attribute(hipdnnBackendAttributeName_t attribute_name,
+                       hipdnnBackendAttributeType_t attribute_type,
+                       int64_t requested_element_count,
+                       int64_t* element_count,
+                       void* array_of_elements) const override = 0;
+    void set_attribute(hipdnnBackendAttributeName_t attribute_name,
+                       hipdnnBackendAttributeType_t attribute_type,
+                       int64_t element_count,
+                       const void* array_of_elements) override = 0;
+
+    hipdnnBackendDescriptorType_t get_type() const override { return _type; }
+
+    static hipdnnBackendDescriptorType_t get_static_type()
+    {
+        return T::get_static_type();
+    }
 };
+
+// Helper trait for static_assert
+template <typename Child_descriptor>
+constexpr bool is_valid_backend_child_descriptor_v =
+    std::is_base_of_v<
+        hipdnnBackendDescriptorImpl<std::remove_const_t<Child_descriptor>>,
+        std::remove_const_t<Child_descriptor>
+    >;
 
 // Unpacks a hipdnnBackendDescriptor into a shared_ptr of the specified type.
 // Throws an exception if the descriptor is null.
@@ -72,14 +116,18 @@ template <typename Child_descriptor>
 inline std::shared_ptr<Child_descriptor> unpack_descriptor(
     const hipdnnBackendDescriptor* descriptor, hipdnnStatus_t status, const std::string& message)
 {
-    static_assert(std::is_base_of_v<hipdnnPrivateBackendDescriptor, Child_descriptor>,
-                  "Child_descriptor must inherit from hipdnnPrivateBackendDescriptor");
+    static_assert(is_valid_backend_child_descriptor_v<Child_descriptor>,
+                  "Child_descriptor must inherit from hipdnnBackendDescriptorImpl");
 
     THROW_IF_NULL(descriptor, status, message);
-    THROW_IF_NULL(descriptor->private_descriptor, status, message);
+    THROW_IF_NULL(descriptor->impl, status, message);
+    THROW_IF_NE(descriptor->get_type(),
+                Child_descriptor::get_static_type(),
+                hipdnnStatus_t::HIPDNN_STATUS_BAD_PARAM,
+                "Unpacking hipdnnBackendDescriptor failed: Descriptor type mismatch.");
 
     auto child_descriptor
-        = std::static_pointer_cast<Child_descriptor>(descriptor->private_descriptor);
+        = std::static_pointer_cast<Child_descriptor>(descriptor->impl);
 
     return child_descriptor;
 }
@@ -92,8 +140,8 @@ inline std::shared_ptr<Child_descriptor> unpack_descriptor(const void* array_of_
                                                            hipdnnStatus_t status,
                                                            const std::string& message)
 {
-    static_assert(std::is_base_of_v<hipdnnPrivateBackendDescriptor, Child_descriptor>,
-                  "Child_descriptor must inherit from hipdnnPrivateBackendDescriptor");
+    static_assert(is_valid_backend_child_descriptor_v<Child_descriptor>,
+                  "Child_descriptor must inherit from hipdnnBackendDescriptorImpl");
 
     THROW_IF_NULL(array_of_elements, status, message);
 
@@ -105,48 +153,22 @@ inline std::shared_ptr<Child_descriptor> unpack_descriptor(const void* array_of_
 // Note: Ownership of the descriptor is transferred to the caller,
 //       and it is the caller's responsibility to delete it.
 //       You can use Scoped_descriptor to manage the lifetime of the descriptor automatically.
-template <typename Child_descriptor>
 inline hipdnnBackendDescriptor*
-    pack_descriptor(const std::shared_ptr<const Child_descriptor>& private_descriptor)
+    pack_descriptor(const std::shared_ptr<const Backend_descriptor_interface>& impl)
 {
-    static_assert(std::is_base_of_v<hipdnnPrivateBackendDescriptor, Child_descriptor>,
-                  "Child_descriptor must inherit from hipdnnPrivateBackendDescriptor");
-
     auto descriptor = new hipdnnBackendDescriptor();
-    descriptor->private_descriptor = std::const_pointer_cast<hipdnnPrivateBackendDescriptor>(
-        std::static_pointer_cast<const hipdnnPrivateBackendDescriptor>(private_descriptor));
-    return descriptor;
-}
-
-// Packs a shared_ptr into a new hipdnnBackendDescriptor.
-// Note: Ownership of the descriptor is transferred to the caller,
-//       and it is the caller's responsibility to delete it.
-//       You can use Scoped_descriptor to manage the lifetime of the descriptor automatically.
-template <typename Child_descriptor>
-inline hipdnnBackendDescriptor*
-    pack_descriptor(const std::shared_ptr<Child_descriptor>& private_descriptor)
-{
-    static_assert(std::is_base_of_v<hipdnnPrivateBackendDescriptor, Child_descriptor>,
-                  "Child_descriptor must inherit from hipdnnPrivateBackendDescriptor");
-
-    auto descriptor = new hipdnnBackendDescriptor();
-    descriptor->private_descriptor
-        = std::static_pointer_cast<hipdnnPrivateBackendDescriptor>(private_descriptor);
+    descriptor->impl = std::const_pointer_cast<Backend_descriptor_interface>(impl);
     return descriptor;
 }
 
 // Packs a shared_ptr into a new hipdnnBackendDescriptor, and stores it into a provided array_of_elements ptr.
 // Note: Ownership of the descriptor is transferred to the public API caller.
 //       It is the caller's responsibility to delete it.
-template <typename Child_descriptor>
-inline void pack_descriptor(const std::shared_ptr<const Child_descriptor>& private_descriptor,
+inline void pack_descriptor(const std::shared_ptr<const Backend_descriptor_interface>& impl,
                             void*& array_of_elements)
 {
-    static_assert(std::is_base_of_v<hipdnnPrivateBackendDescriptor, Child_descriptor>,
-                  "Child_descriptor must inherit from hipdnnPrivateBackendDescriptor");
-
     *static_cast<hipdnnBackendDescriptor**>(array_of_elements)
-        = pack_descriptor(private_descriptor);
+        = pack_descriptor(impl);
 }
 }
 //NOLINTEND(readability-identifier-naming)

--- a/backend/src/descriptors/descriptor_factory.cpp
+++ b/backend/src/descriptors/descriptor_factory.cpp
@@ -52,7 +52,7 @@ void Descriptor_factory::create(hipdnnBackendDescriptorType_t descriptor_type,
                                    + " is not supported.");
     }
 
-    *descriptor = pack_descriptor(private_desc);
+    *descriptor = hipdnnBackendDescriptor::pack_descriptor(private_desc);
 
     HIPDNN_LOG_INFO("Created descriptor: {:p}", static_cast<void*>(*descriptor));
 }
@@ -69,7 +69,7 @@ void Descriptor_factory::create_graph_ext(hipdnnBackendDescriptor_t* descriptor,
 
     auto graph_descriptor = std::make_shared<Graph_descriptor>();
     graph_descriptor->deserialize_graph(serialized_graph, graph_byte_size);
-    *descriptor = pack_descriptor(graph_descriptor);
+    *descriptor = hipdnnBackendDescriptor::pack_descriptor(graph_descriptor);
 
     HIPDNN_LOG_INFO("Created graph descriptor: {:p}", static_cast<void*>(*descriptor));
 }

--- a/backend/src/descriptors/descriptor_factory.cpp
+++ b/backend/src/descriptors/descriptor_factory.cpp
@@ -24,7 +24,7 @@ void Descriptor_factory::create(hipdnnBackendDescriptorType_t descriptor_type,
     HIPDNN_LOG_INFO("Creating descriptor of type: {}",
                     hipdnn_get_backend_descriptor_type_name(descriptor_type));
 
-    std::shared_ptr<hipdnnPrivateBackendDescriptor> private_desc;
+    std::shared_ptr<Backend_descriptor_interface> private_desc;
     switch(descriptor_type)
     {
     case HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR:

--- a/backend/src/descriptors/engine_config_descriptor.cpp
+++ b/backend/src/descriptors/engine_config_descriptor.cpp
@@ -79,7 +79,7 @@ void Engine_config_descriptor::get_engine(hipdnnBackendAttributeType_t attribute
         *element_count = 1;
     }
 
-    pack_descriptor(_engine, array_of_elements);
+    hipdnnBackendDescriptor::pack_descriptor(_engine, array_of_elements);
 }
 
 void Engine_config_descriptor::get_max_workspace_size(hipdnnBackendAttributeType_t attribute_type,
@@ -152,7 +152,7 @@ void Engine_config_descriptor::set_engine(hipdnnBackendAttributeType_t attribute
                 "Engine_config_descriptor failed to set engine: "
                 "Invalid element count.");
 
-    auto engine = unpack_descriptor<const Engine_descriptor>(
+    auto engine = hipdnnBackendDescriptor::unpack_descriptor<const Engine_descriptor>(
         array_of_elements,
         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
         "Engine_config_descriptor failed to set engine: Engine is null.");

--- a/backend/src/descriptors/engine_config_descriptor.cpp
+++ b/backend/src/descriptors/engine_config_descriptor.cpp
@@ -10,11 +10,6 @@
 namespace hipdnn_backend
 {
 
-Engine_config_descriptor::Engine_config_descriptor()
-{
-    type = HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR;
-}
-
 void Engine_config_descriptor::finalize()
 {
     THROW_IF_TRUE(is_finalized(),
@@ -25,7 +20,7 @@ void Engine_config_descriptor::finalize()
                   HIPDNN_STATUS_BAD_PARAM,
                   "Engine_config_descriptor::finalize() failed: Engine is not set.");
 
-    hipdnnPrivateBackendDescriptor::finalize();
+    hipdnnBackendDescriptorImpl<Engine_config_descriptor>::finalize();
 }
 
 void Engine_config_descriptor::get_attribute(hipdnnBackendAttributeName_t attribute_name,
@@ -162,12 +157,6 @@ void Engine_config_descriptor::set_engine(hipdnnBackendAttributeType_t attribute
         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
         "Engine_config_descriptor failed to set engine: Engine is null.");
 
-    THROW_IF_NE(engine->type,
-                HIPDNN_BACKEND_ENGINE_DESCRIPTOR,
-                HIPDNN_STATUS_BAD_PARAM,
-                "Engine_config_descriptor failed to set engine: "
-                "Invalid engine descriptor type.");
-
     THROW_IF_FALSE(engine->is_finalized(),
                    HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED,
                    "Engine_config_descriptor failed to set engine: "
@@ -203,4 +192,8 @@ std::shared_ptr<const Engine_descriptor> Engine_config_descriptor::get_engine() 
     return _engine;
 }
 
+hipdnnBackendDescriptorType_t Engine_config_descriptor::get_static_type()
+{
+    return HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR;
+}
 } // namespace hipdnn_backend

--- a/backend/src/descriptors/engine_config_descriptor.hpp
+++ b/backend/src/descriptors/engine_config_descriptor.hpp
@@ -10,7 +10,7 @@ namespace hipdnn_backend
 
 class Engine_descriptor;
 
-class Engine_config_descriptor : public hipdnnPrivateBackendDescriptor
+class Engine_config_descriptor : public hipdnnBackendDescriptorImpl<Engine_config_descriptor>
 {
 private:
     std::shared_ptr<const Engine_descriptor> _engine;
@@ -33,9 +33,6 @@ private:
 public:
     static constexpr int64_t INVALID_WORKSPACE_SIZE = -1;
 
-    Engine_config_descriptor();
-    ~Engine_config_descriptor() override = default;
-
     void finalize() override;
 
     void get_attribute(hipdnnBackendAttributeName_t attribute_name,
@@ -53,6 +50,8 @@ public:
 
     // Throws an exception if the descriptor is not finalized.
     std::shared_ptr<const Engine_descriptor> get_engine() const;
+
+    static hipdnnBackendDescriptorType_t get_static_type();
 };
 
 } // namespace hipdnn_backend

--- a/backend/src/descriptors/engine_descriptor.cpp
+++ b/backend/src/descriptors/engine_descriptor.cpp
@@ -83,7 +83,7 @@ void Engine_descriptor::get_graph(hipdnnBackendAttributeType_t attribute_type,
         *element_count = 1;
     }
 
-    pack_descriptor(_graph, array_of_elements);
+    hipdnnBackendDescriptor::pack_descriptor(_graph, array_of_elements);
 }
 
 void Engine_descriptor::get_global_id(hipdnnBackendAttributeType_t attribute_type,
@@ -158,7 +158,7 @@ void Engine_descriptor::set_graph(hipdnnBackendAttributeType_t attribute_type,
                 HIPDNN_STATUS_BAD_PARAM,
                 "Engine_descriptor failed to set graph: Invalid element count.");
 
-    auto graph = unpack_descriptor<const Graph_descriptor>(
+    auto graph = hipdnnBackendDescriptor::unpack_descriptor<const Graph_descriptor>(
         array_of_elements,
         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
         "Engine_descriptor failed to set graph: Graph is null.");

--- a/backend/src/descriptors/engine_descriptor.cpp
+++ b/backend/src/descriptors/engine_descriptor.cpp
@@ -10,11 +10,6 @@
 namespace hipdnn_backend
 {
 
-Engine_descriptor::Engine_descriptor()
-{
-    type = HIPDNN_BACKEND_ENGINE_DESCRIPTOR;
-}
-
 void Engine_descriptor::finalize()
 {
     THROW_IF_TRUE(is_finalized(),
@@ -28,7 +23,7 @@ void Engine_descriptor::finalize()
                    HIPDNN_STATUS_BAD_PARAM,
                    "Engine_descriptor::finalize() failed: Engine id is not set.");
 
-    hipdnnPrivateBackendDescriptor::finalize();
+    hipdnnBackendDescriptorImpl<Engine_descriptor>::finalize();
 }
 
 void Engine_descriptor::get_attribute(hipdnnBackendAttributeName_t attribute_name,
@@ -168,11 +163,6 @@ void Engine_descriptor::set_graph(hipdnnBackendAttributeType_t attribute_type,
         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
         "Engine_descriptor failed to set graph: Graph is null.");
 
-    THROW_IF_NE(graph->type,
-                HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR,
-                HIPDNN_STATUS_BAD_PARAM,
-                "Engine_descriptor failed to set graph: Invalid graph type.");
-
     THROW_IF_FALSE(graph->is_finalized(),
                    HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED,
                    "Engine_descriptor failed to set graph: Graph is not finalized.");
@@ -218,6 +208,11 @@ int64_t Engine_descriptor::get_engine_id() const
                    "Engine_descriptor::get_engine_id() failed: Not finalized.");
 
     return _engine_id;
+}
+
+hipdnnBackendDescriptorType_t Engine_descriptor::get_static_type()
+{
+    return HIPDNN_BACKEND_ENGINE_DESCRIPTOR;
 }
 
 } // namespace hipdnn_backend

--- a/backend/src/descriptors/engine_descriptor.hpp
+++ b/backend/src/descriptors/engine_descriptor.hpp
@@ -36,7 +36,6 @@ private:
                        void* array_of_elements) const;
 
 public:
-
     void finalize() override;
 
     void get_attribute(hipdnnBackendAttributeName_t attribute_name,

--- a/backend/src/descriptors/engine_descriptor.hpp
+++ b/backend/src/descriptors/engine_descriptor.hpp
@@ -10,7 +10,7 @@ namespace hipdnn_backend
 
 class Graph_descriptor;
 
-class Engine_descriptor : public hipdnnPrivateBackendDescriptor
+class Engine_descriptor : public hipdnnBackendDescriptorImpl<Engine_descriptor>
 {
 private:
     std::shared_ptr<const Graph_descriptor> _graph;
@@ -36,8 +36,6 @@ private:
                        void* array_of_elements) const;
 
 public:
-    Engine_descriptor();
-    ~Engine_descriptor() override = default;
 
     void finalize() override;
 
@@ -55,6 +53,8 @@ public:
     // These getters throw an exception if the descriptor is not finalized.
     std::shared_ptr<const Graph_descriptor> get_graph() const;
     int64_t get_engine_id() const;
+
+    static hipdnnBackendDescriptorType_t get_static_type();
 };
 
 } // namespace hipdnn_backend

--- a/backend/src/descriptors/engine_heuristic_descriptor.cpp
+++ b/backend/src/descriptors/engine_heuristic_descriptor.cpp
@@ -13,11 +13,6 @@
 namespace hipdnn_backend
 {
 
-Engine_heuristic_descriptor::Engine_heuristic_descriptor()
-{
-    type = HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR;
-}
-
 void Engine_heuristic_descriptor::finalize()
 {
     THROW_IF_TRUE(is_finalized(),
@@ -32,7 +27,7 @@ void Engine_heuristic_descriptor::finalize()
                    HIPDNN_STATUS_BAD_PARAM,
                    "Engine_heuristic_descriptor::finalize() failed: Heuristic mode is not set.");
 
-    hipdnnPrivateBackendDescriptor::finalize();
+    hipdnnBackendDescriptorImpl<Engine_heuristic_descriptor>::finalize();
 }
 
 void Engine_heuristic_descriptor::get_attribute(hipdnnBackendAttributeName_t attribute_name,
@@ -149,11 +144,6 @@ void Engine_heuristic_descriptor::set_graph(hipdnnBackendAttributeType_t attribu
         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
         "Engine_heuristic_descriptor failed to set graph: Null pointer.");
 
-    THROW_IF_NE(graph->type,
-                HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR,
-                HIPDNN_STATUS_BAD_PARAM,
-                "Engine_heuristic_descriptor failed to set graph: Invalid graph type.");
-
     THROW_IF_FALSE(graph->is_finalized(),
                    HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED,
                    "Engine_heuristic_descriptor failed to set graph: Graph is not finalized.");
@@ -231,12 +221,6 @@ void Engine_heuristic_descriptor::get_engine_configs(hipdnnBackendAttributeType_
                 "Engine_heuristic_descriptor failed to get engine config: Config "
                 "descriptor is null.");
 
-            THROW_IF_NE(config->type,
-                        HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR,
-                        HIPDNN_STATUS_BAD_PARAM,
-                        "Engine_heuristic_descriptor failed to get engine config: Invalid "
-                        "config descriptor type.");
-
             auto engine = std::make_shared<Engine_descriptor>();
 
             engine->set_attribute(
@@ -308,6 +292,11 @@ std::shared_ptr<const Graph_descriptor> Engine_heuristic_descriptor::get_graph()
                    "Engine_heuristic_descriptor::get_graph() failed: Not finalized.");
 
     return _graph;
+}
+
+hipdnnBackendDescriptorType_t Engine_heuristic_descriptor::get_static_type()
+{
+    return HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR;
 }
 
 } // namespace hipdnn_backend

--- a/backend/src/descriptors/engine_heuristic_descriptor.cpp
+++ b/backend/src/descriptors/engine_heuristic_descriptor.cpp
@@ -139,7 +139,7 @@ void Engine_heuristic_descriptor::set_graph(hipdnnBackendAttributeType_t attribu
                 HIPDNN_STATUS_BAD_PARAM,
                 "Engine_heuristic_descriptor failed to set graph: Invalid element count.");
 
-    auto graph = unpack_descriptor<const Graph_descriptor>(
+    auto graph = hipdnnBackendDescriptor::unpack_descriptor<const Graph_descriptor>(
         array_of_elements,
         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
         "Engine_heuristic_descriptor failed to set graph: Null pointer.");
@@ -175,7 +175,7 @@ void Engine_heuristic_descriptor::get_graph(hipdnnBackendAttributeType_t attribu
         *element_count = 1;
     }
 
-    pack_descriptor(_graph, array_of_elements);
+    hipdnnBackendDescriptor::pack_descriptor(_graph, array_of_elements);
 }
 
 void Engine_heuristic_descriptor::get_engine_configs(hipdnnBackendAttributeType_t attribute_type,
@@ -215,7 +215,7 @@ void Engine_heuristic_descriptor::get_engine_configs(hipdnnBackendAttributeType_
             std::cmp_less(i, _engine_ids.size()) && std::cmp_less(i, requested_element_count);
             ++i)
         {
-            auto config = unpack_descriptor<Engine_config_descriptor>(
+            auto config = hipdnnBackendDescriptor::unpack_descriptor<Engine_config_descriptor>(
                 output_array[i],
                 HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
                 "Engine_heuristic_descriptor failed to get engine config: Config "
@@ -226,14 +226,14 @@ void Engine_heuristic_descriptor::get_engine_configs(hipdnnBackendAttributeType_
             engine->set_attribute(
                 HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &_engine_ids[i]);
 
-            Scoped_descriptor graph_desc(pack_descriptor(_graph));
+            Scoped_descriptor graph_desc(hipdnnBackendDescriptor::pack_descriptor(_graph));
             engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                   1,
                                   graph_desc.get_ptr());
             engine->finalize();
 
-            Scoped_descriptor engine_desc(pack_descriptor(engine));
+            Scoped_descriptor engine_desc(hipdnnBackendDescriptor::pack_descriptor(engine));
             config->set_attribute(HIPDNN_ATTR_ENGINECFG_ENGINE,
                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                   1,

--- a/backend/src/descriptors/engine_heuristic_descriptor.hpp
+++ b/backend/src/descriptors/engine_heuristic_descriptor.hpp
@@ -45,7 +45,6 @@ private:
                             void* array_of_elements) const;
 
 public:
-
     void finalize() override;
 
     void get_attribute(hipdnnBackendAttributeName_t attribute_name,

--- a/backend/src/descriptors/engine_heuristic_descriptor.hpp
+++ b/backend/src/descriptors/engine_heuristic_descriptor.hpp
@@ -12,7 +12,7 @@ namespace hipdnn_backend
 
 class Graph_descriptor;
 
-class Engine_heuristic_descriptor : public hipdnnPrivateBackendDescriptor
+class Engine_heuristic_descriptor : public hipdnnBackendDescriptorImpl<Engine_heuristic_descriptor>
 {
 private:
     std::shared_ptr<const Graph_descriptor> _graph;
@@ -45,8 +45,6 @@ private:
                             void* array_of_elements) const;
 
 public:
-    Engine_heuristic_descriptor();
-    ~Engine_heuristic_descriptor() override = default;
 
     void finalize() override;
 
@@ -65,6 +63,8 @@ public:
 
     // Throws an exception if the descriptor is not finalized.
     std::shared_ptr<const Graph_descriptor> get_graph() const;
+
+    static hipdnnBackendDescriptorType_t get_static_type();
 };
 
 } // namespace hipdnn_backend

--- a/backend/src/descriptors/execution_plan_descriptor.cpp
+++ b/backend/src/descriptors/execution_plan_descriptor.cpp
@@ -150,7 +150,7 @@ void Execution_plan_descriptor::set_engine_config(hipdnnBackendAttributeType_t a
                 HIPDNN_STATUS_BAD_PARAM,
                 "Execution_plan_descriptor failed to set engine config: Invalid element count.");
 
-    auto engine_config = unpack_descriptor<const Engine_config_descriptor>(
+    auto engine_config = hipdnnBackendDescriptor::unpack_descriptor<const Engine_config_descriptor>(
         array_of_elements,
         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
         "Execution_plan_descriptor failed to set engine config: Null pointer.");
@@ -194,7 +194,7 @@ void Execution_plan_descriptor::get_engine_config(hipdnnBackendAttributeType_t a
                   "Execution_plan_descriptor failed to get engine config: Engine config is null. "
                   "Engine config was not set.");
 
-    pack_descriptor(_engine_config, array_of_elements);
+    hipdnnBackendDescriptor::pack_descriptor(_engine_config, array_of_elements);
 }
 
 std::shared_ptr<const Engine_config_descriptor> Execution_plan_descriptor::get_engine_config() const

--- a/backend/src/descriptors/execution_plan_descriptor.cpp
+++ b/backend/src/descriptors/execution_plan_descriptor.cpp
@@ -10,11 +10,6 @@
 namespace hipdnn_backend
 {
 
-Execution_plan_descriptor::Execution_plan_descriptor()
-{
-    type = HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR;
-}
-
 void Execution_plan_descriptor::finalize()
 {
     THROW_IF_TRUE(is_finalized(),
@@ -29,7 +24,7 @@ void Execution_plan_descriptor::finalize()
                   HIPDNN_STATUS_BAD_PARAM,
                   "Execution_plan_descriptor::finalize() failed: Engine was not set.");
 
-    hipdnnPrivateBackendDescriptor::finalize();
+    hipdnnBackendDescriptorImpl<Execution_plan_descriptor>::finalize();
 }
 
 void Execution_plan_descriptor::get_attribute(hipdnnBackendAttributeName_t attribute_name,
@@ -160,12 +155,6 @@ void Execution_plan_descriptor::set_engine_config(hipdnnBackendAttributeType_t a
         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
         "Execution_plan_descriptor failed to set engine config: Null pointer.");
 
-    THROW_IF_NE(engine_config->type,
-                HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR,
-                HIPDNN_STATUS_BAD_PARAM,
-                "Execution_plan_descriptor failed to set engine config: Invalid engine config "
-                "descriptor type.");
-
     THROW_IF_FALSE(engine_config->is_finalized(),
                    HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED,
                    "Execution_plan_descriptor failed to set engine config: Engine config "
@@ -215,6 +204,11 @@ std::shared_ptr<const Engine_config_descriptor> Execution_plan_descriptor::get_e
                    "Execution_plan_descriptor::get_engine_config() failed: Not finalized.");
 
     return _engine_config;
+}
+
+hipdnnBackendDescriptorType_t Execution_plan_descriptor::get_static_type()
+{
+    return HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR;
 }
 
 } // namespace hipdnn_backend

--- a/backend/src/descriptors/execution_plan_descriptor.hpp
+++ b/backend/src/descriptors/execution_plan_descriptor.hpp
@@ -34,7 +34,6 @@ private:
                            void* array_of_elements) const;
 
 public:
-
     void finalize() override;
 
     void get_attribute(hipdnnBackendAttributeName_t attribute_name,

--- a/backend/src/descriptors/execution_plan_descriptor.hpp
+++ b/backend/src/descriptors/execution_plan_descriptor.hpp
@@ -9,7 +9,7 @@ namespace hipdnn_backend
 {
 
 class Engine_config_descriptor;
-class Execution_plan_descriptor : public hipdnnPrivateBackendDescriptor
+class Execution_plan_descriptor : public hipdnnBackendDescriptorImpl<Execution_plan_descriptor>
 {
 private:
     hipdnnHandle_t _handle = nullptr;
@@ -34,8 +34,6 @@ private:
                            void* array_of_elements) const;
 
 public:
-    Execution_plan_descriptor();
-    ~Execution_plan_descriptor() override = default;
 
     void finalize() override;
 
@@ -52,6 +50,8 @@ public:
 
     // Throws an exception if the descriptor is not finalized.
     std::shared_ptr<const Engine_config_descriptor> get_engine_config() const;
+
+    static hipdnnBackendDescriptorType_t get_static_type();
 };
 
 } // namespace hipdnn_backend

--- a/backend/src/descriptors/graph_descriptor.cpp
+++ b/backend/src/descriptors/graph_descriptor.cpp
@@ -10,7 +10,7 @@
 
 namespace hipdnn_backend
 {
-    
+
 void Graph_descriptor::finalize()
 {
     THROW_IF_NULL(_graph, HIPDNN_STATUS_BAD_PARAM, "Graph_descriptor::finalize: graph is null");

--- a/backend/src/descriptors/graph_descriptor.cpp
+++ b/backend/src/descriptors/graph_descriptor.cpp
@@ -10,17 +10,12 @@
 
 namespace hipdnn_backend
 {
-
-Graph_descriptor::Graph_descriptor()
-{
-    type = HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR;
-}
-
+    
 void Graph_descriptor::finalize()
 {
     THROW_IF_NULL(_graph, HIPDNN_STATUS_BAD_PARAM, "Graph_descriptor::finalize: graph is null");
     THROW_IF_NULL(_handle, HIPDNN_STATUS_BAD_PARAM, "Graph_descriptor::finalize: handle is null");
-    hipdnnPrivateBackendDescriptor::finalize();
+    hipdnnBackendDescriptorImpl<Graph_descriptor>::finalize();
 }
 
 void Graph_descriptor::set_handle(hipdnnBackendAttributeType_t attribute_type,
@@ -121,6 +116,11 @@ const std::vector<uint8_t>& Graph_descriptor::get_serialized_graph()
     }
 
     return _serialized_graph;
+}
+
+hipdnnBackendDescriptorType_t Graph_descriptor::get_static_type()
+{
+    return HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR;
 }
 
 } // namespace hipdnn_backend

--- a/backend/src/descriptors/graph_descriptor.hpp
+++ b/backend/src/descriptors/graph_descriptor.hpp
@@ -24,7 +24,6 @@ private:
                     const void* array_of_elements);
 
 public:
-
     void finalize() override;
 
     void get_attribute([[maybe_unused]] hipdnnBackendAttributeName_t attribute_name,

--- a/backend/src/descriptors/graph_descriptor.hpp
+++ b/backend/src/descriptors/graph_descriptor.hpp
@@ -12,7 +12,7 @@
 namespace hipdnn_backend
 {
 
-class Graph_descriptor : public hipdnnPrivateBackendDescriptor
+class Graph_descriptor : public hipdnnBackendDescriptorImpl<Graph_descriptor>
 {
 private:
     std::unique_ptr<hipdnn_sdk::data_objects::GraphT> _graph;
@@ -24,8 +24,6 @@ private:
                     const void* array_of_elements);
 
 public:
-    Graph_descriptor();
-    ~Graph_descriptor() override = default;
 
     void finalize() override;
 
@@ -43,5 +41,7 @@ public:
     void deserialize_graph(const uint8_t* serialized_graph, size_t graph_byte_size);
 
     const std::vector<uint8_t>& get_serialized_graph();
+
+    static hipdnnBackendDescriptorType_t get_static_type();
 };
 }

--- a/backend/src/descriptors/variant_descriptor.cpp
+++ b/backend/src/descriptors/variant_descriptor.cpp
@@ -10,11 +10,6 @@
 namespace hipdnn_backend
 {
 
-Variant_descriptor::Variant_descriptor()
-{
-    type = HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR;
-}
-
 void Variant_descriptor::finalize()
 {
     THROW_IF_NE(_data_pointers.size(),
@@ -24,7 +19,7 @@ void Variant_descriptor::finalize()
     THROW_IF_TRUE(
         _data_pointers.empty(), HIPDNN_STATUS_BAD_PARAM, "Data pointers and unique ids are empty");
 
-    hipdnnPrivateBackendDescriptor::finalize();
+    hipdnnBackendDescriptorImpl<Variant_descriptor>::finalize();
 }
 
 void Variant_descriptor::get_attribute(hipdnnBackendAttributeName_t attribute_name,
@@ -169,6 +164,11 @@ const std::vector<int64_t>& Variant_descriptor::get_tensor_ids() const
                    HIPDNN_STATUS_INTERNAL_ERROR,
                    "Variant_descriptor::get_unique_ids() failed: Not finalized.");
     return _unique_ids;
+}
+
+hipdnnBackendDescriptorType_t Variant_descriptor::get_static_type()
+{
+    return HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR;
 }
 
 }

--- a/backend/src/descriptors/variant_descriptor.hpp
+++ b/backend/src/descriptors/variant_descriptor.hpp
@@ -19,7 +19,6 @@ private:
     void* _workspace = nullptr;
 
 public:
-
     void finalize() override;
 
     void get_attribute(hipdnnBackendAttributeName_t attribute_name,

--- a/backend/src/descriptors/variant_descriptor.hpp
+++ b/backend/src/descriptors/variant_descriptor.hpp
@@ -11,7 +11,7 @@
 namespace hipdnn_backend
 {
 
-class Variant_descriptor : public hipdnnPrivateBackendDescriptor
+class Variant_descriptor : public hipdnnBackendDescriptorImpl<Variant_descriptor>
 {
 private:
     std::vector<const void*> _data_pointers;
@@ -19,8 +19,6 @@ private:
     void* _workspace = nullptr;
 
 public:
-    Variant_descriptor();
-    ~Variant_descriptor() override = default;
 
     void finalize() override;
 
@@ -39,5 +37,7 @@ public:
     void* get_workspace() const;
     const std::vector<const void*>& get_data_pointers() const;
     const std::vector<int64_t>& get_tensor_ids() const;
+
+    static hipdnnBackendDescriptorType_t get_static_type();
 };
 }

--- a/backend/src/hipdnn_backend.cpp
+++ b/backend/src/hipdnn_backend.cpp
@@ -34,17 +34,11 @@ void throw_if_invalid_descriptor(hipdnnBackendDescriptor_t descriptor)
                                                "hipdnnBackendDescriptor_t is nullptr");
     }
 
-    if(!descriptor->impl)
+    if(!descriptor->is_valid())
     {
         throw hipdnn_backend::Hipdnn_exception(
             HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
             "hipdnnBackendDescriptor_t private_descriptor is nullptr");
-    }
-
-    if(descriptor->get_type() == HIPDNN_INVALID_TYPE)
-    {
-        throw hipdnn_backend::Hipdnn_exception(HIPDNN_STATUS_BAD_PARAM,
-                                               "hipdnnBackendDescriptor_t is invalid type");
     }
 }
 

--- a/backend/src/hipdnn_backend.cpp
+++ b/backend/src/hipdnn_backend.cpp
@@ -213,10 +213,10 @@ HIPDNN_BACKEND_EXPORT hipdnnStatus_t
         throw_if_invalid_descriptor(descriptor);
 
         descriptor->get_attribute(attribute_name,
-                                    attribute_type,
-                                    requested_element_count,
-                                    element_count,
-                                    array_of_elements);
+                                  attribute_type,
+                                  requested_element_count,
+                                  element_count,
+                                  array_of_elements);
 
         if(element_count == nullptr)
         {
@@ -252,8 +252,7 @@ HIPDNN_BACKEND_EXPORT hipdnnStatus_t
     return hipdnn_backend::try_catch([&, api_name = __func__]() {
         throw_if_invalid_descriptor(descriptor);
 
-        descriptor->set_attribute(
-            attribute_name, attribute_type, element_count, array_of_elements);
+        descriptor->set_attribute(attribute_name, attribute_type, element_count, array_of_elements);
 
         LOG_API_SUCCESS(
             api_name, "status={}", hipdnn_backend::hipdnn_get_status_string(HIPDNN_STATUS_SUCCESS));

--- a/backend/src/hipdnn_backend.cpp
+++ b/backend/src/hipdnn_backend.cpp
@@ -34,14 +34,14 @@ void throw_if_invalid_descriptor(hipdnnBackendDescriptor_t descriptor)
                                                "hipdnnBackendDescriptor_t is nullptr");
     }
 
-    if(descriptor->private_descriptor == nullptr)
+    if(!descriptor->impl)
     {
         throw hipdnn_backend::Hipdnn_exception(
             HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
             "hipdnnBackendDescriptor_t private_descriptor is nullptr");
     }
 
-    if(descriptor->private_descriptor->type == HIPDNN_INVALID_TYPE)
+    if(descriptor->get_type() == HIPDNN_INVALID_TYPE)
     {
         throw hipdnn_backend::Hipdnn_exception(HIPDNN_STATUS_BAD_PARAM,
                                                "hipdnnBackendDescriptor_t is invalid type");
@@ -173,16 +173,15 @@ HIPDNN_BACKEND_EXPORT hipdnnStatus_t hipdnnBackendFinalize(hipdnnBackendDescript
     return hipdnn_backend::try_catch([&, api_name = __func__]() {
         throw_if_invalid_descriptor(descriptor);
 
-        auto& private_descriptor = descriptor->private_descriptor;
-        private_descriptor->finalize();
+        descriptor->finalize();
 
-        if(private_descriptor->type == HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR)
+        if(descriptor->get_type() == HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR)
         {
             Plugin_manager plugin_manager;
             plugin_manager.initialize();
             plugin_manager.finalize_engine_config(descriptor);
         }
-        else if(private_descriptor->type == HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR)
+        else if(descriptor->get_type() == HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR)
         {
             Plugin_manager plugin_manager;
             plugin_manager.initialize();
@@ -213,11 +212,11 @@ HIPDNN_BACKEND_EXPORT hipdnnStatus_t
     return hipdnn_backend::try_catch([&, api_name = __func__]() {
         throw_if_invalid_descriptor(descriptor);
 
-        descriptor->private_descriptor->get_attribute(attribute_name,
-                                                      attribute_type,
-                                                      requested_element_count,
-                                                      element_count,
-                                                      array_of_elements);
+        descriptor->get_attribute(attribute_name,
+                                    attribute_type,
+                                    requested_element_count,
+                                    element_count,
+                                    array_of_elements);
 
         if(element_count == nullptr)
         {
@@ -253,7 +252,7 @@ HIPDNN_BACKEND_EXPORT hipdnnStatus_t
     return hipdnn_backend::try_catch([&, api_name = __func__]() {
         throw_if_invalid_descriptor(descriptor);
 
-        descriptor->private_descriptor->set_attribute(
+        descriptor->set_attribute(
             attribute_name, attribute_type, element_count, array_of_elements);
 
         LOG_API_SUCCESS(

--- a/backend/src/plugin/engine_plugin_resource_manager.cpp
+++ b/backend/src/plugin/engine_plugin_resource_manager.cpp
@@ -415,22 +415,10 @@ void Engine_plugin_resource_manager::execute_op_graph(hipdnnBackendDescriptor_t 
     auto execution_plan_desc = execution_plan->as_descriptor<Execution_plan_descriptor>();
     auto variant_pack_desc = variant_pack->as_descriptor<Variant_descriptor>();
 
-    THROW_IF_NE(execution_plan_desc->type,
-                HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR,
-                HIPDNN_STATUS_BAD_PARAM,
-                "Engine_plugin_resource_manager::execute_op_graph failed: Invalid execution plan "
-                "descriptor type");
-
     THROW_IF_FALSE(execution_plan_desc->is_finalized(),
                    HIPDNN_STATUS_BAD_PARAM,
                    "Engine_plugin_resource_manager::execute_op_graph failed: execution_plan_desc "
                    "is not finalized");
-
-    THROW_IF_NE(variant_pack_desc->type,
-                HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR,
-                HIPDNN_STATUS_BAD_PARAM,
-                "Engine_plugin_resource_manager::execute_op_graph failed: Invalid variant pack "
-                "descriptor type");
 
     THROW_IF_FALSE(variant_pack_desc->is_finalized(),
                    HIPDNN_STATUS_BAD_PARAM,

--- a/backend/src/plugin/engine_plugin_resource_manager.cpp
+++ b/backend/src/plugin/engine_plugin_resource_manager.cpp
@@ -91,7 +91,7 @@ Engine_plugin_resource_manager::Engine_plugin_resource_manager(
     {
         auto handle = plugin.create_handle();
 
-        if(_handle_to_plugin.find(handle) != _handle_to_plugin.end())
+        if(_handle_to_plugin.contains(handle))
         {
             throw Hipdnn_exception(HIPDNN_STATUS_PLUGIN_ERROR, "Plugin handle already exists");
         }

--- a/backend/src/plugin/plugin_manager.cpp
+++ b/backend/src/plugin/plugin_manager.cpp
@@ -104,16 +104,6 @@ void Plugin_manager::execute(hipdnnHandle* handle,
     auto execution_plan_desc = execution_plan->as_descriptor<Execution_plan_descriptor>();
     auto variant_desc = variant_pack->as_descriptor<Variant_descriptor>();
 
-    THROW_IF_NE(execution_plan_desc->type,
-                HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR,
-                HIPDNN_STATUS_BAD_PARAM,
-                "Plugin_manager::execute failed: Invalid execution plan descriptor type");
-
-    THROW_IF_NE(variant_desc->type,
-                HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR,
-                HIPDNN_STATUS_BAD_PARAM,
-                "Plugin_manager::execute failed: Invalid variant pack descriptor type");
-
     THROW_IF_FALSE(execution_plan_desc->is_finalized(),
                    HIPDNN_STATUS_BAD_PARAM,
                    "Plugin_manager::execute failed: execution_plan_desc is not finalized");

--- a/backend/tests/descriptors/mocks/mock_descriptor.hpp
+++ b/backend/tests/descriptors/mocks/mock_descriptor.hpp
@@ -10,14 +10,10 @@
 namespace hipdnn_backend
 {
 
-class Mock_descriptor : public hipdnnPrivateBackendDescriptor
+template <typename Desc_type>
+class Mock_descriptor : public hipdnnBackendDescriptorImpl<Mock_descriptor<Desc_type>>
 {
 public:
-    Mock_descriptor(hipdnnBackendDescriptorType_t desc_type = HIPDNN_INVALID_TYPE)
-    {
-        type = desc_type;
-    }
-    ~Mock_descriptor() override = default;
 
     MOCK_METHOD(void, finalize, (), (override));
     MOCK_METHOD(bool, is_finalized, (), (const, override));
@@ -36,6 +32,11 @@ public:
                  int64_t* element_count,
                  void* array_of_elements),
                 (const, override));
+
+    static hipdnnBackendDescriptorType_t get_static_type()
+    {
+        return Desc_type::get_static_type();
+    }
 };
 
 ACTION_P(SetArg4ToInt64, value) // NOLINT
@@ -43,21 +44,23 @@ ACTION_P(SetArg4ToInt64, value) // NOLINT
     *static_cast<int64_t*>(arg4) = value;
 }
 
+template <typename Desc_type>
 inline std::unique_ptr<hipdnnBackendDescriptor>
-    make_mock_descriptor_wrapper(hipdnnBackendDescriptorType_t desc_type = HIPDNN_INVALID_TYPE)
+    make_mock_descriptor_wrapper()
 {
     auto mock_wrapper = std::make_unique<hipdnnBackendDescriptor>();
-    mock_wrapper->private_descriptor = std::make_shared<Mock_descriptor>(desc_type);
+    mock_wrapper->impl = std::make_shared<Mock_descriptor<Desc_type>>();
     return mock_wrapper;
 }
 
-inline Mock_descriptor* unpack_mock_descriptor(hipdnnBackendDescriptor* descriptor)
+template <typename Desc_type>
+inline Mock_descriptor<Desc_type>* unpack_mock_descriptor(hipdnnBackendDescriptor* descriptor)
 {
-    if(descriptor == nullptr || descriptor->private_descriptor == nullptr)
+    if(descriptor == nullptr || descriptor->impl == nullptr)
     {
         return nullptr;
     }
-    return dynamic_cast<Mock_descriptor*>(descriptor->private_descriptor.get());
+    return dynamic_cast<Mock_descriptor<Desc_type>*>(descriptor->impl.get());
 }
 
 } // namespace hipdnn_backend

--- a/backend/tests/descriptors/mocks/mock_descriptor.hpp
+++ b/backend/tests/descriptors/mocks/mock_descriptor.hpp
@@ -43,22 +43,4 @@ ACTION_P(SetArg4ToInt64, value) // NOLINT
     *static_cast<int64_t*>(arg4) = value;
 }
 
-template <typename Desc_type>
-inline std::unique_ptr<hipdnnBackendDescriptor> make_mock_descriptor_wrapper()
-{
-    auto mock_wrapper = std::make_unique<hipdnnBackendDescriptor>();
-    mock_wrapper->impl = std::make_shared<Mock_descriptor<Desc_type>>();
-    return mock_wrapper;
-}
-
-template <typename Desc_type>
-inline Mock_descriptor<Desc_type>* unpack_mock_descriptor(hipdnnBackendDescriptor* descriptor)
-{
-    if(descriptor == nullptr || descriptor->impl == nullptr)
-    {
-        return nullptr;
-    }
-    return dynamic_cast<Mock_descriptor<Desc_type>*>(descriptor->impl.get());
-}
-
 } // namespace hipdnn_backend

--- a/backend/tests/descriptors/mocks/mock_descriptor.hpp
+++ b/backend/tests/descriptors/mocks/mock_descriptor.hpp
@@ -14,7 +14,6 @@ template <typename Desc_type>
 class Mock_descriptor : public hipdnnBackendDescriptorImpl<Mock_descriptor<Desc_type>>
 {
 public:
-
     MOCK_METHOD(void, finalize, (), (override));
     MOCK_METHOD(bool, is_finalized, (), (const, override));
     MOCK_METHOD(void,
@@ -45,8 +44,7 @@ ACTION_P(SetArg4ToInt64, value) // NOLINT
 }
 
 template <typename Desc_type>
-inline std::unique_ptr<hipdnnBackendDescriptor>
-    make_mock_descriptor_wrapper()
+inline std::unique_ptr<hipdnnBackendDescriptor> make_mock_descriptor_wrapper()
 {
     auto mock_wrapper = std::make_unique<hipdnnBackendDescriptor>();
     mock_wrapper->impl = std::make_shared<Mock_descriptor<Desc_type>>();

--- a/backend/tests/descriptors/test_backend_descriptor.cpp
+++ b/backend/tests/descriptors/test_backend_descriptor.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "descriptors/backend_descriptor.hpp"
+#include "descriptors/engine_descriptor.hpp"
 #include "descriptors/scoped_descriptor.hpp"
 #include "mocks/mock_descriptor.hpp"
 
@@ -13,55 +14,55 @@ using namespace hipdnn_backend;
 
 TEST(BackendDescriptorTest, PackAndUnpackDescriptorWorks)
 {
-    auto mock_ptr = std::make_shared<Mock_descriptor>(HIPDNN_BACKEND_ENGINE_DESCRIPTOR);
+    auto mock_ptr = std::make_shared<Mock_descriptor<Engine_descriptor>>();
 
     Scoped_descriptor packed(pack_descriptor(mock_ptr));
     ASSERT_NE(packed.get(), nullptr);
-    ASSERT_NE(packed.get()->private_descriptor, nullptr);
+    ASSERT_NE(packed.get()->impl, nullptr);
 
     auto unpacked
-        = unpack_descriptor<Mock_descriptor>(packed.get(), HIPDNN_STATUS_INTERNAL_ERROR, "fail");
+        = unpack_descriptor<Mock_descriptor<Engine_descriptor>>(packed.get(), HIPDNN_STATUS_INTERNAL_ERROR, "fail");
     ASSERT_EQ(unpacked.get(), mock_ptr.get());
-    ASSERT_EQ(unpacked->type, HIPDNN_BACKEND_ENGINE_DESCRIPTOR);
+    ASSERT_EQ(unpacked->get_type(), HIPDNN_BACKEND_ENGINE_DESCRIPTOR);
 }
 
 TEST(BackendDescriptorTest, AsDescriptorCastsCorrectly)
 {
-    auto mock_ptr = std::make_shared<Mock_descriptor>();
+    auto mock_ptr = std::make_shared<Mock_descriptor<Engine_descriptor>>();
     Scoped_descriptor packed(pack_descriptor(mock_ptr));
 
-    auto result = packed.get()->as_descriptor<Mock_descriptor>();
+    auto result = packed.get()->as_descriptor<Mock_descriptor<Engine_descriptor>>();
     ASSERT_EQ(result.get(), mock_ptr.get());
 }
 
 TEST(BackendDescriptorTest, UnpackDescriptorFromArrayWorks)
 {
-    auto mock_ptr = std::make_shared<Mock_descriptor>();
+    auto mock_ptr = std::make_shared<Mock_descriptor<Engine_descriptor>>();
     Scoped_descriptor packed(pack_descriptor(mock_ptr));
 
     void* array_of_elements = &packed.descriptor;
-    auto unpacked = unpack_descriptor<Mock_descriptor>(
+    auto unpacked = unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
         array_of_elements, HIPDNN_STATUS_INTERNAL_ERROR, "fail");
     ASSERT_EQ(unpacked.get(), mock_ptr.get());
 }
 
 TEST(BackendDescriptorTest, PackDescriptorToArrayWorks)
 {
-    auto mock_ptr = std::make_shared<Mock_descriptor>();
+    auto mock_ptr = std::make_shared<Mock_descriptor<Engine_descriptor>>();
     hipdnnBackendDescriptor_t desc = nullptr;
     void* array_of_elements = &desc;
-    pack_descriptor<Mock_descriptor>(mock_ptr, array_of_elements);
+    pack_descriptor(mock_ptr, array_of_elements);
     Scoped_descriptor scoped(desc);
 
     ASSERT_NE(desc, nullptr);
-    ASSERT_NE(desc->private_descriptor, nullptr);
+    ASSERT_NE(desc->impl, nullptr);
 }
 
 TEST(BackendDescriptorTest, UnpackDescriptorThrowsOnNullDescriptor)
 {
     EXPECT_THROW(
         {
-            unpack_descriptor<Mock_descriptor>(static_cast<hipdnnBackendDescriptor*>(nullptr),
+            unpack_descriptor<Mock_descriptor<Engine_descriptor>>(static_cast<hipdnnBackendDescriptor*>(nullptr),
                                                HIPDNN_STATUS_INTERNAL_ERROR,
                                                "fail");
         },
@@ -71,10 +72,10 @@ TEST(BackendDescriptorTest, UnpackDescriptorThrowsOnNullDescriptor)
 TEST(BackendDescriptorTest, UnpackDescriptorThrowsOnNullPrivateDescriptor)
 {
     Scoped_descriptor packed(new hipdnnBackendDescriptor());
-    packed.get()->private_descriptor = nullptr;
+    packed.get()->impl = nullptr;
 
     EXPECT_THROW(
-        { unpack_descriptor<Mock_descriptor>(packed.get(), HIPDNN_STATUS_INTERNAL_ERROR, "fail"); },
+        { unpack_descriptor<Mock_descriptor<Engine_descriptor>>(packed.get(), HIPDNN_STATUS_INTERNAL_ERROR, "fail"); },
         Hipdnn_exception);
 }
 
@@ -82,7 +83,7 @@ TEST(BackendDescriptorTest, UnpackDescriptorFromArrayThrowsOnNullArray)
 {
     EXPECT_THROW(
         {
-            unpack_descriptor<Mock_descriptor>(
+            unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
                 static_cast<void*>(nullptr), HIPDNN_STATUS_INTERNAL_ERROR, "fail");
         },
         Hipdnn_exception);

--- a/backend/tests/descriptors/test_backend_descriptor.cpp
+++ b/backend/tests/descriptors/test_backend_descriptor.cpp
@@ -20,8 +20,8 @@ TEST(BackendDescriptorTest, PackAndUnpackDescriptorWorks)
     ASSERT_NE(packed.get(), nullptr);
     ASSERT_NE(packed.get()->impl, nullptr);
 
-    auto unpacked
-        = unpack_descriptor<Mock_descriptor<Engine_descriptor>>(packed.get(), HIPDNN_STATUS_INTERNAL_ERROR, "fail");
+    auto unpacked = unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
+        packed.get(), HIPDNN_STATUS_INTERNAL_ERROR, "fail");
     ASSERT_EQ(unpacked.get(), mock_ptr.get());
     ASSERT_EQ(unpacked->get_type(), HIPDNN_BACKEND_ENGINE_DESCRIPTOR);
 }
@@ -62,9 +62,10 @@ TEST(BackendDescriptorTest, UnpackDescriptorThrowsOnNullDescriptor)
 {
     EXPECT_THROW(
         {
-            unpack_descriptor<Mock_descriptor<Engine_descriptor>>(static_cast<hipdnnBackendDescriptor*>(nullptr),
-                                               HIPDNN_STATUS_INTERNAL_ERROR,
-                                               "fail");
+            unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
+                static_cast<hipdnnBackendDescriptor*>(nullptr),
+                HIPDNN_STATUS_INTERNAL_ERROR,
+                "fail");
         },
         Hipdnn_exception);
 }
@@ -75,7 +76,10 @@ TEST(BackendDescriptorTest, UnpackDescriptorThrowsOnNullPrivateDescriptor)
     packed.get()->impl = nullptr;
 
     EXPECT_THROW(
-        { unpack_descriptor<Mock_descriptor<Engine_descriptor>>(packed.get(), HIPDNN_STATUS_INTERNAL_ERROR, "fail"); },
+        {
+            unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
+                packed.get(), HIPDNN_STATUS_INTERNAL_ERROR, "fail");
+        },
         Hipdnn_exception);
 }
 

--- a/backend/tests/descriptors/test_backend_descriptor.cpp
+++ b/backend/tests/descriptors/test_backend_descriptor.cpp
@@ -16,11 +16,10 @@ TEST(BackendDescriptorTest, PackAndUnpackDescriptorWorks)
 {
     auto mock_ptr = std::make_shared<Mock_descriptor<Engine_descriptor>>();
 
-    Scoped_descriptor packed(pack_descriptor(mock_ptr));
+    Scoped_descriptor packed(hipdnnBackendDescriptor::pack_descriptor(mock_ptr));
     ASSERT_NE(packed.get(), nullptr);
-    ASSERT_NE(packed.get()->impl, nullptr);
 
-    auto unpacked = unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
+    auto unpacked = hipdnnBackendDescriptor::unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
         packed.get(), HIPDNN_STATUS_INTERNAL_ERROR, "fail");
     ASSERT_EQ(unpacked.get(), mock_ptr.get());
     ASSERT_EQ(unpacked->get_type(), HIPDNN_BACKEND_ENGINE_DESCRIPTOR);
@@ -29,7 +28,7 @@ TEST(BackendDescriptorTest, PackAndUnpackDescriptorWorks)
 TEST(BackendDescriptorTest, AsDescriptorCastsCorrectly)
 {
     auto mock_ptr = std::make_shared<Mock_descriptor<Engine_descriptor>>();
-    Scoped_descriptor packed(pack_descriptor(mock_ptr));
+    Scoped_descriptor packed(hipdnnBackendDescriptor::pack_descriptor(mock_ptr));
 
     auto result = packed.get()->as_descriptor<Mock_descriptor<Engine_descriptor>>();
     ASSERT_EQ(result.get(), mock_ptr.get());
@@ -38,10 +37,10 @@ TEST(BackendDescriptorTest, AsDescriptorCastsCorrectly)
 TEST(BackendDescriptorTest, UnpackDescriptorFromArrayWorks)
 {
     auto mock_ptr = std::make_shared<Mock_descriptor<Engine_descriptor>>();
-    Scoped_descriptor packed(pack_descriptor(mock_ptr));
+    Scoped_descriptor packed(hipdnnBackendDescriptor::pack_descriptor(mock_ptr));
 
     void* array_of_elements = &packed.descriptor;
-    auto unpacked = unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
+    auto unpacked = hipdnnBackendDescriptor::unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
         array_of_elements, HIPDNN_STATUS_INTERNAL_ERROR, "fail");
     ASSERT_EQ(unpacked.get(), mock_ptr.get());
 }
@@ -51,18 +50,17 @@ TEST(BackendDescriptorTest, PackDescriptorToArrayWorks)
     auto mock_ptr = std::make_shared<Mock_descriptor<Engine_descriptor>>();
     hipdnnBackendDescriptor_t desc = nullptr;
     void* array_of_elements = &desc;
-    pack_descriptor(mock_ptr, array_of_elements);
+    hipdnnBackendDescriptor::pack_descriptor(mock_ptr, array_of_elements);
     Scoped_descriptor scoped(desc);
 
     ASSERT_NE(desc, nullptr);
-    ASSERT_NE(desc->impl, nullptr);
 }
 
 TEST(BackendDescriptorTest, UnpackDescriptorThrowsOnNullDescriptor)
 {
     EXPECT_THROW(
         {
-            unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
+            hipdnnBackendDescriptor::unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
                 static_cast<hipdnnBackendDescriptor*>(nullptr),
                 HIPDNN_STATUS_INTERNAL_ERROR,
                 "fail");
@@ -73,11 +71,10 @@ TEST(BackendDescriptorTest, UnpackDescriptorThrowsOnNullDescriptor)
 TEST(BackendDescriptorTest, UnpackDescriptorThrowsOnNullPrivateDescriptor)
 {
     Scoped_descriptor packed(new hipdnnBackendDescriptor());
-    packed.get()->impl = nullptr;
 
     EXPECT_THROW(
         {
-            unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
+            hipdnnBackendDescriptor::unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
                 packed.get(), HIPDNN_STATUS_INTERNAL_ERROR, "fail");
         },
         Hipdnn_exception);
@@ -87,7 +84,7 @@ TEST(BackendDescriptorTest, UnpackDescriptorFromArrayThrowsOnNullArray)
 {
     EXPECT_THROW(
         {
-            unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
+            hipdnnBackendDescriptor::unpack_descriptor<Mock_descriptor<Engine_descriptor>>(
                 static_cast<void*>(nullptr), HIPDNN_STATUS_INTERNAL_ERROR, "fail");
         },
         Hipdnn_exception);

--- a/backend/tests/descriptors/test_descriptor_factory.cpp
+++ b/backend/tests/descriptors/test_descriptor_factory.cpp
@@ -155,9 +155,7 @@ TEST(Descriptor_Factory_Test, Create_Variant_Descriptor)
         Descriptor_factory::create(HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR, &descriptor));
     EXPECT_NE(descriptor, nullptr);
 
-    auto variant_descriptor = dynamic_cast<Variant_descriptor*>(descriptor->impl.get());
-    EXPECT_NE(variant_descriptor, nullptr);
-
+    auto variant_descriptor = descriptor->as_descriptor<Variant_descriptor>();
     EXPECT_FALSE(variant_descriptor->is_finalized());
 
     ASSERT_NO_THROW(Descriptor_factory::destroy(descriptor));

--- a/backend/tests/descriptors/test_descriptor_factory.cpp
+++ b/backend/tests/descriptors/test_descriptor_factory.cpp
@@ -156,7 +156,7 @@ TEST(Descriptor_Factory_Test, Create_Variant_Descriptor)
     EXPECT_NE(descriptor, nullptr);
 
     auto variant_descriptor
-        = dynamic_cast<Variant_descriptor*>(descriptor->private_descriptor.get());
+        = dynamic_cast<Variant_descriptor*>(descriptor->impl.get());
     EXPECT_NE(variant_descriptor, nullptr);
 
     EXPECT_FALSE(variant_descriptor->is_finalized());

--- a/backend/tests/descriptors/test_descriptor_factory.cpp
+++ b/backend/tests/descriptors/test_descriptor_factory.cpp
@@ -155,8 +155,7 @@ TEST(Descriptor_Factory_Test, Create_Variant_Descriptor)
         Descriptor_factory::create(HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR, &descriptor));
     EXPECT_NE(descriptor, nullptr);
 
-    auto variant_descriptor
-        = dynamic_cast<Variant_descriptor*>(descriptor->impl.get());
+    auto variant_descriptor = dynamic_cast<Variant_descriptor*>(descriptor->impl.get());
     EXPECT_NE(variant_descriptor, nullptr);
 
     EXPECT_FALSE(variant_descriptor->is_finalized());

--- a/backend/tests/descriptors/test_descriptor_utils.hpp
+++ b/backend/tests/descriptors/test_descriptor_utils.hpp
@@ -11,10 +11,7 @@ namespace test_descriptor_utils
 template <typename T>
 hipdnnBackendDescriptor* create_descriptor_ptr()
 {
-    auto desc_wrapper = new hipdnnBackendDescriptor();
-    desc_wrapper->impl = std::make_shared<T>();
-
-    return desc_wrapper;
+    return hipdnnBackendDescriptor::pack_descriptor(std::make_shared<T>());
 }
 
 template <typename T>

--- a/backend/tests/descriptors/test_descriptor_utils.hpp
+++ b/backend/tests/descriptors/test_descriptor_utils.hpp
@@ -12,7 +12,7 @@ template <typename T>
 hipdnnBackendDescriptor* create_descriptor_ptr()
 {
     auto desc_wrapper = new hipdnnBackendDescriptor();
-    desc_wrapper->private_descriptor = std::make_shared<T>();
+    desc_wrapper->impl = std::make_shared<T>();
 
     return desc_wrapper;
 }

--- a/backend/tests/descriptors/test_engine_config_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_config_descriptor.cpp
@@ -24,21 +24,22 @@ public:
     std::unique_ptr<hipdnnBackendDescriptor> _engine_config_wrapper = nullptr;
     std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_wrapper = nullptr;
     std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_bad_type_wrapper = nullptr;
+    std::unique_ptr<hipdnnBackendDescriptor> _mock_wrong_type_wrapper = nullptr;
 
     Engine_config_descriptor* get_engine_config_descriptor() const
     {
         return dynamic_cast<Engine_config_descriptor*>(
-            _engine_config_wrapper->private_descriptor.get());
+            _engine_config_wrapper->impl.get());
     }
 
-    Mock_descriptor* get_mock_engine() const
+    Mock_descriptor<Engine_descriptor>* get_mock_engine() const
     {
-        return unpack_mock_descriptor(_mock_engine_wrapper.get());
+        return unpack_mock_descriptor<Engine_descriptor>(_mock_engine_wrapper.get());
     }
 
-    Mock_descriptor* get_mock_engine_bad_type() const
+    Mock_descriptor<Engine_descriptor>* get_mock_engine_bad_type() const
     {
-        return unpack_mock_descriptor(_mock_engine_bad_type_wrapper.get());
+        return unpack_mock_descriptor<Engine_descriptor>(_mock_engine_bad_type_wrapper.get());
     }
 
     void set_engine() const
@@ -67,8 +68,9 @@ protected:
     void SetUp() override
     {
         _engine_config_wrapper = create_descriptor<Engine_config_descriptor>();
-        _mock_engine_wrapper = make_mock_descriptor_wrapper(HIPDNN_BACKEND_ENGINE_DESCRIPTOR);
-        _mock_engine_bad_type_wrapper = make_mock_descriptor_wrapper();
+        _mock_engine_wrapper = make_mock_descriptor_wrapper<Engine_descriptor>();
+        _mock_engine_bad_type_wrapper = make_mock_descriptor_wrapper<Engine_descriptor>();
+        _mock_wrong_type_wrapper = make_mock_descriptor_wrapper<Engine_config_descriptor>();
     }
 };
 
@@ -77,7 +79,7 @@ TEST_F(Engine_config_descriptor_test, CreateEngineConfigDescriptor)
     auto engine_config = get_engine_config_descriptor();
     ASSERT_NE(engine_config, nullptr);
     ASSERT_FALSE(engine_config->is_finalized());
-    ASSERT_EQ(engine_config->type, HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR);
+    ASSERT_EQ(engine_config->get_type(), HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR);
 }
 
 TEST_F(Engine_config_descriptor_test, SetEngineConfigDescriptorEngine)
@@ -109,6 +111,12 @@ TEST_F(Engine_config_descriptor_test, SetEngineConfigDescriptorEngine)
                                                             HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                                             1,
                                                             &_mock_engine_bad_type_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+
+    ASSERT_THROW_HIPDNN_STATUS(engine_config->set_attribute(HIPDNN_ATTR_ENGINECFG_ENGINE,
+                                                            HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                            1,
+                                                            &_mock_wrong_type_wrapper),
                                HIPDNN_STATUS_BAD_PARAM);
 
     EXPECT_CALL(*get_mock_engine(), is_finalized()).WillOnce(Return(false));
@@ -217,7 +225,7 @@ TEST_F(Engine_config_descriptor_test, GetEngineConfigDescriptorEngine)
                                                  1,
                                                  nullptr,
                                                  engine.get_ptr()));
-    ASSERT_EQ(engine.get()->private_descriptor, _mock_engine_wrapper->private_descriptor);
+    ASSERT_EQ(engine.get()->impl, _mock_engine_wrapper->impl);
 
     int64_t count;
     ASSERT_NO_THROW(engine_config->get_attribute(HIPDNN_ATTR_ENGINECFG_ENGINE,
@@ -240,8 +248,8 @@ TEST_F(Engine_config_descriptor_test, GetEngineReturnsPointerIfFinalized)
     make_engine_config_finalized();
     auto engine_ptr = engine_config->get_engine();
     ASSERT_NE(engine_ptr, nullptr);
-    ASSERT_EQ(static_cast<const hipdnnPrivateBackendDescriptor*>(engine_ptr.get()),
-              static_cast<const hipdnnPrivateBackendDescriptor*>(get_mock_engine()));
+    ASSERT_EQ(static_cast<const Backend_descriptor_interface*>(engine_ptr.get()),
+              static_cast<const Backend_descriptor_interface*>(get_mock_engine()));
 }
 
 TEST_F(Engine_config_descriptor_test, GetEngineDescriptorMaxWorkspaceSize)

--- a/backend/tests/descriptors/test_engine_config_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_config_descriptor.cpp
@@ -14,7 +14,6 @@
 #include <memory>
 
 using namespace hipdnn_backend;
-using namespace test_descriptor_utils;
 
 using ::testing::Return;
 
@@ -26,19 +25,19 @@ public:
     std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_bad_type_wrapper = nullptr;
     std::unique_ptr<hipdnnBackendDescriptor> _mock_wrong_type_wrapper = nullptr;
 
-    Engine_config_descriptor* get_engine_config_descriptor() const
+    std::shared_ptr<Engine_config_descriptor> get_engine_config_descriptor() const
     {
-        return dynamic_cast<Engine_config_descriptor*>(_engine_config_wrapper->impl.get());
+        return _engine_config_wrapper->as_descriptor<Engine_config_descriptor>();
     }
 
-    Mock_descriptor<Engine_descriptor>* get_mock_engine() const
+    std::shared_ptr<Mock_descriptor<Engine_descriptor>> get_mock_engine() const
     {
-        return unpack_mock_descriptor<Engine_descriptor>(_mock_engine_wrapper.get());
+        return _mock_engine_wrapper->as_descriptor<Mock_descriptor<Engine_descriptor>>();
     }
 
-    Mock_descriptor<Engine_descriptor>* get_mock_engine_bad_type() const
+    std::shared_ptr<Mock_descriptor<Engine_descriptor>> get_mock_engine_bad_type() const
     {
-        return unpack_mock_descriptor<Engine_descriptor>(_mock_engine_bad_type_wrapper.get());
+        return _mock_engine_bad_type_wrapper->as_descriptor<Mock_descriptor<Engine_descriptor>>();
     }
 
     void set_engine() const
@@ -66,10 +65,14 @@ public:
 protected:
     void SetUp() override
     {
-        _engine_config_wrapper = create_descriptor<Engine_config_descriptor>();
-        _mock_engine_wrapper = make_mock_descriptor_wrapper<Engine_descriptor>();
-        _mock_engine_bad_type_wrapper = make_mock_descriptor_wrapper<Engine_descriptor>();
-        _mock_wrong_type_wrapper = make_mock_descriptor_wrapper<Engine_config_descriptor>();
+        _engine_config_wrapper
+            = test_descriptor_utils::create_descriptor<Engine_config_descriptor>();
+        _mock_engine_wrapper
+            = test_descriptor_utils::create_descriptor<Mock_descriptor<Engine_descriptor>>();
+        _mock_engine_bad_type_wrapper
+            = test_descriptor_utils::create_descriptor<Mock_descriptor<Engine_descriptor>>();
+        _mock_wrong_type_wrapper
+            = test_descriptor_utils::create_descriptor<Mock_descriptor<Engine_config_descriptor>>();
     }
 };
 
@@ -224,7 +227,7 @@ TEST_F(Engine_config_descriptor_test, GetEngineConfigDescriptorEngine)
                                                  1,
                                                  nullptr,
                                                  engine.get_ptr()));
-    ASSERT_EQ(engine.get()->impl, _mock_engine_wrapper->impl);
+    ASSERT_EQ(*engine.get(), *(_mock_engine_wrapper.get()));
 
     int64_t count;
     ASSERT_NO_THROW(engine_config->get_attribute(HIPDNN_ATTR_ENGINECFG_ENGINE,
@@ -248,7 +251,7 @@ TEST_F(Engine_config_descriptor_test, GetEngineReturnsPointerIfFinalized)
     auto engine_ptr = engine_config->get_engine();
     ASSERT_NE(engine_ptr, nullptr);
     ASSERT_EQ(static_cast<const Backend_descriptor_interface*>(engine_ptr.get()),
-              static_cast<const Backend_descriptor_interface*>(get_mock_engine()));
+              static_cast<const Backend_descriptor_interface*>(get_mock_engine().get()));
 }
 
 TEST_F(Engine_config_descriptor_test, GetEngineDescriptorMaxWorkspaceSize)

--- a/backend/tests/descriptors/test_engine_config_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_config_descriptor.cpp
@@ -28,8 +28,7 @@ public:
 
     Engine_config_descriptor* get_engine_config_descriptor() const
     {
-        return dynamic_cast<Engine_config_descriptor*>(
-            _engine_config_wrapper->impl.get());
+        return dynamic_cast<Engine_config_descriptor*>(_engine_config_wrapper->impl.get());
     }
 
     Mock_descriptor<Engine_descriptor>* get_mock_engine() const

--- a/backend/tests/descriptors/test_engine_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_descriptor.cpp
@@ -1,307 +1,307 @@
-// Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier: MIT
+// // Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// // SPDX-License-Identifier: MIT
 
-#include "descriptors/engine_descriptor.hpp"
-#include "descriptors/graph_descriptor.hpp"
-#include "descriptors/scoped_descriptor.hpp"
-#include "hipdnn_backend.h"
-#include "hipdnn_exception.hpp"
-#include "mocks/mock_descriptor.hpp"
-#include "test_descriptor_utils.hpp"
-#include "test_macros.hpp"
+// #include "descriptors/engine_descriptor.hpp"
+// #include "descriptors/graph_descriptor.hpp"
+// #include "descriptors/scoped_descriptor.hpp"
+// #include "hipdnn_backend.h"
+// #include "hipdnn_exception.hpp"
+// #include "mocks/mock_descriptor.hpp"
+// #include "test_descriptor_utils.hpp"
+// #include "test_macros.hpp"
 
-#include <gtest/gtest.h>
+// #include <gtest/gtest.h>
 
-#include <memory>
+// #include <memory>
 
-using namespace hipdnn_backend;
-using namespace test_descriptor_utils;
+// using namespace hipdnn_backend;
+// using namespace test_descriptor_utils;
 
-using ::testing::Return;
+// using ::testing::Return;
 
-class Engine_descriptor_test : public ::testing::Test
-{
-public:
-    std::unique_ptr<hipdnnBackendDescriptor> _engine_wrapper = nullptr;
-    std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_wrapper = nullptr;
-    std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_bad_type_wrapper = nullptr;
+// class Engine_descriptor_test : public ::testing::Test
+// {
+// public:
+//     std::unique_ptr<hipdnnBackendDescriptor> _engine_wrapper = nullptr;
+//     std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_wrapper = nullptr;
+//     std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_bad_type_wrapper = nullptr;
 
-    Engine_descriptor* get_engine_descriptor() const
-    {
-        return dynamic_cast<Engine_descriptor*>(_engine_wrapper->private_descriptor.get());
-    }
+//     Engine_descriptor* get_engine_descriptor() const
+//     {
+//         return dynamic_cast<Engine_descriptor*>(_engine_wrapper->private_descriptor.get());
+//     }
 
-    Mock_descriptor* get_mock_graph() const
-    {
-        return unpack_mock_descriptor(_mock_graph_wrapper.get());
-    }
+//     Mock_descriptor* get_mock_graph() const
+//     {
+//         return unpack_mock_descriptor(_mock_graph_wrapper.get());
+//     }
 
-    Mock_descriptor* get_mock_graph_bad_type() const
-    {
-        return unpack_mock_descriptor(_mock_graph_bad_type_wrapper.get());
-    }
+//     Mock_descriptor* get_mock_graph_bad_type() const
+//     {
+//         return unpack_mock_descriptor(_mock_graph_bad_type_wrapper.get());
+//     }
 
-    void set_graph() const
-    {
-        EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
-        ASSERT_NO_THROW(get_engine_descriptor()->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-                                                               HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                               1,
-                                                               &_mock_graph_wrapper));
-    }
+//     void set_graph() const
+//     {
+//         EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
+//         ASSERT_NO_THROW(get_engine_descriptor()->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+//                                                                HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                                1,
+//                                                                &_mock_graph_wrapper));
+//     }
 
-    void set_global_index() const
-    {
-        int64_t gidx = 0;
-        ASSERT_NO_THROW(get_engine_descriptor()->set_attribute(
-            HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &gidx));
-    }
+//     void set_global_index() const
+//     {
+//         int64_t gidx = 0;
+//         ASSERT_NO_THROW(get_engine_descriptor()->set_attribute(
+//             HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &gidx));
+//     }
 
-    void make_engine_finalized() const
-    {
-        set_graph();
-        set_global_index();
-        ASSERT_NO_THROW(get_engine_descriptor()->finalize());
-    }
+//     void make_engine_finalized() const
+//     {
+//         set_graph();
+//         set_global_index();
+//         ASSERT_NO_THROW(get_engine_descriptor()->finalize());
+//     }
 
-protected:
-    void SetUp() override
-    {
-        _engine_wrapper = create_descriptor<Engine_descriptor>();
-        _mock_graph_wrapper
-            = make_mock_descriptor_wrapper(HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR);
-        _mock_graph_bad_type_wrapper = make_mock_descriptor_wrapper();
-    }
-};
+// protected:
+//     void SetUp() override
+//     {
+//         _engine_wrapper = create_descriptor<Engine_descriptor>();
+//         _mock_graph_wrapper
+//             = make_mock_descriptor_wrapper(HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR);
+//         _mock_graph_bad_type_wrapper = make_mock_descriptor_wrapper();
+//     }
+// };
 
-TEST_F(Engine_descriptor_test, CreateEngineDescriptor)
-{
-    auto engine = get_engine_descriptor();
-    ASSERT_NE(engine, nullptr);
-    ASSERT_FALSE(engine->is_finalized());
-    ASSERT_EQ(engine->type, HIPDNN_BACKEND_ENGINE_DESCRIPTOR);
-}
+// TEST_F(Engine_descriptor_test, CreateEngineDescriptor)
+// {
+//     auto engine = get_engine_descriptor();
+//     ASSERT_NE(engine, nullptr);
+//     ASSERT_FALSE(engine->is_finalized());
+//     ASSERT_EQ(engine->type, HIPDNN_BACKEND_ENGINE_DESCRIPTOR);
+// }
 
-TEST_F(Engine_descriptor_test, SetEngineDescriptorGraph)
-{
-    auto engine = get_engine_descriptor();
+// TEST_F(Engine_descriptor_test, SetEngineDescriptorGraph)
+// {
+//     auto engine = get_engine_descriptor();
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        engine->set_attribute(
-            HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, &_mock_graph_wrapper),
-        HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         engine->set_attribute(
+//             HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, &_mock_graph_wrapper),
+//         HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                     2,
-                                                     &_mock_graph_wrapper),
-                               HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+//                                                      HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                      2,
+//                                                      &_mock_graph_wrapper),
+//                                HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        engine->set_attribute(
-            HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         engine->set_attribute(
+//             HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr),
+//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    hipdnnBackendDescriptor_t graph = nullptr;
-    ASSERT_THROW_HIPDNN_STATUS(
-        engine->set_attribute(
-            HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &graph),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+//     hipdnnBackendDescriptor_t graph = nullptr;
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         engine->set_attribute(
+//             HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &graph),
+//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                     1,
-                                                     &_mock_graph_bad_type_wrapper),
-                               HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+//                                                      HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                      1,
+//                                                      &_mock_graph_bad_type_wrapper),
+//                                HIPDNN_STATUS_BAD_PARAM);
 
-    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(false));
-    ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                     1,
-                                                     &_mock_graph_wrapper),
-                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(false));
+//     ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+//                                                      HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                      1,
+//                                                      &_mock_graph_wrapper),
+//                                HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
 
-    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
-    ASSERT_NO_THROW(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-                                          HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                          1,
-                                          &_mock_graph_wrapper));
-}
+//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
+//     ASSERT_NO_THROW(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+//                                           HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                           1,
+//                                           &_mock_graph_wrapper));
+// }
 
-TEST_F(Engine_descriptor_test, SetEngineDescriptorGlobalId)
-{
-    auto engine = get_engine_descriptor();
-    int64_t gidx = 0;
+// TEST_F(Engine_descriptor_test, SetEngineDescriptorGlobalId)
+// {
+//     auto engine = get_engine_descriptor();
+//     int64_t gidx = 0;
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        engine->set_attribute(
-            HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &gidx),
-        HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         engine->set_attribute(
+//             HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &gidx),
+//         HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        engine->set_attribute(HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 2, &gidx),
-        HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         engine->set_attribute(HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 2, &gidx),
+//         HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        engine->set_attribute(HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         engine->set_attribute(HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr),
+//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    ASSERT_NO_THROW(
-        engine->set_attribute(HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &gidx));
-}
+//     ASSERT_NO_THROW(
+//         engine->set_attribute(HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &gidx));
+// }
 
-TEST_F(Engine_descriptor_test, SetAttrOnFinalizedEngineDescriptor)
-{
-    auto engine = get_engine_descriptor();
-    make_engine_finalized();
+// TEST_F(Engine_descriptor_test, SetAttrOnFinalizedEngineDescriptor)
+// {
+//     auto engine = get_engine_descriptor();
+//     make_engine_finalized();
 
-    ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                     1,
-                                                     &_mock_graph_wrapper),
-                               HIPDNN_STATUS_NOT_INITIALIZED);
-}
+//     ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+//                                                      HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                      1,
+//                                                      &_mock_graph_wrapper),
+//                                HIPDNN_STATUS_NOT_INITIALIZED);
+// }
 
-TEST_F(Engine_descriptor_test, FinalizeEngineDescriptor)
-{
-    auto engine = get_engine_descriptor();
-    ASSERT_THROW_HIPDNN_STATUS(engine->finalize(), HIPDNN_STATUS_BAD_PARAM);
+// TEST_F(Engine_descriptor_test, FinalizeEngineDescriptor)
+// {
+//     auto engine = get_engine_descriptor();
+//     ASSERT_THROW_HIPDNN_STATUS(engine->finalize(), HIPDNN_STATUS_BAD_PARAM);
 
-    set_graph();
-    set_global_index();
+//     set_graph();
+//     set_global_index();
 
-    ASSERT_NO_THROW(engine->finalize());
+//     ASSERT_NO_THROW(engine->finalize());
 
-    ASSERT_THROW_HIPDNN_STATUS(engine->finalize(), HIPDNN_STATUS_BAD_PARAM);
-}
+//     ASSERT_THROW_HIPDNN_STATUS(engine->finalize(), HIPDNN_STATUS_BAD_PARAM);
+// }
 
-TEST_F(Engine_descriptor_test, GetAttrOnUnfinalizedEngineDescriptor)
-{
-    auto engine = get_engine_descriptor();
-    hipdnnBackendDescriptor_t dummy_graph = nullptr;
+// TEST_F(Engine_descriptor_test, GetAttrOnUnfinalizedEngineDescriptor)
+// {
+//     auto engine = get_engine_descriptor();
+//     hipdnnBackendDescriptor_t dummy_graph = nullptr;
 
-    ASSERT_THROW_HIPDNN_STATUS(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                     1,
-                                                     nullptr,
-                                                     &dummy_graph),
-                               HIPDNN_STATUS_NOT_INITIALIZED);
-}
+//     ASSERT_THROW_HIPDNN_STATUS(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+//                                                      HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                      1,
+//                                                      nullptr,
+//                                                      &dummy_graph),
+//                                HIPDNN_STATUS_NOT_INITIALIZED);
+// }
 
-TEST_F(Engine_descriptor_test, GetEngineDescriptorUnsupportedAttr)
-{
-    auto engine = get_engine_descriptor();
-    int32_t dummy;
+// TEST_F(Engine_descriptor_test, GetEngineDescriptorUnsupportedAttr)
+// {
+//     auto engine = get_engine_descriptor();
+//     int32_t dummy;
 
-    make_engine_finalized();
+//     make_engine_finalized();
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        engine->get_attribute(
-            HIPDNN_ATTR_ENGINE_SM_COUNT_TARGET, HIPDNN_TYPE_INT32, 1, nullptr, &dummy),
-        HIPDNN_STATUS_NOT_SUPPORTED);
-}
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         engine->get_attribute(
+//             HIPDNN_ATTR_ENGINE_SM_COUNT_TARGET, HIPDNN_TYPE_INT32, 1, nullptr, &dummy),
+//         HIPDNN_STATUS_NOT_SUPPORTED);
+// }
 
-TEST_F(Engine_descriptor_test, GetEngineDescriptorGraph)
-{
-    auto engine = get_engine_descriptor();
-    Scoped_descriptor graph;
-    Scoped_descriptor graph_2;
+// TEST_F(Engine_descriptor_test, GetEngineDescriptorGraph)
+// {
+//     auto engine = get_engine_descriptor();
+//     Scoped_descriptor graph;
+//     Scoped_descriptor graph_2;
 
-    make_engine_finalized();
+//     make_engine_finalized();
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        engine->get_attribute(
-            HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, nullptr, graph.get_ptr()),
-        HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         engine->get_attribute(
+//             HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, nullptr, graph.get_ptr()),
+//         HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                     2,
-                                                     nullptr,
-                                                     graph.get_ptr()),
-                               HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+//                                                      HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                      2,
+//                                                      nullptr,
+//                                                      graph.get_ptr()),
+//                                HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                     1,
-                                                     nullptr,
-                                                     nullptr),
-                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+//     ASSERT_THROW_HIPDNN_STATUS(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+//                                                      HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                      1,
+//                                                      nullptr,
+//                                                      nullptr),
+//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    ASSERT_NO_THROW(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-                                          HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                          1,
-                                          nullptr,
-                                          graph.get_ptr()));
-    ASSERT_EQ(graph.get()->private_descriptor, _mock_graph_wrapper->private_descriptor);
+//     ASSERT_NO_THROW(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+//                                           HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                           1,
+//                                           nullptr,
+//                                           graph.get_ptr()));
+//     ASSERT_EQ(graph.get()->private_descriptor, _mock_graph_wrapper->private_descriptor);
 
-    int64_t count;
-    ASSERT_NO_THROW(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-                                          HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                          1,
-                                          &count,
-                                          graph_2.get_ptr()));
-    ASSERT_EQ(count, 1);
-}
+//     int64_t count;
+//     ASSERT_NO_THROW(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+//                                           HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                           1,
+//                                           &count,
+//                                           graph_2.get_ptr()));
+//     ASSERT_EQ(count, 1);
+// }
 
-TEST_F(Engine_descriptor_test, GetEngineDescriptorGlobalId)
-{
-    auto engine = get_engine_descriptor();
-    int64_t gidx = -1;
+// TEST_F(Engine_descriptor_test, GetEngineDescriptorGlobalId)
+// {
+//     auto engine = get_engine_descriptor();
+//     int64_t gidx = -1;
 
-    make_engine_finalized();
+//     make_engine_finalized();
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        engine->get_attribute(
-            HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, &gidx),
-        HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         engine->get_attribute(
+//             HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, &gidx),
+//         HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        engine->get_attribute(
-            HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 2, nullptr, &gidx),
-        HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         engine->get_attribute(
+//             HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 2, nullptr, &gidx),
+//         HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        engine->get_attribute(
-            HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, nullptr),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         engine->get_attribute(
+//             HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, nullptr),
+//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    ASSERT_NO_THROW(engine->get_attribute(
-        HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, &gidx));
-    ASSERT_EQ(gidx, 0);
+//     ASSERT_NO_THROW(engine->get_attribute(
+//         HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, &gidx));
+//     ASSERT_EQ(gidx, 0);
 
-    int64_t count;
-    ASSERT_NO_THROW(engine->get_attribute(
-        HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &count, &gidx));
-    ASSERT_EQ(count, 1);
-}
+//     int64_t count;
+//     ASSERT_NO_THROW(engine->get_attribute(
+//         HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &count, &gidx));
+//     ASSERT_EQ(count, 1);
+// }
 
-TEST_F(Engine_descriptor_test, GetGraphThrowsIfNotFinalized)
-{
-    auto engine = get_engine_descriptor();
-    ASSERT_THROW_HIPDNN_STATUS(engine->get_graph(), HIPDNN_STATUS_INTERNAL_ERROR);
-}
+// TEST_F(Engine_descriptor_test, GetGraphThrowsIfNotFinalized)
+// {
+//     auto engine = get_engine_descriptor();
+//     ASSERT_THROW_HIPDNN_STATUS(engine->get_graph(), HIPDNN_STATUS_INTERNAL_ERROR);
+// }
 
-TEST_F(Engine_descriptor_test, GetGraphReturnsPointerIfFinalized)
-{
-    auto engine = get_engine_descriptor();
-    make_engine_finalized();
-    auto graph_ptr = engine->get_graph();
-    ASSERT_NE(graph_ptr, nullptr);
-    ASSERT_EQ(static_cast<const hipdnnPrivateBackendDescriptor*>(graph_ptr.get()),
-              static_cast<const hipdnnPrivateBackendDescriptor*>(get_mock_graph()));
-}
+// TEST_F(Engine_descriptor_test, GetGraphReturnsPointerIfFinalized)
+// {
+//     auto engine = get_engine_descriptor();
+//     make_engine_finalized();
+//     auto graph_ptr = engine->get_graph();
+//     ASSERT_NE(graph_ptr, nullptr);
+//     ASSERT_EQ(static_cast<const hipdnnBackendDescriptorImpl*>(graph_ptr.get()),
+//               static_cast<const hipdnnBackendDescriptorImpl*>(get_mock_graph()));
+// }
 
-TEST_F(Engine_descriptor_test, GetEngineIdThrowsIfNotFinalized)
-{
-    auto engine = get_engine_descriptor();
-    ASSERT_THROW_HIPDNN_STATUS(engine->get_engine_id(), HIPDNN_STATUS_INTERNAL_ERROR);
-}
+// TEST_F(Engine_descriptor_test, GetEngineIdThrowsIfNotFinalized)
+// {
+//     auto engine = get_engine_descriptor();
+//     ASSERT_THROW_HIPDNN_STATUS(engine->get_engine_id(), HIPDNN_STATUS_INTERNAL_ERROR);
+// }
 
-TEST_F(Engine_descriptor_test, GetEngineIdReturnsValueIfFinalized)
-{
-    auto engine = get_engine_descriptor();
-    make_engine_finalized();
-    auto engine_id = engine->get_engine_id();
-    ASSERT_EQ(engine_id, 0);
-}
+// TEST_F(Engine_descriptor_test, GetEngineIdReturnsValueIfFinalized)
+// {
+//     auto engine = get_engine_descriptor();
+//     make_engine_finalized();
+//     auto engine_id = engine->get_engine_id();
+//     ASSERT_EQ(engine_id, 0);
+// }

--- a/backend/tests/descriptors/test_engine_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_descriptor.cpp
@@ -15,7 +15,6 @@
 #include <memory>
 
 using namespace hipdnn_backend;
-using namespace test_descriptor_utils;
 
 using ::testing::Return;
 
@@ -29,17 +28,18 @@ public:
 
     Engine_descriptor* get_engine_descriptor() const
     {
-        return dynamic_cast<Engine_descriptor*>(_engine_wrapper->impl.get());
+        return _engine_wrapper->as_descriptor<Engine_descriptor>().get();
     }
 
     Mock_descriptor<Graph_descriptor>* get_mock_graph() const
     {
-        return unpack_mock_descriptor<Graph_descriptor>(_mock_graph_wrapper.get());
+        return _mock_graph_wrapper->as_descriptor<Mock_descriptor<Graph_descriptor>>().get();
     }
 
     Mock_descriptor<Graph_descriptor>* get_mock_graph_bad_type() const
     {
-        return unpack_mock_descriptor<Graph_descriptor>(_mock_graph_bad_type_wrapper.get());
+        return _mock_graph_bad_type_wrapper->as_descriptor<Mock_descriptor<Graph_descriptor>>()
+            .get();
     }
 
     void set_graph() const
@@ -68,11 +68,13 @@ public:
 protected:
     void SetUp() override
     {
-        _engine_wrapper = create_descriptor<Engine_descriptor>();
+        _engine_wrapper = test_descriptor_utils::create_descriptor<Engine_descriptor>();
         _mock_graph_wrapper
-            = make_mock_descriptor_wrapper<Graph_descriptor>();
-        _mock_graph_bad_type_wrapper = make_mock_descriptor_wrapper<Graph_descriptor>();
-        _mock_wrong_type_wrapper = make_mock_descriptor_wrapper<Engine_descriptor>();
+            = test_descriptor_utils::create_descriptor<Mock_descriptor<Graph_descriptor>>();
+        _mock_graph_bad_type_wrapper
+            = test_descriptor_utils::create_descriptor<Mock_descriptor<Graph_descriptor>>();
+        _mock_wrong_type_wrapper
+            = test_descriptor_utils::create_descriptor<Mock_descriptor<Engine_descriptor>>();
     }
 };
 
@@ -115,12 +117,12 @@ TEST_F(Engine_descriptor_test, SetEngineDescriptorGraph)
                                                      1,
                                                      &_mock_graph_bad_type_wrapper),
                                HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
-    
+
     ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                    1,
-                                                    &_mock_wrong_type_wrapper),
-                            HIPDNN_STATUS_BAD_PARAM);
+                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                     1,
+                                                     &_mock_wrong_type_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM);
 
     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(false));
     ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
@@ -241,7 +243,7 @@ TEST_F(Engine_descriptor_test, GetEngineDescriptorGraph)
                                           1,
                                           nullptr,
                                           graph.get_ptr()));
-    ASSERT_EQ(graph.get()->impl, _mock_graph_wrapper->impl);
+    ASSERT_EQ(*graph.get(), *(_mock_graph_wrapper.get()));
 
     int64_t count;
     ASSERT_NO_THROW(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,

--- a/backend/tests/descriptors/test_engine_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_descriptor.cpp
@@ -1,307 +1,315 @@
-// // Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// // SPDX-License-Identifier: MIT
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
-// #include "descriptors/engine_descriptor.hpp"
-// #include "descriptors/graph_descriptor.hpp"
-// #include "descriptors/scoped_descriptor.hpp"
-// #include "hipdnn_backend.h"
-// #include "hipdnn_exception.hpp"
-// #include "mocks/mock_descriptor.hpp"
-// #include "test_descriptor_utils.hpp"
-// #include "test_macros.hpp"
+#include "descriptors/engine_descriptor.hpp"
+#include "descriptors/graph_descriptor.hpp"
+#include "descriptors/scoped_descriptor.hpp"
+#include "hipdnn_backend.h"
+#include "hipdnn_exception.hpp"
+#include "mocks/mock_descriptor.hpp"
+#include "test_descriptor_utils.hpp"
+#include "test_macros.hpp"
 
-// #include <gtest/gtest.h>
+#include <gtest/gtest.h>
 
-// #include <memory>
+#include <memory>
 
-// using namespace hipdnn_backend;
-// using namespace test_descriptor_utils;
+using namespace hipdnn_backend;
+using namespace test_descriptor_utils;
 
-// using ::testing::Return;
+using ::testing::Return;
 
-// class Engine_descriptor_test : public ::testing::Test
-// {
-// public:
-//     std::unique_ptr<hipdnnBackendDescriptor> _engine_wrapper = nullptr;
-//     std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_wrapper = nullptr;
-//     std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_bad_type_wrapper = nullptr;
+class Engine_descriptor_test : public ::testing::Test
+{
+public:
+    std::unique_ptr<hipdnnBackendDescriptor> _engine_wrapper = nullptr;
+    std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_wrapper = nullptr;
+    std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_bad_type_wrapper = nullptr;
+    std::unique_ptr<hipdnnBackendDescriptor> _mock_wrong_type_wrapper = nullptr;
 
-//     Engine_descriptor* get_engine_descriptor() const
-//     {
-//         return dynamic_cast<Engine_descriptor*>(_engine_wrapper->private_descriptor.get());
-//     }
+    Engine_descriptor* get_engine_descriptor() const
+    {
+        return dynamic_cast<Engine_descriptor*>(_engine_wrapper->impl.get());
+    }
 
-//     Mock_descriptor* get_mock_graph() const
-//     {
-//         return unpack_mock_descriptor(_mock_graph_wrapper.get());
-//     }
+    Mock_descriptor<Graph_descriptor>* get_mock_graph() const
+    {
+        return unpack_mock_descriptor<Graph_descriptor>(_mock_graph_wrapper.get());
+    }
 
-//     Mock_descriptor* get_mock_graph_bad_type() const
-//     {
-//         return unpack_mock_descriptor(_mock_graph_bad_type_wrapper.get());
-//     }
+    Mock_descriptor<Graph_descriptor>* get_mock_graph_bad_type() const
+    {
+        return unpack_mock_descriptor<Graph_descriptor>(_mock_graph_bad_type_wrapper.get());
+    }
 
-//     void set_graph() const
-//     {
-//         EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
-//         ASSERT_NO_THROW(get_engine_descriptor()->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-//                                                                HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                                1,
-//                                                                &_mock_graph_wrapper));
-//     }
+    void set_graph() const
+    {
+        EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
+        ASSERT_NO_THROW(get_engine_descriptor()->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+                                                               HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                               1,
+                                                               &_mock_graph_wrapper));
+    }
 
-//     void set_global_index() const
-//     {
-//         int64_t gidx = 0;
-//         ASSERT_NO_THROW(get_engine_descriptor()->set_attribute(
-//             HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &gidx));
-//     }
+    void set_global_index() const
+    {
+        int64_t gidx = 0;
+        ASSERT_NO_THROW(get_engine_descriptor()->set_attribute(
+            HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &gidx));
+    }
 
-//     void make_engine_finalized() const
-//     {
-//         set_graph();
-//         set_global_index();
-//         ASSERT_NO_THROW(get_engine_descriptor()->finalize());
-//     }
+    void make_engine_finalized() const
+    {
+        set_graph();
+        set_global_index();
+        ASSERT_NO_THROW(get_engine_descriptor()->finalize());
+    }
 
-// protected:
-//     void SetUp() override
-//     {
-//         _engine_wrapper = create_descriptor<Engine_descriptor>();
-//         _mock_graph_wrapper
-//             = make_mock_descriptor_wrapper(HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR);
-//         _mock_graph_bad_type_wrapper = make_mock_descriptor_wrapper();
-//     }
-// };
+protected:
+    void SetUp() override
+    {
+        _engine_wrapper = create_descriptor<Engine_descriptor>();
+        _mock_graph_wrapper
+            = make_mock_descriptor_wrapper<Graph_descriptor>();
+        _mock_graph_bad_type_wrapper = make_mock_descriptor_wrapper<Graph_descriptor>();
+        _mock_wrong_type_wrapper = make_mock_descriptor_wrapper<Engine_descriptor>();
+    }
+};
 
-// TEST_F(Engine_descriptor_test, CreateEngineDescriptor)
-// {
-//     auto engine = get_engine_descriptor();
-//     ASSERT_NE(engine, nullptr);
-//     ASSERT_FALSE(engine->is_finalized());
-//     ASSERT_EQ(engine->type, HIPDNN_BACKEND_ENGINE_DESCRIPTOR);
-// }
+TEST_F(Engine_descriptor_test, CreateEngineDescriptor)
+{
+    auto engine = get_engine_descriptor();
+    ASSERT_NE(engine, nullptr);
+    ASSERT_FALSE(engine->is_finalized());
+    ASSERT_EQ(engine->get_type(), HIPDNN_BACKEND_ENGINE_DESCRIPTOR);
+}
 
-// TEST_F(Engine_descriptor_test, SetEngineDescriptorGraph)
-// {
-//     auto engine = get_engine_descriptor();
+TEST_F(Engine_descriptor_test, SetEngineDescriptorGraph)
+{
+    auto engine = get_engine_descriptor();
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         engine->set_attribute(
-//             HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, &_mock_graph_wrapper),
-//         HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(
+        engine->set_attribute(
+            HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, &_mock_graph_wrapper),
+        HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-//                                                      HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                      2,
-//                                                      &_mock_graph_wrapper),
-//                                HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                     2,
+                                                     &_mock_graph_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         engine->set_attribute(
-//             HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr),
-//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    ASSERT_THROW_HIPDNN_STATUS(
+        engine->set_attribute(
+            HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-//     hipdnnBackendDescriptor_t graph = nullptr;
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         engine->set_attribute(
-//             HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &graph),
-//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    hipdnnBackendDescriptor_t graph = nullptr;
+    ASSERT_THROW_HIPDNN_STATUS(
+        engine->set_attribute(
+            HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &graph),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-//     ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-//                                                      HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                      1,
-//                                                      &_mock_graph_bad_type_wrapper),
-//                                HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                     1,
+                                                     &_mock_graph_bad_type_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+    
+    ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                    1,
+                                                    &_mock_wrong_type_wrapper),
+                            HIPDNN_STATUS_BAD_PARAM);
 
-//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(false));
-//     ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-//                                                      HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                      1,
-//                                                      &_mock_graph_wrapper),
-//                                HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(false));
+    ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                     1,
+                                                     &_mock_graph_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
 
-//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
-//     ASSERT_NO_THROW(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-//                                           HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                           1,
-//                                           &_mock_graph_wrapper));
-// }
+    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
+    ASSERT_NO_THROW(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+                                          HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                          1,
+                                          &_mock_graph_wrapper));
+}
 
-// TEST_F(Engine_descriptor_test, SetEngineDescriptorGlobalId)
-// {
-//     auto engine = get_engine_descriptor();
-//     int64_t gidx = 0;
+TEST_F(Engine_descriptor_test, SetEngineDescriptorGlobalId)
+{
+    auto engine = get_engine_descriptor();
+    int64_t gidx = 0;
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         engine->set_attribute(
-//             HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &gidx),
-//         HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(
+        engine->set_attribute(
+            HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &gidx),
+        HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         engine->set_attribute(HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 2, &gidx),
-//         HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(
+        engine->set_attribute(HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 2, &gidx),
+        HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         engine->set_attribute(HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr),
-//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    ASSERT_THROW_HIPDNN_STATUS(
+        engine->set_attribute(HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-//     ASSERT_NO_THROW(
-//         engine->set_attribute(HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &gidx));
-// }
+    ASSERT_NO_THROW(
+        engine->set_attribute(HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &gidx));
+}
 
-// TEST_F(Engine_descriptor_test, SetAttrOnFinalizedEngineDescriptor)
-// {
-//     auto engine = get_engine_descriptor();
-//     make_engine_finalized();
+TEST_F(Engine_descriptor_test, SetAttrOnFinalizedEngineDescriptor)
+{
+    auto engine = get_engine_descriptor();
+    make_engine_finalized();
 
-//     ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-//                                                      HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                      1,
-//                                                      &_mock_graph_wrapper),
-//                                HIPDNN_STATUS_NOT_INITIALIZED);
-// }
+    ASSERT_THROW_HIPDNN_STATUS(engine->set_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                     1,
+                                                     &_mock_graph_wrapper),
+                               HIPDNN_STATUS_NOT_INITIALIZED);
+}
 
-// TEST_F(Engine_descriptor_test, FinalizeEngineDescriptor)
-// {
-//     auto engine = get_engine_descriptor();
-//     ASSERT_THROW_HIPDNN_STATUS(engine->finalize(), HIPDNN_STATUS_BAD_PARAM);
+TEST_F(Engine_descriptor_test, FinalizeEngineDescriptor)
+{
+    auto engine = get_engine_descriptor();
+    ASSERT_THROW_HIPDNN_STATUS(engine->finalize(), HIPDNN_STATUS_BAD_PARAM);
 
-//     set_graph();
-//     set_global_index();
+    set_graph();
+    set_global_index();
 
-//     ASSERT_NO_THROW(engine->finalize());
+    ASSERT_NO_THROW(engine->finalize());
 
-//     ASSERT_THROW_HIPDNN_STATUS(engine->finalize(), HIPDNN_STATUS_BAD_PARAM);
-// }
+    ASSERT_THROW_HIPDNN_STATUS(engine->finalize(), HIPDNN_STATUS_BAD_PARAM);
+}
 
-// TEST_F(Engine_descriptor_test, GetAttrOnUnfinalizedEngineDescriptor)
-// {
-//     auto engine = get_engine_descriptor();
-//     hipdnnBackendDescriptor_t dummy_graph = nullptr;
+TEST_F(Engine_descriptor_test, GetAttrOnUnfinalizedEngineDescriptor)
+{
+    auto engine = get_engine_descriptor();
+    hipdnnBackendDescriptor_t dummy_graph = nullptr;
 
-//     ASSERT_THROW_HIPDNN_STATUS(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-//                                                      HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                      1,
-//                                                      nullptr,
-//                                                      &dummy_graph),
-//                                HIPDNN_STATUS_NOT_INITIALIZED);
-// }
+    ASSERT_THROW_HIPDNN_STATUS(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                     1,
+                                                     nullptr,
+                                                     &dummy_graph),
+                               HIPDNN_STATUS_NOT_INITIALIZED);
+}
 
-// TEST_F(Engine_descriptor_test, GetEngineDescriptorUnsupportedAttr)
-// {
-//     auto engine = get_engine_descriptor();
-//     int32_t dummy;
+TEST_F(Engine_descriptor_test, GetEngineDescriptorUnsupportedAttr)
+{
+    auto engine = get_engine_descriptor();
+    int32_t dummy;
 
-//     make_engine_finalized();
+    make_engine_finalized();
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         engine->get_attribute(
-//             HIPDNN_ATTR_ENGINE_SM_COUNT_TARGET, HIPDNN_TYPE_INT32, 1, nullptr, &dummy),
-//         HIPDNN_STATUS_NOT_SUPPORTED);
-// }
+    ASSERT_THROW_HIPDNN_STATUS(
+        engine->get_attribute(
+            HIPDNN_ATTR_ENGINE_SM_COUNT_TARGET, HIPDNN_TYPE_INT32, 1, nullptr, &dummy),
+        HIPDNN_STATUS_NOT_SUPPORTED);
+}
 
-// TEST_F(Engine_descriptor_test, GetEngineDescriptorGraph)
-// {
-//     auto engine = get_engine_descriptor();
-//     Scoped_descriptor graph;
-//     Scoped_descriptor graph_2;
+TEST_F(Engine_descriptor_test, GetEngineDescriptorGraph)
+{
+    auto engine = get_engine_descriptor();
+    Scoped_descriptor graph;
+    Scoped_descriptor graph_2;
 
-//     make_engine_finalized();
+    make_engine_finalized();
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         engine->get_attribute(
-//             HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, nullptr, graph.get_ptr()),
-//         HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(
+        engine->get_attribute(
+            HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, nullptr, graph.get_ptr()),
+        HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-//                                                      HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                      2,
-//                                                      nullptr,
-//                                                      graph.get_ptr()),
-//                                HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                     2,
+                                                     nullptr,
+                                                     graph.get_ptr()),
+                               HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-//                                                      HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                      1,
-//                                                      nullptr,
-//                                                      nullptr),
-//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    ASSERT_THROW_HIPDNN_STATUS(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+                                                     HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                     1,
+                                                     nullptr,
+                                                     nullptr),
+                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-//     ASSERT_NO_THROW(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-//                                           HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                           1,
-//                                           nullptr,
-//                                           graph.get_ptr()));
-//     ASSERT_EQ(graph.get()->private_descriptor, _mock_graph_wrapper->private_descriptor);
+    ASSERT_NO_THROW(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+                                          HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                          1,
+                                          nullptr,
+                                          graph.get_ptr()));
+    ASSERT_EQ(graph.get()->impl, _mock_graph_wrapper->impl);
 
-//     int64_t count;
-//     ASSERT_NO_THROW(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
-//                                           HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                           1,
-//                                           &count,
-//                                           graph_2.get_ptr()));
-//     ASSERT_EQ(count, 1);
-// }
+    int64_t count;
+    ASSERT_NO_THROW(engine->get_attribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+                                          HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                          1,
+                                          &count,
+                                          graph_2.get_ptr()));
+    ASSERT_EQ(count, 1);
+}
 
-// TEST_F(Engine_descriptor_test, GetEngineDescriptorGlobalId)
-// {
-//     auto engine = get_engine_descriptor();
-//     int64_t gidx = -1;
+TEST_F(Engine_descriptor_test, GetEngineDescriptorGlobalId)
+{
+    auto engine = get_engine_descriptor();
+    int64_t gidx = -1;
 
-//     make_engine_finalized();
+    make_engine_finalized();
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         engine->get_attribute(
-//             HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, &gidx),
-//         HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(
+        engine->get_attribute(
+            HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, &gidx),
+        HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         engine->get_attribute(
-//             HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 2, nullptr, &gidx),
-//         HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(
+        engine->get_attribute(
+            HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 2, nullptr, &gidx),
+        HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         engine->get_attribute(
-//             HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, nullptr),
-//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    ASSERT_THROW_HIPDNN_STATUS(
+        engine->get_attribute(
+            HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, nullptr),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-//     ASSERT_NO_THROW(engine->get_attribute(
-//         HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, &gidx));
-//     ASSERT_EQ(gidx, 0);
+    ASSERT_NO_THROW(engine->get_attribute(
+        HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, &gidx));
+    ASSERT_EQ(gidx, 0);
 
-//     int64_t count;
-//     ASSERT_NO_THROW(engine->get_attribute(
-//         HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &count, &gidx));
-//     ASSERT_EQ(count, 1);
-// }
+    int64_t count;
+    ASSERT_NO_THROW(engine->get_attribute(
+        HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &count, &gidx));
+    ASSERT_EQ(count, 1);
+}
 
-// TEST_F(Engine_descriptor_test, GetGraphThrowsIfNotFinalized)
-// {
-//     auto engine = get_engine_descriptor();
-//     ASSERT_THROW_HIPDNN_STATUS(engine->get_graph(), HIPDNN_STATUS_INTERNAL_ERROR);
-// }
+TEST_F(Engine_descriptor_test, GetGraphThrowsIfNotFinalized)
+{
+    auto engine = get_engine_descriptor();
+    ASSERT_THROW_HIPDNN_STATUS(engine->get_graph(), HIPDNN_STATUS_INTERNAL_ERROR);
+}
 
-// TEST_F(Engine_descriptor_test, GetGraphReturnsPointerIfFinalized)
-// {
-//     auto engine = get_engine_descriptor();
-//     make_engine_finalized();
-//     auto graph_ptr = engine->get_graph();
-//     ASSERT_NE(graph_ptr, nullptr);
-//     ASSERT_EQ(static_cast<const hipdnnBackendDescriptorImpl*>(graph_ptr.get()),
-//               static_cast<const hipdnnBackendDescriptorImpl*>(get_mock_graph()));
-// }
+TEST_F(Engine_descriptor_test, GetGraphReturnsPointerIfFinalized)
+{
+    auto engine = get_engine_descriptor();
+    make_engine_finalized();
+    auto graph_ptr = engine->get_graph();
+    ASSERT_NE(graph_ptr, nullptr);
+    ASSERT_EQ(static_cast<const Backend_descriptor_interface*>(graph_ptr.get()),
+              static_cast<const Backend_descriptor_interface*>(get_mock_graph()));
+}
 
-// TEST_F(Engine_descriptor_test, GetEngineIdThrowsIfNotFinalized)
-// {
-//     auto engine = get_engine_descriptor();
-//     ASSERT_THROW_HIPDNN_STATUS(engine->get_engine_id(), HIPDNN_STATUS_INTERNAL_ERROR);
-// }
+TEST_F(Engine_descriptor_test, GetEngineIdThrowsIfNotFinalized)
+{
+    auto engine = get_engine_descriptor();
+    ASSERT_THROW_HIPDNN_STATUS(engine->get_engine_id(), HIPDNN_STATUS_INTERNAL_ERROR);
+}
 
-// TEST_F(Engine_descriptor_test, GetEngineIdReturnsValueIfFinalized)
-// {
-//     auto engine = get_engine_descriptor();
-//     make_engine_finalized();
-//     auto engine_id = engine->get_engine_id();
-//     ASSERT_EQ(engine_id, 0);
-// }
+TEST_F(Engine_descriptor_test, GetEngineIdReturnsValueIfFinalized)
+{
+    auto engine = get_engine_descriptor();
+    make_engine_finalized();
+    auto engine_id = engine->get_engine_id();
+    ASSERT_EQ(engine_id, 0);
+}

--- a/backend/tests/descriptors/test_engine_heuristic_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_heuristic_descriptor.cpp
@@ -1,496 +1,496 @@
-// Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier: MIT
-
-#include "descriptors/engine_config_descriptor.hpp"
-#include "descriptors/engine_descriptor.hpp"
-#include "descriptors/engine_heuristic_descriptor.hpp"
-#include "descriptors/graph_descriptor.hpp"
-#include "descriptors/scoped_descriptor.hpp"
-#include "hipdnn_backend.h"
-#include "hipdnn_exception.hpp"
-#include "mocks/mock_descriptor.hpp"
-#include "test_descriptor_utils.hpp"
-#include "test_macros.hpp"
-
-#include <gtest/gtest.h>
-
-#include <memory>
-#include <vector>
-
-using namespace hipdnn_backend;
-using namespace test_descriptor_utils;
-
-using ::testing::Return;
-
-class Engine_heuristic_descriptor_test : public ::testing::Test
-{
-public:
-    std::unique_ptr<hipdnnBackendDescriptor> _engine_heuristic_wrapper = nullptr;
-    std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_wrapper = nullptr;
-    std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_bad_type_wrapper = nullptr;
-
-    Engine_heuristic_descriptor* get_engine_heuristic_descriptor() const
-    {
-        return dynamic_cast<Engine_heuristic_descriptor*>(
-            _engine_heuristic_wrapper->private_descriptor.get());
-    }
-
-    Mock_descriptor* get_mock_graph() const
-    {
-        return unpack_mock_descriptor(_mock_graph_wrapper.get());
-    }
-
-    Mock_descriptor* get_mock_graph_bad_type() const
-    {
-        return unpack_mock_descriptor(_mock_graph_bad_type_wrapper.get());
-    }
-
-    void set_graph() const
-    {
-        EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
-        ASSERT_NO_THROW(
-            get_engine_heuristic_descriptor()->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-                                                             HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                             1,
-                                                             &_mock_graph_wrapper));
-    }
-
-    void set_heuristic_mode() const
-    {
-        hipdnnBackendHeurMode_t mode = HIPDNN_HEUR_MODE_FALLBACK;
-        ASSERT_NO_THROW(get_engine_heuristic_descriptor()->set_attribute(
-            HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &mode));
-    }
-
-    void set_engine_ids() const
-    {
-        std::vector<int64_t> engine_ids = {0, 1, 2};
-        ASSERT_NO_THROW(get_engine_heuristic_descriptor()->set_engine_ids(engine_ids));
-    }
-
-    void make_engine_heuristic_finalized() const
-    {
-        set_graph();
-        set_heuristic_mode();
-        ASSERT_NO_THROW(get_engine_heuristic_descriptor()->finalize());
-        set_engine_ids();
-    }
-
-protected:
-    void SetUp() override
-    {
-        _engine_heuristic_wrapper = create_descriptor<Engine_heuristic_descriptor>();
-        _mock_graph_wrapper
-            = make_mock_descriptor_wrapper(HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR);
-        _mock_graph_bad_type_wrapper = make_mock_descriptor_wrapper();
-    }
-};
-
-TEST_F(Engine_heuristic_descriptor_test, CreateEngineHeuristicDescriptor)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    ASSERT_NE(heur, nullptr);
-    ASSERT_FALSE(heur->is_finalized());
-    ASSERT_EQ(heur->type, HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR);
-}
-
-TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorGraph)
-{
-    auto heur = get_engine_heuristic_descriptor();
-
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->set_attribute(
-            HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, &_mock_graph_wrapper),
-        HIPDNN_STATUS_BAD_PARAM);
-
-    ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   2,
-                                                   &_mock_graph_wrapper),
-                               HIPDNN_STATUS_BAD_PARAM);
-
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->set_attribute(
-            HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-    hipdnnBackendDescriptor_t graph = nullptr;
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->set_attribute(
-            HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &graph),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-    ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   1,
-                                                   &_mock_graph_bad_type_wrapper),
-                               HIPDNN_STATUS_BAD_PARAM);
-
-    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(false));
-    ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   1,
-                                                   &_mock_graph_wrapper),
-                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
-
-    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
-    ASSERT_NO_THROW(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                        1,
-                                        &_mock_graph_wrapper));
-}
-
-TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorHeurMode)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    hipdnnBackendHeurMode_t mode = HIPDNN_HEUR_MODE_FALLBACK;
-    auto unsupported_mode = static_cast<hipdnnBackendHeurMode_t>(999);
-
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &mode),
-        HIPDNN_STATUS_BAD_PARAM);
-
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 2, &mode),
-        HIPDNN_STATUS_BAD_PARAM);
-
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->set_attribute(
-            HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &unsupported_mode),
-        HIPDNN_STATUS_NOT_SUPPORTED);
-
-    ASSERT_NO_THROW(
-        heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &mode));
-}
-
-TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorUnsupportedAttr)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    int32_t dummy = 0;
-
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_INT32, 1, &dummy),
-        HIPDNN_STATUS_NOT_SUPPORTED);
-}
-
-TEST_F(Engine_heuristic_descriptor_test, SetEngineIds)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    std::vector<int64_t> engine_ids = {0, 1, 2};
-
-    ASSERT_THROW_HIPDNN_STATUS(heur->set_engine_ids(engine_ids), HIPDNN_STATUS_INTERNAL_ERROR);
-
-    make_engine_heuristic_finalized();
-
-    ASSERT_NO_THROW(heur->set_engine_ids(engine_ids));
-}
-
-TEST_F(Engine_heuristic_descriptor_test, SetAttrOnFinalizedEngineHeuristicDescriptor)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    make_engine_heuristic_finalized();
-
-    ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   1,
-                                                   &_mock_graph_wrapper),
-                               HIPDNN_STATUS_NOT_INITIALIZED);
-}
-
-TEST_F(Engine_heuristic_descriptor_test, FinalizeEngineHeuristicDescriptor)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
-
-    set_graph();
-    ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
-
-    set_heuristic_mode();
-    ASSERT_NO_THROW(heur->finalize());
-
-    set_engine_ids();
-
-    ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
-}
-
-TEST_F(Engine_heuristic_descriptor_test, FinalizeEngineHeuristicDescriptorReverseOrder)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
-
-    set_heuristic_mode();
-    ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
-
-    set_graph();
-    ASSERT_NO_THROW(heur->finalize());
-
-    set_engine_ids();
-
-    ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
-}
-
-TEST_F(Engine_heuristic_descriptor_test, GetAttrOnUnfinalizedEngineHeuristicDescriptor)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    hipdnnBackendDescriptor_t dummy_graph = nullptr;
-
-    ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   1,
-                                                   nullptr,
-                                                   &dummy_graph),
-                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
-}
-
-TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorUnsupportedAttr)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    hipdnnBackendHeurMode_t dummy;
-
-    make_engine_heuristic_finalized();
-
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->get_attribute(
-            HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr, &dummy),
-        HIPDNN_STATUS_NOT_SUPPORTED);
-}
-
-TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorGraph)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    Scoped_descriptor graph;
-    Scoped_descriptor graph2;
-
-    make_engine_heuristic_finalized();
-
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->get_attribute(
-            HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, nullptr, graph.get_ptr()),
-        HIPDNN_STATUS_BAD_PARAM);
-
-    ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   2,
-                                                   nullptr,
-                                                   graph.get_ptr()),
-                               HIPDNN_STATUS_BAD_PARAM);
-
-    ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   1,
-                                                   nullptr,
-                                                   nullptr),
-                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-    ASSERT_NO_THROW(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                        1,
-                                        nullptr,
-                                        graph.get_ptr()));
-    ASSERT_EQ(graph.get()->private_descriptor, _mock_graph_wrapper->private_descriptor);
-
-    int64_t count;
-    ASSERT_NO_THROW(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                        1,
-                                        &count,
-                                        graph2.get_ptr()));
-    ASSERT_EQ(count, 1);
-}
-
-TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorEngineConfigs)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    make_engine_heuristic_finalized();
-    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
-
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_INT64, 0, nullptr, nullptr),
-        HIPDNN_STATUS_BAD_PARAM);
-
-    int64_t count = 0;
-    ASSERT_NO_THROW(heur->get_attribute(
-        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 0, &count, nullptr));
-    ASSERT_EQ(count, 3);
-
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->get_attribute(
-            HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, nullptr),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-    std::vector<hipdnnBackendDescriptor_t> configs(3);
-    for(size_t i = 0; i < 3; ++i)
-    {
-        configs[i] = create_descriptor_ptr<Engine_config_descriptor>();
-    }
-
-    ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   3,
-                                                   nullptr,
-                                                   configs.data()),
-                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-    count = 0;
-    ASSERT_NO_THROW(heur->get_attribute(
-        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 3, &count, configs.data()));
-    ASSERT_EQ(count, 3);
-
-    for(auto config : configs)
-    {
-        delete config;
-    }
-
-    configs.clear();
-
-    Scoped_descriptor single_config(create_descriptor_ptr<Engine_config_descriptor>());
-
-    count = 0;
-    ASSERT_NO_THROW(heur->get_attribute(
-        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &count, &single_config));
-    ASSERT_EQ(count, 1);
-}
-
-TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsWithNullConfig)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    make_engine_heuristic_finalized();
-
-    std::vector<hipdnnBackendDescriptor_t> configs(3);
-    configs[0] = create_descriptor_ptr<Engine_config_descriptor>();
-    configs[1] = nullptr;
-    configs[2] = create_descriptor_ptr<Engine_config_descriptor>();
-
-    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
-    int64_t count = 0;
-    ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   3,
-                                                   &count,
-                                                   configs.data()),
-                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-    for(auto config : configs)
-    {
-        delete config;
-    }
-}
-
-TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsWithNoEngineIds)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    set_graph();
-    set_heuristic_mode();
-
-    ASSERT_NO_THROW(heur->finalize());
-
-    std::vector<int64_t> engine_ids = {};
-    ASSERT_NO_THROW(heur->set_engine_ids(engine_ids));
-
-    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
-
-    std::vector<hipdnnBackendDescriptor_t> configs(3);
-    for(size_t i = 0; i < 3; ++i)
-    {
-        configs[i] = create_descriptor_ptr<Engine_config_descriptor>();
-    }
-
-    int64_t count = 0;
-    ASSERT_NO_THROW(heur->get_attribute(
-        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 3, &count, configs.data()));
-    ASSERT_EQ(count, 0);
-
-    for(auto config : configs)
-    {
-        delete config;
-    }
-}
-
-TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsRequestMoreThanAvailable)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    make_engine_heuristic_finalized();
-
-    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
-
-    std::vector<hipdnnBackendDescriptor_t> configs(5);
-    for(size_t i = 0; i < 3; ++i)
-    {
-        configs[i] = create_descriptor_ptr<Engine_config_descriptor>();
-    }
-
-    int64_t count = 0;
-    ASSERT_NO_THROW(heur->get_attribute(
-        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 5, &count, configs.data()));
-    ASSERT_EQ(count, 3);
-
-    for(auto config : configs)
-    {
-        delete config;
-    }
-}
-
-TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsCountOnly)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    make_engine_heuristic_finalized();
-
-    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
-
-    int64_t count = 0;
-    ASSERT_NO_THROW(heur->get_attribute(
-        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 0, &count, nullptr));
-    ASSERT_EQ(count, 3);
-}
-
-TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorHeurMode)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    hipdnnBackendHeurMode_t mode = HIPDNN_HEUR_MODE_FALLBACK;
-
-    make_engine_heuristic_finalized();
-
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->get_attribute(
-            HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, &mode),
-        HIPDNN_STATUS_BAD_PARAM);
-
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 2, nullptr, &mode),
-        HIPDNN_STATUS_BAD_PARAM);
-
-    ASSERT_THROW_HIPDNN_STATUS(
-        heur->get_attribute(
-            HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr, nullptr),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-    ASSERT_NO_THROW(
-        heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr, &mode));
-    ASSERT_EQ(mode, HIPDNN_HEUR_MODE_FALLBACK);
-
-    int64_t count = 0;
-    ASSERT_NO_THROW(
-        heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &count, &mode));
-    ASSERT_EQ(count, 1);
-    ASSERT_EQ(mode, HIPDNN_HEUR_MODE_FALLBACK);
-}
-
-TEST_F(Engine_heuristic_descriptor_test, GetGraphThrowsIfNotFinalized)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    ASSERT_THROW_HIPDNN_STATUS(heur->get_graph(), HIPDNN_STATUS_INTERNAL_ERROR);
-}
-
-TEST_F(Engine_heuristic_descriptor_test, GetGraphReturnsPointerIfFinalized)
-{
-    auto heur = get_engine_heuristic_descriptor();
-    make_engine_heuristic_finalized();
-    auto graph_ptr = heur->get_graph();
-    ASSERT_NE(graph_ptr, nullptr);
-    ASSERT_EQ(static_cast<const hipdnnPrivateBackendDescriptor*>(graph_ptr.get()),
-              static_cast<const hipdnnPrivateBackendDescriptor*>(get_mock_graph()));
-}
+// // Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// // SPDX-License-Identifier: MIT
+
+// #include "descriptors/engine_config_descriptor.hpp"
+// #include "descriptors/engine_descriptor.hpp"
+// #include "descriptors/engine_heuristic_descriptor.hpp"
+// #include "descriptors/graph_descriptor.hpp"
+// #include "descriptors/scoped_descriptor.hpp"
+// #include "hipdnn_backend.h"
+// #include "hipdnn_exception.hpp"
+// #include "mocks/mock_descriptor.hpp"
+// #include "test_descriptor_utils.hpp"
+// #include "test_macros.hpp"
+
+// #include <gtest/gtest.h>
+
+// #include <memory>
+// #include <vector>
+
+// using namespace hipdnn_backend;
+// using namespace test_descriptor_utils;
+
+// using ::testing::Return;
+
+// class Engine_heuristic_descriptor_test : public ::testing::Test
+// {
+// public:
+//     std::unique_ptr<hipdnnBackendDescriptor> _engine_heuristic_wrapper = nullptr;
+//     std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_wrapper = nullptr;
+//     std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_bad_type_wrapper = nullptr;
+
+//     Engine_heuristic_descriptor* get_engine_heuristic_descriptor() const
+//     {
+//         return dynamic_cast<Engine_heuristic_descriptor*>(
+//             _engine_heuristic_wrapper->private_descriptor.get());
+//     }
+
+//     Mock_descriptor* get_mock_graph() const
+//     {
+//         return unpack_mock_descriptor(_mock_graph_wrapper.get());
+//     }
+
+//     Mock_descriptor* get_mock_graph_bad_type() const
+//     {
+//         return unpack_mock_descriptor(_mock_graph_bad_type_wrapper.get());
+//     }
+
+//     void set_graph() const
+//     {
+//         EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
+//         ASSERT_NO_THROW(
+//             get_engine_heuristic_descriptor()->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+//                                                              HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                              1,
+//                                                              &_mock_graph_wrapper));
+//     }
+
+//     void set_heuristic_mode() const
+//     {
+//         hipdnnBackendHeurMode_t mode = HIPDNN_HEUR_MODE_FALLBACK;
+//         ASSERT_NO_THROW(get_engine_heuristic_descriptor()->set_attribute(
+//             HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &mode));
+//     }
+
+//     void set_engine_ids() const
+//     {
+//         std::vector<int64_t> engine_ids = {0, 1, 2};
+//         ASSERT_NO_THROW(get_engine_heuristic_descriptor()->set_engine_ids(engine_ids));
+//     }
+
+//     void make_engine_heuristic_finalized() const
+//     {
+//         set_graph();
+//         set_heuristic_mode();
+//         ASSERT_NO_THROW(get_engine_heuristic_descriptor()->finalize());
+//         set_engine_ids();
+//     }
+
+// protected:
+//     void SetUp() override
+//     {
+//         _engine_heuristic_wrapper = create_descriptor<Engine_heuristic_descriptor>();
+//         _mock_graph_wrapper
+//             = make_mock_descriptor_wrapper(HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR);
+//         _mock_graph_bad_type_wrapper = make_mock_descriptor_wrapper();
+//     }
+// };
+
+// TEST_F(Engine_heuristic_descriptor_test, CreateEngineHeuristicDescriptor)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     ASSERT_NE(heur, nullptr);
+//     ASSERT_FALSE(heur->is_finalized());
+//     ASSERT_EQ(heur->type, HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR);
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorGraph)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->set_attribute(
+//             HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, &_mock_graph_wrapper),
+//         HIPDNN_STATUS_BAD_PARAM);
+
+//     ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                    2,
+//                                                    &_mock_graph_wrapper),
+//                                HIPDNN_STATUS_BAD_PARAM);
+
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->set_attribute(
+//             HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr),
+//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+//     hipdnnBackendDescriptor_t graph = nullptr;
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->set_attribute(
+//             HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &graph),
+//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+//     ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                    1,
+//                                                    &_mock_graph_bad_type_wrapper),
+//                                HIPDNN_STATUS_BAD_PARAM);
+
+//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(false));
+//     ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                    1,
+//                                                    &_mock_graph_wrapper),
+//                                HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+
+//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
+//     ASSERT_NO_THROW(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+//                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                         1,
+//                                         &_mock_graph_wrapper));
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorHeurMode)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     hipdnnBackendHeurMode_t mode = HIPDNN_HEUR_MODE_FALLBACK;
+//     auto unsupported_mode = static_cast<hipdnnBackendHeurMode_t>(999);
+
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &mode),
+//         HIPDNN_STATUS_BAD_PARAM);
+
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 2, &mode),
+//         HIPDNN_STATUS_BAD_PARAM);
+
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr),
+//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->set_attribute(
+//             HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &unsupported_mode),
+//         HIPDNN_STATUS_NOT_SUPPORTED);
+
+//     ASSERT_NO_THROW(
+//         heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &mode));
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorUnsupportedAttr)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     int32_t dummy = 0;
+
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_INT32, 1, &dummy),
+//         HIPDNN_STATUS_NOT_SUPPORTED);
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, SetEngineIds)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     std::vector<int64_t> engine_ids = {0, 1, 2};
+
+//     ASSERT_THROW_HIPDNN_STATUS(heur->set_engine_ids(engine_ids), HIPDNN_STATUS_INTERNAL_ERROR);
+
+//     make_engine_heuristic_finalized();
+
+//     ASSERT_NO_THROW(heur->set_engine_ids(engine_ids));
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, SetAttrOnFinalizedEngineHeuristicDescriptor)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     make_engine_heuristic_finalized();
+
+//     ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                    1,
+//                                                    &_mock_graph_wrapper),
+//                                HIPDNN_STATUS_NOT_INITIALIZED);
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, FinalizeEngineHeuristicDescriptor)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
+
+//     set_graph();
+//     ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
+
+//     set_heuristic_mode();
+//     ASSERT_NO_THROW(heur->finalize());
+
+//     set_engine_ids();
+
+//     ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, FinalizeEngineHeuristicDescriptorReverseOrder)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
+
+//     set_heuristic_mode();
+//     ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
+
+//     set_graph();
+//     ASSERT_NO_THROW(heur->finalize());
+
+//     set_engine_ids();
+
+//     ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, GetAttrOnUnfinalizedEngineHeuristicDescriptor)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     hipdnnBackendDescriptor_t dummy_graph = nullptr;
+
+//     ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                    1,
+//                                                    nullptr,
+//                                                    &dummy_graph),
+//                                HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorUnsupportedAttr)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     hipdnnBackendHeurMode_t dummy;
+
+//     make_engine_heuristic_finalized();
+
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->get_attribute(
+//             HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr, &dummy),
+//         HIPDNN_STATUS_NOT_SUPPORTED);
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorGraph)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     Scoped_descriptor graph;
+//     Scoped_descriptor graph2;
+
+//     make_engine_heuristic_finalized();
+
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->get_attribute(
+//             HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, nullptr, graph.get_ptr()),
+//         HIPDNN_STATUS_BAD_PARAM);
+
+//     ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                    2,
+//                                                    nullptr,
+//                                                    graph.get_ptr()),
+//                                HIPDNN_STATUS_BAD_PARAM);
+
+//     ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                    1,
+//                                                    nullptr,
+//                                                    nullptr),
+//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+//     ASSERT_NO_THROW(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+//                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                         1,
+//                                         nullptr,
+//                                         graph.get_ptr()));
+//     ASSERT_EQ(graph.get()->private_descriptor, _mock_graph_wrapper->private_descriptor);
+
+//     int64_t count;
+//     ASSERT_NO_THROW(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+//                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                         1,
+//                                         &count,
+//                                         graph2.get_ptr()));
+//     ASSERT_EQ(count, 1);
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorEngineConfigs)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     make_engine_heuristic_finalized();
+//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
+
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_INT64, 0, nullptr, nullptr),
+//         HIPDNN_STATUS_BAD_PARAM);
+
+//     int64_t count = 0;
+//     ASSERT_NO_THROW(heur->get_attribute(
+//         HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 0, &count, nullptr));
+//     ASSERT_EQ(count, 3);
+
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->get_attribute(
+//             HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, nullptr),
+//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+//     std::vector<hipdnnBackendDescriptor_t> configs(3);
+//     for(size_t i = 0; i < 3; ++i)
+//     {
+//         configs[i] = create_descriptor_ptr<Engine_config_descriptor>();
+//     }
+
+//     ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS,
+//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                    3,
+//                                                    nullptr,
+//                                                    configs.data()),
+//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+//     count = 0;
+//     ASSERT_NO_THROW(heur->get_attribute(
+//         HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 3, &count, configs.data()));
+//     ASSERT_EQ(count, 3);
+
+//     for(auto config : configs)
+//     {
+//         delete config;
+//     }
+
+//     configs.clear();
+
+//     Scoped_descriptor single_config(create_descriptor_ptr<Engine_config_descriptor>());
+
+//     count = 0;
+//     ASSERT_NO_THROW(heur->get_attribute(
+//         HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &count, &single_config));
+//     ASSERT_EQ(count, 1);
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsWithNullConfig)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     make_engine_heuristic_finalized();
+
+//     std::vector<hipdnnBackendDescriptor_t> configs(3);
+//     configs[0] = create_descriptor_ptr<Engine_config_descriptor>();
+//     configs[1] = nullptr;
+//     configs[2] = create_descriptor_ptr<Engine_config_descriptor>();
+
+//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
+//     int64_t count = 0;
+//     ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS,
+//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                    3,
+//                                                    &count,
+//                                                    configs.data()),
+//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+//     for(auto config : configs)
+//     {
+//         delete config;
+//     }
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsWithNoEngineIds)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     set_graph();
+//     set_heuristic_mode();
+
+//     ASSERT_NO_THROW(heur->finalize());
+
+//     std::vector<int64_t> engine_ids = {};
+//     ASSERT_NO_THROW(heur->set_engine_ids(engine_ids));
+
+//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
+
+//     std::vector<hipdnnBackendDescriptor_t> configs(3);
+//     for(size_t i = 0; i < 3; ++i)
+//     {
+//         configs[i] = create_descriptor_ptr<Engine_config_descriptor>();
+//     }
+
+//     int64_t count = 0;
+//     ASSERT_NO_THROW(heur->get_attribute(
+//         HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 3, &count, configs.data()));
+//     ASSERT_EQ(count, 0);
+
+//     for(auto config : configs)
+//     {
+//         delete config;
+//     }
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsRequestMoreThanAvailable)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     make_engine_heuristic_finalized();
+
+//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
+
+//     std::vector<hipdnnBackendDescriptor_t> configs(5);
+//     for(size_t i = 0; i < 3; ++i)
+//     {
+//         configs[i] = create_descriptor_ptr<Engine_config_descriptor>();
+//     }
+
+//     int64_t count = 0;
+//     ASSERT_NO_THROW(heur->get_attribute(
+//         HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 5, &count, configs.data()));
+//     ASSERT_EQ(count, 3);
+
+//     for(auto config : configs)
+//     {
+//         delete config;
+//     }
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsCountOnly)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     make_engine_heuristic_finalized();
+
+//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
+
+//     int64_t count = 0;
+//     ASSERT_NO_THROW(heur->get_attribute(
+//         HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 0, &count, nullptr));
+//     ASSERT_EQ(count, 3);
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorHeurMode)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     hipdnnBackendHeurMode_t mode = HIPDNN_HEUR_MODE_FALLBACK;
+
+//     make_engine_heuristic_finalized();
+
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->get_attribute(
+//             HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, &mode),
+//         HIPDNN_STATUS_BAD_PARAM);
+
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 2, nullptr, &mode),
+//         HIPDNN_STATUS_BAD_PARAM);
+
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         heur->get_attribute(
+//             HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr, nullptr),
+//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+//     ASSERT_NO_THROW(
+//         heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr, &mode));
+//     ASSERT_EQ(mode, HIPDNN_HEUR_MODE_FALLBACK);
+
+//     int64_t count = 0;
+//     ASSERT_NO_THROW(
+//         heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &count, &mode));
+//     ASSERT_EQ(count, 1);
+//     ASSERT_EQ(mode, HIPDNN_HEUR_MODE_FALLBACK);
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, GetGraphThrowsIfNotFinalized)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     ASSERT_THROW_HIPDNN_STATUS(heur->get_graph(), HIPDNN_STATUS_INTERNAL_ERROR);
+// }
+
+// TEST_F(Engine_heuristic_descriptor_test, GetGraphReturnsPointerIfFinalized)
+// {
+//     auto heur = get_engine_heuristic_descriptor();
+//     make_engine_heuristic_finalized();
+//     auto graph_ptr = heur->get_graph();
+//     ASSERT_NE(graph_ptr, nullptr);
+//     ASSERT_EQ(static_cast<const hipdnnBackendDescriptorImpl*>(graph_ptr.get()),
+//               static_cast<const hipdnnBackendDescriptorImpl*>(get_mock_graph()));
+// }

--- a/backend/tests/descriptors/test_engine_heuristic_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_heuristic_descriptor.cpp
@@ -1,496 +1,507 @@
-// // Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// // SPDX-License-Identifier: MIT
-
-// #include "descriptors/engine_config_descriptor.hpp"
-// #include "descriptors/engine_descriptor.hpp"
-// #include "descriptors/engine_heuristic_descriptor.hpp"
-// #include "descriptors/graph_descriptor.hpp"
-// #include "descriptors/scoped_descriptor.hpp"
-// #include "hipdnn_backend.h"
-// #include "hipdnn_exception.hpp"
-// #include "mocks/mock_descriptor.hpp"
-// #include "test_descriptor_utils.hpp"
-// #include "test_macros.hpp"
-
-// #include <gtest/gtest.h>
-
-// #include <memory>
-// #include <vector>
-
-// using namespace hipdnn_backend;
-// using namespace test_descriptor_utils;
-
-// using ::testing::Return;
-
-// class Engine_heuristic_descriptor_test : public ::testing::Test
-// {
-// public:
-//     std::unique_ptr<hipdnnBackendDescriptor> _engine_heuristic_wrapper = nullptr;
-//     std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_wrapper = nullptr;
-//     std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_bad_type_wrapper = nullptr;
-
-//     Engine_heuristic_descriptor* get_engine_heuristic_descriptor() const
-//     {
-//         return dynamic_cast<Engine_heuristic_descriptor*>(
-//             _engine_heuristic_wrapper->private_descriptor.get());
-//     }
-
-//     Mock_descriptor* get_mock_graph() const
-//     {
-//         return unpack_mock_descriptor(_mock_graph_wrapper.get());
-//     }
-
-//     Mock_descriptor* get_mock_graph_bad_type() const
-//     {
-//         return unpack_mock_descriptor(_mock_graph_bad_type_wrapper.get());
-//     }
-
-//     void set_graph() const
-//     {
-//         EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
-//         ASSERT_NO_THROW(
-//             get_engine_heuristic_descriptor()->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-//                                                              HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                              1,
-//                                                              &_mock_graph_wrapper));
-//     }
-
-//     void set_heuristic_mode() const
-//     {
-//         hipdnnBackendHeurMode_t mode = HIPDNN_HEUR_MODE_FALLBACK;
-//         ASSERT_NO_THROW(get_engine_heuristic_descriptor()->set_attribute(
-//             HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &mode));
-//     }
-
-//     void set_engine_ids() const
-//     {
-//         std::vector<int64_t> engine_ids = {0, 1, 2};
-//         ASSERT_NO_THROW(get_engine_heuristic_descriptor()->set_engine_ids(engine_ids));
-//     }
-
-//     void make_engine_heuristic_finalized() const
-//     {
-//         set_graph();
-//         set_heuristic_mode();
-//         ASSERT_NO_THROW(get_engine_heuristic_descriptor()->finalize());
-//         set_engine_ids();
-//     }
-
-// protected:
-//     void SetUp() override
-//     {
-//         _engine_heuristic_wrapper = create_descriptor<Engine_heuristic_descriptor>();
-//         _mock_graph_wrapper
-//             = make_mock_descriptor_wrapper(HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR);
-//         _mock_graph_bad_type_wrapper = make_mock_descriptor_wrapper();
-//     }
-// };
-
-// TEST_F(Engine_heuristic_descriptor_test, CreateEngineHeuristicDescriptor)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     ASSERT_NE(heur, nullptr);
-//     ASSERT_FALSE(heur->is_finalized());
-//     ASSERT_EQ(heur->type, HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR);
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorGraph)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->set_attribute(
-//             HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, &_mock_graph_wrapper),
-//         HIPDNN_STATUS_BAD_PARAM);
-
-//     ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                    2,
-//                                                    &_mock_graph_wrapper),
-//                                HIPDNN_STATUS_BAD_PARAM);
-
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->set_attribute(
-//             HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr),
-//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-//     hipdnnBackendDescriptor_t graph = nullptr;
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->set_attribute(
-//             HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &graph),
-//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-//     ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                    1,
-//                                                    &_mock_graph_bad_type_wrapper),
-//                                HIPDNN_STATUS_BAD_PARAM);
-
-//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(false));
-//     ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                    1,
-//                                                    &_mock_graph_wrapper),
-//                                HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
-
-//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
-//     ASSERT_NO_THROW(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-//                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                         1,
-//                                         &_mock_graph_wrapper));
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorHeurMode)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     hipdnnBackendHeurMode_t mode = HIPDNN_HEUR_MODE_FALLBACK;
-//     auto unsupported_mode = static_cast<hipdnnBackendHeurMode_t>(999);
-
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &mode),
-//         HIPDNN_STATUS_BAD_PARAM);
-
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 2, &mode),
-//         HIPDNN_STATUS_BAD_PARAM);
-
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr),
-//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->set_attribute(
-//             HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &unsupported_mode),
-//         HIPDNN_STATUS_NOT_SUPPORTED);
-
-//     ASSERT_NO_THROW(
-//         heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &mode));
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorUnsupportedAttr)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     int32_t dummy = 0;
-
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_INT32, 1, &dummy),
-//         HIPDNN_STATUS_NOT_SUPPORTED);
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, SetEngineIds)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     std::vector<int64_t> engine_ids = {0, 1, 2};
-
-//     ASSERT_THROW_HIPDNN_STATUS(heur->set_engine_ids(engine_ids), HIPDNN_STATUS_INTERNAL_ERROR);
-
-//     make_engine_heuristic_finalized();
-
-//     ASSERT_NO_THROW(heur->set_engine_ids(engine_ids));
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, SetAttrOnFinalizedEngineHeuristicDescriptor)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     make_engine_heuristic_finalized();
-
-//     ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                    1,
-//                                                    &_mock_graph_wrapper),
-//                                HIPDNN_STATUS_NOT_INITIALIZED);
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, FinalizeEngineHeuristicDescriptor)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
-
-//     set_graph();
-//     ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
-
-//     set_heuristic_mode();
-//     ASSERT_NO_THROW(heur->finalize());
-
-//     set_engine_ids();
-
-//     ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, FinalizeEngineHeuristicDescriptorReverseOrder)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
-
-//     set_heuristic_mode();
-//     ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
-
-//     set_graph();
-//     ASSERT_NO_THROW(heur->finalize());
-
-//     set_engine_ids();
-
-//     ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, GetAttrOnUnfinalizedEngineHeuristicDescriptor)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     hipdnnBackendDescriptor_t dummy_graph = nullptr;
-
-//     ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                    1,
-//                                                    nullptr,
-//                                                    &dummy_graph),
-//                                HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorUnsupportedAttr)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     hipdnnBackendHeurMode_t dummy;
-
-//     make_engine_heuristic_finalized();
-
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->get_attribute(
-//             HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr, &dummy),
-//         HIPDNN_STATUS_NOT_SUPPORTED);
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorGraph)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     Scoped_descriptor graph;
-//     Scoped_descriptor graph2;
-
-//     make_engine_heuristic_finalized();
-
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->get_attribute(
-//             HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, nullptr, graph.get_ptr()),
-//         HIPDNN_STATUS_BAD_PARAM);
-
-//     ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                    2,
-//                                                    nullptr,
-//                                                    graph.get_ptr()),
-//                                HIPDNN_STATUS_BAD_PARAM);
-
-//     ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                    1,
-//                                                    nullptr,
-//                                                    nullptr),
-//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-//     ASSERT_NO_THROW(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-//                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                         1,
-//                                         nullptr,
-//                                         graph.get_ptr()));
-//     ASSERT_EQ(graph.get()->private_descriptor, _mock_graph_wrapper->private_descriptor);
-
-//     int64_t count;
-//     ASSERT_NO_THROW(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-//                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                         1,
-//                                         &count,
-//                                         graph2.get_ptr()));
-//     ASSERT_EQ(count, 1);
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorEngineConfigs)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     make_engine_heuristic_finalized();
-//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
-
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_INT64, 0, nullptr, nullptr),
-//         HIPDNN_STATUS_BAD_PARAM);
-
-//     int64_t count = 0;
-//     ASSERT_NO_THROW(heur->get_attribute(
-//         HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 0, &count, nullptr));
-//     ASSERT_EQ(count, 3);
-
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->get_attribute(
-//             HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, nullptr),
-//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-//     std::vector<hipdnnBackendDescriptor_t> configs(3);
-//     for(size_t i = 0; i < 3; ++i)
-//     {
-//         configs[i] = create_descriptor_ptr<Engine_config_descriptor>();
-//     }
-
-//     ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS,
-//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                    3,
-//                                                    nullptr,
-//                                                    configs.data()),
-//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-//     count = 0;
-//     ASSERT_NO_THROW(heur->get_attribute(
-//         HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 3, &count, configs.data()));
-//     ASSERT_EQ(count, 3);
-
-//     for(auto config : configs)
-//     {
-//         delete config;
-//     }
-
-//     configs.clear();
-
-//     Scoped_descriptor single_config(create_descriptor_ptr<Engine_config_descriptor>());
-
-//     count = 0;
-//     ASSERT_NO_THROW(heur->get_attribute(
-//         HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &count, &single_config));
-//     ASSERT_EQ(count, 1);
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsWithNullConfig)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     make_engine_heuristic_finalized();
-
-//     std::vector<hipdnnBackendDescriptor_t> configs(3);
-//     configs[0] = create_descriptor_ptr<Engine_config_descriptor>();
-//     configs[1] = nullptr;
-//     configs[2] = create_descriptor_ptr<Engine_config_descriptor>();
-
-//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
-//     int64_t count = 0;
-//     ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS,
-//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                    3,
-//                                                    &count,
-//                                                    configs.data()),
-//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-//     for(auto config : configs)
-//     {
-//         delete config;
-//     }
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsWithNoEngineIds)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     set_graph();
-//     set_heuristic_mode();
-
-//     ASSERT_NO_THROW(heur->finalize());
-
-//     std::vector<int64_t> engine_ids = {};
-//     ASSERT_NO_THROW(heur->set_engine_ids(engine_ids));
-
-//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
-
-//     std::vector<hipdnnBackendDescriptor_t> configs(3);
-//     for(size_t i = 0; i < 3; ++i)
-//     {
-//         configs[i] = create_descriptor_ptr<Engine_config_descriptor>();
-//     }
-
-//     int64_t count = 0;
-//     ASSERT_NO_THROW(heur->get_attribute(
-//         HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 3, &count, configs.data()));
-//     ASSERT_EQ(count, 0);
-
-//     for(auto config : configs)
-//     {
-//         delete config;
-//     }
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsRequestMoreThanAvailable)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     make_engine_heuristic_finalized();
-
-//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
-
-//     std::vector<hipdnnBackendDescriptor_t> configs(5);
-//     for(size_t i = 0; i < 3; ++i)
-//     {
-//         configs[i] = create_descriptor_ptr<Engine_config_descriptor>();
-//     }
-
-//     int64_t count = 0;
-//     ASSERT_NO_THROW(heur->get_attribute(
-//         HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 5, &count, configs.data()));
-//     ASSERT_EQ(count, 3);
-
-//     for(auto config : configs)
-//     {
-//         delete config;
-//     }
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsCountOnly)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     make_engine_heuristic_finalized();
-
-//     EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
-
-//     int64_t count = 0;
-//     ASSERT_NO_THROW(heur->get_attribute(
-//         HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 0, &count, nullptr));
-//     ASSERT_EQ(count, 3);
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorHeurMode)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     hipdnnBackendHeurMode_t mode = HIPDNN_HEUR_MODE_FALLBACK;
-
-//     make_engine_heuristic_finalized();
-
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->get_attribute(
-//             HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, &mode),
-//         HIPDNN_STATUS_BAD_PARAM);
-
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 2, nullptr, &mode),
-//         HIPDNN_STATUS_BAD_PARAM);
-
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         heur->get_attribute(
-//             HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr, nullptr),
-//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-
-//     ASSERT_NO_THROW(
-//         heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr, &mode));
-//     ASSERT_EQ(mode, HIPDNN_HEUR_MODE_FALLBACK);
-
-//     int64_t count = 0;
-//     ASSERT_NO_THROW(
-//         heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &count, &mode));
-//     ASSERT_EQ(count, 1);
-//     ASSERT_EQ(mode, HIPDNN_HEUR_MODE_FALLBACK);
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, GetGraphThrowsIfNotFinalized)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     ASSERT_THROW_HIPDNN_STATUS(heur->get_graph(), HIPDNN_STATUS_INTERNAL_ERROR);
-// }
-
-// TEST_F(Engine_heuristic_descriptor_test, GetGraphReturnsPointerIfFinalized)
-// {
-//     auto heur = get_engine_heuristic_descriptor();
-//     make_engine_heuristic_finalized();
-//     auto graph_ptr = heur->get_graph();
-//     ASSERT_NE(graph_ptr, nullptr);
-//     ASSERT_EQ(static_cast<const hipdnnBackendDescriptorImpl*>(graph_ptr.get()),
-//               static_cast<const hipdnnBackendDescriptorImpl*>(get_mock_graph()));
-// }
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "descriptors/engine_config_descriptor.hpp"
+#include "descriptors/engine_descriptor.hpp"
+#include "descriptors/engine_heuristic_descriptor.hpp"
+#include "descriptors/graph_descriptor.hpp"
+#include "descriptors/scoped_descriptor.hpp"
+#include "hipdnn_backend.h"
+#include "hipdnn_exception.hpp"
+#include "mocks/mock_descriptor.hpp"
+#include "test_descriptor_utils.hpp"
+#include "test_macros.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+using namespace hipdnn_backend;
+using namespace test_descriptor_utils;
+
+using ::testing::Return;
+
+class Engine_heuristic_descriptor_test : public ::testing::Test
+{
+public:
+    std::unique_ptr<hipdnnBackendDescriptor> _engine_heuristic_wrapper = nullptr;
+    std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_wrapper = nullptr;
+    std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_bad_type_wrapper = nullptr;
+    std::unique_ptr<hipdnnBackendDescriptor> _mock_wrong_type_wrapper = nullptr;
+
+    Engine_heuristic_descriptor* get_engine_heuristic_descriptor() const
+    {
+        return dynamic_cast<Engine_heuristic_descriptor*>(_engine_heuristic_wrapper->impl.get());
+    }
+
+    Mock_descriptor<Graph_descriptor>* get_mock_graph() const
+    {
+        return unpack_mock_descriptor<Graph_descriptor>(_mock_graph_wrapper.get());
+    }
+
+    Mock_descriptor<Graph_descriptor>* get_mock_graph_bad_type() const
+    {
+        return unpack_mock_descriptor<Graph_descriptor>(_mock_graph_bad_type_wrapper.get());
+    }
+
+    Mock_descriptor<Engine_heuristic_descriptor>* get_mock_wrong_type() const
+    {
+        return unpack_mock_descriptor<Engine_heuristic_descriptor>(_mock_wrong_type_wrapper.get());
+    }
+
+    void set_graph() const
+    {
+        EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
+        ASSERT_NO_THROW(
+            get_engine_heuristic_descriptor()->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+                                                             HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                             1,
+                                                             &_mock_graph_wrapper));
+    }
+
+    void set_heuristic_mode() const
+    {
+        hipdnnBackendHeurMode_t mode = HIPDNN_HEUR_MODE_FALLBACK;
+        ASSERT_NO_THROW(get_engine_heuristic_descriptor()->set_attribute(
+            HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &mode));
+    }
+
+    void set_engine_ids() const
+    {
+        std::vector<int64_t> engine_ids = {0, 1, 2};
+        ASSERT_NO_THROW(get_engine_heuristic_descriptor()->set_engine_ids(engine_ids));
+    }
+
+    void make_engine_heuristic_finalized() const
+    {
+        set_graph();
+        set_heuristic_mode();
+        ASSERT_NO_THROW(get_engine_heuristic_descriptor()->finalize());
+        set_engine_ids();
+    }
+
+protected:
+    void SetUp() override
+    {
+        _engine_heuristic_wrapper = create_descriptor<Engine_heuristic_descriptor>();
+        _mock_graph_wrapper = make_mock_descriptor_wrapper<Graph_descriptor>();
+        _mock_graph_bad_type_wrapper = make_mock_descriptor_wrapper<Graph_descriptor>();
+        _mock_wrong_type_wrapper = make_mock_descriptor_wrapper<Engine_heuristic_descriptor>();
+    }
+};
+
+TEST_F(Engine_heuristic_descriptor_test, CreateEngineHeuristicDescriptor)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    ASSERT_NE(heur, nullptr);
+    ASSERT_FALSE(heur->is_finalized());
+    ASSERT_EQ(heur->get_type(), HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR);
+}
+
+TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorGraph)
+{
+    auto heur = get_engine_heuristic_descriptor();
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->set_attribute(
+            HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, &_mock_graph_wrapper),
+        HIPDNN_STATUS_BAD_PARAM);
+
+    ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   2,
+                                                   &_mock_graph_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM);
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->set_attribute(
+            HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+    hipdnnBackendDescriptor_t graph = nullptr;
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->set_attribute(
+            HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &graph),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+    ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   1,
+                                                   &_mock_graph_bad_type_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+
+    ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   1,
+                                                   &_mock_wrong_type_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM);
+
+    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(false));
+    ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   1,
+                                                   &_mock_graph_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+
+    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
+    ASSERT_NO_THROW(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &_mock_graph_wrapper));
+}
+
+TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorHeurMode)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    hipdnnBackendHeurMode_t mode = HIPDNN_HEUR_MODE_FALLBACK;
+    auto unsupported_mode = static_cast<hipdnnBackendHeurMode_t>(999);
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &mode),
+        HIPDNN_STATUS_BAD_PARAM);
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 2, &mode),
+        HIPDNN_STATUS_BAD_PARAM);
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->set_attribute(
+            HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &unsupported_mode),
+        HIPDNN_STATUS_NOT_SUPPORTED);
+
+    ASSERT_NO_THROW(
+        heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &mode));
+}
+
+TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorUnsupportedAttr)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    int32_t dummy = 0;
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_INT32, 1, &dummy),
+        HIPDNN_STATUS_NOT_SUPPORTED);
+}
+
+TEST_F(Engine_heuristic_descriptor_test, SetEngineIds)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    std::vector<int64_t> engine_ids = {0, 1, 2};
+
+    ASSERT_THROW_HIPDNN_STATUS(heur->set_engine_ids(engine_ids), HIPDNN_STATUS_INTERNAL_ERROR);
+
+    make_engine_heuristic_finalized();
+
+    ASSERT_NO_THROW(heur->set_engine_ids(engine_ids));
+}
+
+TEST_F(Engine_heuristic_descriptor_test, SetAttrOnFinalizedEngineHeuristicDescriptor)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    make_engine_heuristic_finalized();
+
+    ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   1,
+                                                   &_mock_graph_wrapper),
+                               HIPDNN_STATUS_NOT_INITIALIZED);
+}
+
+TEST_F(Engine_heuristic_descriptor_test, FinalizeEngineHeuristicDescriptor)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
+
+    set_graph();
+    ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
+
+    set_heuristic_mode();
+    ASSERT_NO_THROW(heur->finalize());
+
+    set_engine_ids();
+
+    ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(Engine_heuristic_descriptor_test, FinalizeEngineHeuristicDescriptorReverseOrder)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
+
+    set_heuristic_mode();
+    ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
+
+    set_graph();
+    ASSERT_NO_THROW(heur->finalize());
+
+    set_engine_ids();
+
+    ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(Engine_heuristic_descriptor_test, GetAttrOnUnfinalizedEngineHeuristicDescriptor)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    hipdnnBackendDescriptor_t dummy_graph = nullptr;
+
+    ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   1,
+                                                   nullptr,
+                                                   &dummy_graph),
+                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+}
+
+TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorUnsupportedAttr)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    hipdnnBackendHeurMode_t dummy;
+
+    make_engine_heuristic_finalized();
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->get_attribute(
+            HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr, &dummy),
+        HIPDNN_STATUS_NOT_SUPPORTED);
+}
+
+TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorGraph)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    Scoped_descriptor graph;
+    Scoped_descriptor graph2;
+
+    make_engine_heuristic_finalized();
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->get_attribute(
+            HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, nullptr, graph.get_ptr()),
+        HIPDNN_STATUS_BAD_PARAM);
+
+    ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   2,
+                                                   nullptr,
+                                                   graph.get_ptr()),
+                               HIPDNN_STATUS_BAD_PARAM);
+
+    ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   1,
+                                                   nullptr,
+                                                   nullptr),
+                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+    ASSERT_NO_THROW(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        nullptr,
+                                        graph.get_ptr()));
+    ASSERT_EQ(graph.get()->impl, _mock_graph_wrapper->impl);
+
+    int64_t count;
+    ASSERT_NO_THROW(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &count,
+                                        graph2.get_ptr()));
+    ASSERT_EQ(count, 1);
+}
+
+TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorEngineConfigs)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    make_engine_heuristic_finalized();
+    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_INT64, 0, nullptr, nullptr),
+        HIPDNN_STATUS_BAD_PARAM);
+
+    int64_t count = 0;
+    ASSERT_NO_THROW(heur->get_attribute(
+        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 0, &count, nullptr));
+    ASSERT_EQ(count, 3);
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->get_attribute(
+            HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, nullptr),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+    std::vector<hipdnnBackendDescriptor_t> configs(3);
+    for(size_t i = 0; i < 3; ++i)
+    {
+        configs[i] = create_descriptor_ptr<Engine_config_descriptor>();
+    }
+
+    ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   3,
+                                                   nullptr,
+                                                   configs.data()),
+                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+    count = 0;
+    ASSERT_NO_THROW(heur->get_attribute(
+        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 3, &count, configs.data()));
+    ASSERT_EQ(count, 3);
+
+    for(auto config : configs)
+    {
+        delete config;
+    }
+
+    configs.clear();
+
+    Scoped_descriptor single_config(create_descriptor_ptr<Engine_config_descriptor>());
+
+    count = 0;
+    ASSERT_NO_THROW(heur->get_attribute(
+        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &count, &single_config));
+    ASSERT_EQ(count, 1);
+}
+
+TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsWithNullConfig)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    make_engine_heuristic_finalized();
+
+    std::vector<hipdnnBackendDescriptor_t> configs(3);
+    configs[0] = create_descriptor_ptr<Engine_config_descriptor>();
+    configs[1] = nullptr;
+    configs[2] = create_descriptor_ptr<Engine_config_descriptor>();
+
+    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
+    int64_t count = 0;
+    ASSERT_THROW_HIPDNN_STATUS(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   3,
+                                                   &count,
+                                                   configs.data()),
+                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+    for(auto config : configs)
+    {
+        delete config;
+    }
+}
+
+TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsWithNoEngineIds)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    set_graph();
+    set_heuristic_mode();
+
+    ASSERT_NO_THROW(heur->finalize());
+
+    std::vector<int64_t> engine_ids = {};
+    ASSERT_NO_THROW(heur->set_engine_ids(engine_ids));
+
+    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
+
+    std::vector<hipdnnBackendDescriptor_t> configs(3);
+    for(size_t i = 0; i < 3; ++i)
+    {
+        configs[i] = create_descriptor_ptr<Engine_config_descriptor>();
+    }
+
+    int64_t count = 0;
+    ASSERT_NO_THROW(heur->get_attribute(
+        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 3, &count, configs.data()));
+    ASSERT_EQ(count, 0);
+
+    for(auto config : configs)
+    {
+        delete config;
+    }
+}
+
+TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsRequestMoreThanAvailable)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    make_engine_heuristic_finalized();
+
+    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
+
+    std::vector<hipdnnBackendDescriptor_t> configs(5);
+    for(size_t i = 0; i < 3; ++i)
+    {
+        configs[i] = create_descriptor_ptr<Engine_config_descriptor>();
+    }
+
+    int64_t count = 0;
+    ASSERT_NO_THROW(heur->get_attribute(
+        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 5, &count, configs.data()));
+    ASSERT_EQ(count, 3);
+
+    for(auto config : configs)
+    {
+        delete config;
+    }
+}
+
+TEST_F(Engine_heuristic_descriptor_test, GetEngineConfigsCountOnly)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    make_engine_heuristic_finalized();
+
+    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillRepeatedly(Return(true));
+
+    int64_t count = 0;
+    ASSERT_NO_THROW(heur->get_attribute(
+        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 0, &count, nullptr));
+    ASSERT_EQ(count, 3);
+}
+
+TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorHeurMode)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    hipdnnBackendHeurMode_t mode = HIPDNN_HEUR_MODE_FALLBACK;
+
+    make_engine_heuristic_finalized();
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->get_attribute(
+            HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, &mode),
+        HIPDNN_STATUS_BAD_PARAM);
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 2, nullptr, &mode),
+        HIPDNN_STATUS_BAD_PARAM);
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        heur->get_attribute(
+            HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr, nullptr),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+    ASSERT_NO_THROW(
+        heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr, &mode));
+    ASSERT_EQ(mode, HIPDNN_HEUR_MODE_FALLBACK);
+
+    int64_t count = 0;
+    ASSERT_NO_THROW(
+        heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &count, &mode));
+    ASSERT_EQ(count, 1);
+    ASSERT_EQ(mode, HIPDNN_HEUR_MODE_FALLBACK);
+}
+
+TEST_F(Engine_heuristic_descriptor_test, GetGraphThrowsIfNotFinalized)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    ASSERT_THROW_HIPDNN_STATUS(heur->get_graph(), HIPDNN_STATUS_INTERNAL_ERROR);
+}
+
+TEST_F(Engine_heuristic_descriptor_test, GetGraphReturnsPointerIfFinalized)
+{
+    auto heur = get_engine_heuristic_descriptor();
+    make_engine_heuristic_finalized();
+    auto graph_ptr = heur->get_graph();
+    ASSERT_NE(graph_ptr, nullptr);
+    ASSERT_EQ(static_cast<const Backend_descriptor_interface*>(graph_ptr.get()),
+              static_cast<const Backend_descriptor_interface*>(get_mock_graph()));
+}

--- a/backend/tests/descriptors/test_engine_heuristic_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_heuristic_descriptor.cpp
@@ -30,24 +30,25 @@ public:
     std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_bad_type_wrapper = nullptr;
     std::unique_ptr<hipdnnBackendDescriptor> _mock_wrong_type_wrapper = nullptr;
 
-    Engine_heuristic_descriptor* get_engine_heuristic_descriptor() const
+    std::shared_ptr<Engine_heuristic_descriptor> get_engine_heuristic_descriptor() const
     {
-        return dynamic_cast<Engine_heuristic_descriptor*>(_engine_heuristic_wrapper->impl.get());
+        return _engine_heuristic_wrapper->as_descriptor<Engine_heuristic_descriptor>();
     }
 
-    Mock_descriptor<Graph_descriptor>* get_mock_graph() const
+    std::shared_ptr<Mock_descriptor<Graph_descriptor>> get_mock_graph() const
     {
-        return unpack_mock_descriptor<Graph_descriptor>(_mock_graph_wrapper.get());
+        return _mock_graph_wrapper->as_descriptor<Mock_descriptor<Graph_descriptor>>();
     }
 
-    Mock_descriptor<Graph_descriptor>* get_mock_graph_bad_type() const
+    std::shared_ptr<Mock_descriptor<Graph_descriptor>> get_mock_graph_bad_type() const
     {
-        return unpack_mock_descriptor<Graph_descriptor>(_mock_graph_bad_type_wrapper.get());
+        return _mock_graph_bad_type_wrapper->as_descriptor<Mock_descriptor<Graph_descriptor>>();
     }
 
-    Mock_descriptor<Engine_heuristic_descriptor>* get_mock_wrong_type() const
+    std::shared_ptr<Mock_descriptor<Engine_heuristic_descriptor>> get_mock_wrong_type() const
     {
-        return unpack_mock_descriptor<Engine_heuristic_descriptor>(_mock_wrong_type_wrapper.get());
+        return _mock_wrong_type_wrapper
+            ->as_descriptor<Mock_descriptor<Engine_heuristic_descriptor>>();
     }
 
     void set_graph() const
@@ -85,9 +86,10 @@ protected:
     void SetUp() override
     {
         _engine_heuristic_wrapper = create_descriptor<Engine_heuristic_descriptor>();
-        _mock_graph_wrapper = make_mock_descriptor_wrapper<Graph_descriptor>();
-        _mock_graph_bad_type_wrapper = make_mock_descriptor_wrapper<Graph_descriptor>();
-        _mock_wrong_type_wrapper = make_mock_descriptor_wrapper<Engine_heuristic_descriptor>();
+        _mock_graph_wrapper = create_descriptor<Mock_descriptor<Graph_descriptor>>();
+        _mock_graph_bad_type_wrapper = create_descriptor<Mock_descriptor<Graph_descriptor>>();
+        _mock_wrong_type_wrapper
+            = create_descriptor<Mock_descriptor<Engine_heuristic_descriptor>>();
     }
 };
 
@@ -302,7 +304,7 @@ TEST_F(Engine_heuristic_descriptor_test, GetEngineHeuristicDescriptorGraph)
                                         1,
                                         nullptr,
                                         graph.get_ptr()));
-    ASSERT_EQ(graph.get()->impl, _mock_graph_wrapper->impl);
+    ASSERT_EQ(*graph.get(), *(_mock_graph_wrapper.get()));
 
     int64_t count;
     ASSERT_NO_THROW(heur->get_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
@@ -503,5 +505,5 @@ TEST_F(Engine_heuristic_descriptor_test, GetGraphReturnsPointerIfFinalized)
     auto graph_ptr = heur->get_graph();
     ASSERT_NE(graph_ptr, nullptr);
     ASSERT_EQ(static_cast<const Backend_descriptor_interface*>(graph_ptr.get()),
-              static_cast<const Backend_descriptor_interface*>(get_mock_graph()));
+              static_cast<const Backend_descriptor_interface*>(get_mock_graph().get()));
 }

--- a/backend/tests/descriptors/test_execution_plan_descriptor.cpp
+++ b/backend/tests/descriptors/test_execution_plan_descriptor.cpp
@@ -1,312 +1,323 @@
-// // Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// // SPDX-License-Identifier: MIT
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
-// #include "descriptors/engine_config_descriptor.hpp"
-// #include "descriptors/execution_plan_descriptor.hpp"
-// #include "descriptors/scoped_descriptor.hpp"
-// #include "hipdnn_backend.h"
-// #include "hipdnn_exception.hpp"
-// #include "mocks/mock_descriptor.hpp"
-// #include "test_descriptor_utils.hpp"
-// #include "test_macros.hpp"
+#include "descriptors/engine_config_descriptor.hpp"
+#include "descriptors/execution_plan_descriptor.hpp"
+#include "descriptors/scoped_descriptor.hpp"
+#include "hipdnn_backend.h"
+#include "hipdnn_exception.hpp"
+#include "mocks/mock_descriptor.hpp"
+#include "test_descriptor_utils.hpp"
+#include "test_macros.hpp"
 
-// #include <gtest/gtest.h>
+#include <gtest/gtest.h>
 
-// #include <array>
-// #include <memory>
+#include <array>
+#include <memory>
 
-// using namespace hipdnn_backend;
-// using namespace test_descriptor_utils;
+using namespace hipdnn_backend;
+using namespace test_descriptor_utils;
 
-// using ::testing::_;
-// using ::testing::Return;
+using ::testing::_;
+using ::testing::Return;
 
-// // NOLINTBEGIN(readability-function-cognitive-complexity)
-// class Execution_plan_descriptor_test : public ::testing::Test
-// {
-// public:
-//     std::unique_ptr<hipdnnBackendDescriptor> _plan_wrapper = nullptr;
-//     hipdnnHandle_t _handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
-//     std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_config_wrapper = nullptr;
-//     std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_config_bad_type_wrapper = nullptr;
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+class Execution_plan_descriptor_test : public ::testing::Test
+{
+public:
+    std::unique_ptr<hipdnnBackendDescriptor> _plan_wrapper = nullptr;
+    hipdnnHandle_t _handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
+    std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_config_wrapper = nullptr;
+    std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_config_bad_type_wrapper = nullptr;
+    std::unique_ptr<hipdnnBackendDescriptor> _mock_wrong_type_wrapper = nullptr;
 
-//     Execution_plan_descriptor* get_execution_plan_descriptor() const
-//     {
-//         return dynamic_cast<Execution_plan_descriptor*>(_plan_wrapper->private_descriptor.get());
-//     }
+    Execution_plan_descriptor* get_execution_plan_descriptor() const
+    {
+        return dynamic_cast<Execution_plan_descriptor*>(_plan_wrapper->impl.get());
+    }
 
-//     Mock_descriptor* get_mock_engine_config() const
-//     {
-//         return unpack_mock_descriptor(_mock_engine_config_wrapper.get());
-//     }
+    Mock_descriptor<Engine_config_descriptor>* get_mock_engine_config() const
+    {
+        return unpack_mock_descriptor<Engine_config_descriptor>(_mock_engine_config_wrapper.get());
+    }
 
-//     Mock_descriptor* get_mock_engine_config_bad_type() const
-//     {
-//         return unpack_mock_descriptor(_mock_engine_config_bad_type_wrapper.get());
-//     }
+    Mock_descriptor<Engine_config_descriptor>* get_mock_engine_config_bad_type() const
+    {
+        return unpack_mock_descriptor<Engine_config_descriptor>(_mock_engine_config_bad_type_wrapper.get());
+    }
 
-//     void SetUp() override
-//     {
-//         _plan_wrapper = create_descriptor<Execution_plan_descriptor>();
-//         _mock_engine_config_wrapper
-//             = make_mock_descriptor_wrapper(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR);
-//         _mock_engine_config_bad_type_wrapper = make_mock_descriptor_wrapper();
-//     }
+    Mock_descriptor<Execution_plan_descriptor>* get_mock_wrong_type() const
+    {
+        return unpack_mock_descriptor<Execution_plan_descriptor>(_mock_wrong_type_wrapper.get());
+    }
 
-//     void TearDown() override
-//     {
-//         _plan_wrapper.reset();
-//         _mock_engine_config_wrapper.reset();
-//         _mock_engine_config_bad_type_wrapper.reset();
-//     }
+    void SetUp() override
+    {
+        _plan_wrapper = create_descriptor<Execution_plan_descriptor>();
+        _mock_engine_config_wrapper = make_mock_descriptor_wrapper<Engine_config_descriptor>();
+        _mock_engine_config_bad_type_wrapper = make_mock_descriptor_wrapper<Engine_config_descriptor>();
+        _mock_wrong_type_wrapper = make_mock_descriptor_wrapper<Execution_plan_descriptor>();
+    }
 
-//     void make_execution_plan_finalized()
-//     {
-//         ASSERT_NO_THROW(set_handle());
-//         ASSERT_NO_THROW(set_engine_config());
+    void TearDown() override
+    {
+        _plan_wrapper.reset();
+        _mock_engine_config_wrapper.reset();
+        _mock_engine_config_bad_type_wrapper.reset();
+        _mock_wrong_type_wrapper.reset();
+    }
 
-//         auto plan = get_execution_plan_descriptor();
-//         ASSERT_NO_THROW(plan->finalize());
-//     }
+    void make_execution_plan_finalized()
+    {
+        ASSERT_NO_THROW(set_handle());
+        ASSERT_NO_THROW(set_engine_config());
 
-//     void set_handle()
-//     {
-//         auto plan = get_execution_plan_descriptor();
-//         plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle);
-//     }
+        auto plan = get_execution_plan_descriptor();
+        ASSERT_NO_THROW(plan->finalize());
+    }
 
-//     void set_engine_config()
-//     {
-//         auto plan = get_execution_plan_descriptor();
-//         auto mock_engine_config = get_mock_engine_config();
-//         EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(true));
-//         plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-//                             HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                             1,
-//                             &_mock_engine_config_wrapper);
-//     }
-// };
+    void set_handle()
+    {
+        auto plan = get_execution_plan_descriptor();
+        plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle);
+    }
 
-// TEST_F(Execution_plan_descriptor_test, CreateExecutionPlanDescriptor)
-// {
-//     auto plan = get_execution_plan_descriptor();
-//     ASSERT_NE(plan, nullptr);
-//     ASSERT_FALSE(plan->is_finalized());
-//     ASSERT_EQ(plan->type, HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR);
-// }
+    void set_engine_config()
+    {
+        auto plan = get_execution_plan_descriptor();
+        auto mock_engine_config = get_mock_engine_config();
+        EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(true));
+        plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                            HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                            1,
+                            &_mock_engine_config_wrapper);
+    }
+};
 
-// TEST_F(Execution_plan_descriptor_test, SetAttrOnUnfinalizedExecutionPlanDescriptor)
-// {
-//     auto plan = get_execution_plan_descriptor();
-//     uint64_t dummy_workspace_size;
+TEST_F(Execution_plan_descriptor_test, CreateExecutionPlanDescriptor)
+{
+    auto plan = get_execution_plan_descriptor();
+    ASSERT_NE(plan, nullptr);
+    ASSERT_FALSE(plan->is_finalized());
+    ASSERT_EQ(plan->get_type(), HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR);
+}
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         plan->set_attribute(
-//             HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, &dummy_workspace_size),
-//         HIPDNN_STATUS_NOT_SUPPORTED);
+TEST_F(Execution_plan_descriptor_test, SetAttrOnUnfinalizedExecutionPlanDescriptor)
+{
+    auto plan = get_execution_plan_descriptor();
+    uint64_t dummy_workspace_size;
 
-//     make_execution_plan_finalized();
+    ASSERT_THROW_HIPDNN_STATUS(
+        plan->set_attribute(
+            HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, &dummy_workspace_size),
+        HIPDNN_STATUS_NOT_SUPPORTED);
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         plan->set_attribute(
-//             HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, &dummy_workspace_size),
-//         HIPDNN_STATUS_NOT_INITIALIZED);
-// }
+    make_execution_plan_finalized();
 
-// TEST_F(Execution_plan_descriptor_test, SetExecutionPlanDescriptorHandle)
-// {
-//     auto plan = get_execution_plan_descriptor();
-//     hipdnnHandle_t handle = nullptr;
+    ASSERT_THROW_HIPDNN_STATUS(
+        plan->set_attribute(
+            HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, &dummy_workspace_size),
+        HIPDNN_STATUS_NOT_INITIALIZED);
+}
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_INT64, 1, &handle),
-//         HIPDNN_STATUS_BAD_PARAM);
+TEST_F(Execution_plan_descriptor_test, SetExecutionPlanDescriptorHandle)
+{
+    auto plan = get_execution_plan_descriptor();
+    hipdnnHandle_t handle = nullptr;
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 2, &handle),
-//         HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(
+        plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_INT64, 1, &handle),
+        HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, nullptr),
-//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    ASSERT_THROW_HIPDNN_STATUS(
+        plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 2, &handle),
+        HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
-//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    ASSERT_THROW_HIPDNN_STATUS(
+        plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, nullptr),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-//     handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
-//     plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
-// }
+    ASSERT_THROW_HIPDNN_STATUS(
+        plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-// TEST_F(Execution_plan_descriptor_test, SetExecutionPlanDescriptorEngineConfig)
-// {
-//     auto plan = get_execution_plan_descriptor();
-//     auto mock_engine_config = get_mock_engine_config();
+    handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
+    plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+}
 
-//     ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-//                                                    HIPDNN_TYPE_HANDLE,
-//                                                    1,
-//                                                    &_mock_engine_config_wrapper),
-//                                HIPDNN_STATUS_BAD_PARAM);
+TEST_F(Execution_plan_descriptor_test, SetExecutionPlanDescriptorEngineConfig)
+{
+    auto plan = get_execution_plan_descriptor();
+    auto mock_engine_config = get_mock_engine_config();
 
-//     ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                    2,
-//                                                    &_mock_engine_config_wrapper),
-//                                HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                                   HIPDNN_TYPE_HANDLE,
+                                                   1,
+                                                   &_mock_engine_config_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         plan->set_attribute(
-//             HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr),
-//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   2,
+                                                   &_mock_engine_config_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM);
 
-//     hipdnnBackendDescriptor_t engine_config = nullptr;
-//     ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                    1,
-//                                                    &engine_config),
-//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    ASSERT_THROW_HIPDNN_STATUS(
+        plan->set_attribute(
+            HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-//     ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                    1,
-//                                                    &_mock_engine_config_bad_type_wrapper),
-//                                HIPDNN_STATUS_BAD_PARAM);
+    hipdnnBackendDescriptor_t engine_config = nullptr;
+    ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   1,
+                                                   &engine_config),
+                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-//     EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(false));
-//     ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                    1,
-//                                                    &_mock_engine_config_wrapper),
-//                                HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+    ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   1,
+                                                   &_mock_engine_config_bad_type_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
 
-//     EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(true));
-//     plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-//                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                         1,
-//                         &_mock_engine_config_wrapper);
-// }
+    ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   1,
+                                                   &_mock_wrong_type_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM);
 
-// TEST_F(Execution_plan_descriptor_test, FinalizeExecutionPlanDescriptor)
-// {
-//     auto plan = get_execution_plan_descriptor();
-//     ASSERT_THROW_HIPDNN_STATUS(plan->finalize(), HIPDNN_STATUS_BAD_PARAM);
+    EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(false));
+    ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   1,
+                                                   &_mock_engine_config_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
 
-//     set_handle();
-//     set_engine_config();
+    EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(true));
+    plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                        1,
+                        &_mock_engine_config_wrapper);
+}
 
-//     ASSERT_NO_THROW(plan->finalize());
+TEST_F(Execution_plan_descriptor_test, FinalizeExecutionPlanDescriptor)
+{
+    auto plan = get_execution_plan_descriptor();
+    ASSERT_THROW_HIPDNN_STATUS(plan->finalize(), HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW(plan->finalize(), hipdnn_backend::Hipdnn_exception);
-// }
+    set_handle();
+    set_engine_config();
 
-// TEST_F(Execution_plan_descriptor_test, GetAttrOnUnfinalizedExecutionPlanDescriptor)
-// {
-//     auto plan = get_execution_plan_descriptor();
-//     uint64_t dummy_workspace_size;
+    ASSERT_NO_THROW(plan->finalize());
 
-//     ASSERT_THROW_HIPDNN_STATUS(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE,
-//                                                    HIPDNN_TYPE_INT64,
-//                                                    1,
-//                                                    nullptr,
-//                                                    &dummy_workspace_size),
-//                                HIPDNN_STATUS_NOT_INITIALIZED);
-// }
+    ASSERT_THROW(plan->finalize(), hipdnn_backend::Hipdnn_exception);
+}
 
-// TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorWorkspaceSize)
-// {
-//     auto plan = get_execution_plan_descriptor();
-//     auto mock_engine_config = get_mock_engine_config();
-//     int64_t workspace_size = 0;
+TEST_F(Execution_plan_descriptor_test, GetAttrOnUnfinalizedExecutionPlanDescriptor)
+{
+    auto plan = get_execution_plan_descriptor();
+    uint64_t dummy_workspace_size;
 
-//     make_execution_plan_finalized();
-//     EXPECT_CALL(*mock_engine_config, get_attribute(_, _, _, _, _)).WillOnce(SetArg4ToInt64(1024));
-//     plan->get_attribute(
-//         HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, nullptr, &workspace_size);
-//     ASSERT_EQ(workspace_size, 1024);
-// }
+    ASSERT_THROW_HIPDNN_STATUS(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE,
+                                                   HIPDNN_TYPE_INT64,
+                                                   1,
+                                                   nullptr,
+                                                   &dummy_workspace_size),
+                               HIPDNN_STATUS_NOT_INITIALIZED);
+}
 
-// TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorEngineConfig)
-// {
-//     auto plan = get_execution_plan_descriptor();
+TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorWorkspaceSize)
+{
+    auto plan = get_execution_plan_descriptor();
+    auto mock_engine_config = get_mock_engine_config();
+    int64_t workspace_size = 0;
 
-//     Scoped_descriptor returned_engine_config;
-//     Scoped_descriptor null_count_engine_config;
-//     int64_t count = 0;
+    make_execution_plan_finalized();
+    EXPECT_CALL(*mock_engine_config, get_attribute(_, _, _, _, _)).WillOnce(SetArg4ToInt64(1024));
+    plan->get_attribute(
+        HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, nullptr, &workspace_size);
+    ASSERT_EQ(workspace_size, 1024);
+}
 
-//     make_execution_plan_finalized();
+TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorEngineConfig)
+{
+    auto plan = get_execution_plan_descriptor();
 
-//     ASSERT_NO_THROW(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-//                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                         1,
-//                                         &count,
-//                                         returned_engine_config.get_ptr()));
+    Scoped_descriptor returned_engine_config;
+    Scoped_descriptor null_count_engine_config;
+    int64_t count = 0;
 
-//     ASSERT_EQ(count, 1);
-//     ASSERT_EQ(returned_engine_config.get()->private_descriptor,
-//               _mock_engine_config_wrapper->private_descriptor);
+    make_execution_plan_finalized();
 
-//     ASSERT_NO_THROW(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-//                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                         1,
-//                                         nullptr,
-//                                         null_count_engine_config.get_ptr()));
+    ASSERT_NO_THROW(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &count,
+                                        returned_engine_config.get_ptr()));
 
-//     ASSERT_EQ(null_count_engine_config.get()->private_descriptor,
-//               _mock_engine_config_wrapper->private_descriptor);
-// }
+    ASSERT_EQ(count, 1);
+    ASSERT_EQ(returned_engine_config.get()->impl, _mock_engine_config_wrapper->impl);
 
-// TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorEngineConfigErrors)
-// {
-//     auto plan = get_execution_plan_descriptor();
-//     hipdnnBackendDescriptor_t returned_engine_config = nullptr;
-//     int64_t count = 0;
-//     void* dummy = &returned_engine_config;
+    ASSERT_NO_THROW(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        nullptr,
+                                        null_count_engine_config.get_ptr()));
 
-//     make_execution_plan_finalized();
+    ASSERT_EQ(null_count_engine_config.get()->impl, _mock_engine_config_wrapper->impl);
+}
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         plan->get_attribute(
-//             HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG, HIPDNN_TYPE_INT64, 1, &count, &dummy),
-//         HIPDNN_STATUS_BAD_PARAM);
+TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorEngineConfigErrors)
+{
+    auto plan = get_execution_plan_descriptor();
+    hipdnnBackendDescriptor_t returned_engine_config = nullptr;
+    int64_t count = 0;
+    void* dummy = &returned_engine_config;
 
-//     ASSERT_THROW_HIPDNN_STATUS(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-//                                                    0, // Too small (needs to be at least 1)
-//                                                    &count,
-//                                                    &dummy),
-//                                HIPDNN_STATUS_BAD_PARAM);
-// }
+    make_execution_plan_finalized();
 
-// TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorUnsupportedAttr)
-// {
-//     auto plan = get_execution_plan_descriptor();
-//     int64_t count = 0;
-//     std::array<char, 256> dummy_buffer{};
+    ASSERT_THROW_HIPDNN_STATUS(
+        plan->get_attribute(
+            HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG, HIPDNN_TYPE_INT64, 1, &count, &dummy),
+        HIPDNN_STATUS_BAD_PARAM);
 
-//     make_execution_plan_finalized();
+    ASSERT_THROW_HIPDNN_STATUS(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   0, // Too small (needs to be at least 1)
+                                                   &count,
+                                                   &dummy),
+                               HIPDNN_STATUS_BAD_PARAM);
+}
 
-//     ASSERT_THROW_HIPDNN_STATUS(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_KERNEL_CACHE,
-//                                                    HIPDNN_TYPE_INT64,
-//                                                    1,
-//                                                    &count,
-//                                                    dummy_buffer.data()),
-//                                HIPDNN_STATUS_NOT_SUPPORTED);
-// }
+TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorUnsupportedAttr)
+{
+    auto plan = get_execution_plan_descriptor();
+    int64_t count = 0;
+    std::array<char, 256> dummy_buffer{};
 
-// TEST_F(Execution_plan_descriptor_test, GetEngineConfigThrowsIfNotFinalized)
-// {
-//     auto plan = get_execution_plan_descriptor();
-//     ASSERT_THROW_HIPDNN_STATUS(plan->get_engine_config(), HIPDNN_STATUS_INTERNAL_ERROR);
-// }
+    make_execution_plan_finalized();
 
-// TEST_F(Execution_plan_descriptor_test, GetEngineConfigReturnsPointerIfFinalized)
-// {
-//     auto plan = get_execution_plan_descriptor();
-//     make_execution_plan_finalized();
-//     auto engine_config_ptr = plan->get_engine_config();
-//     ASSERT_NE(engine_config_ptr, nullptr);
-//     ASSERT_EQ(static_cast<const hipdnnBackendDescriptorImpl*>(engine_config_ptr.get()),
-//               static_cast<const hipdnnBackendDescriptorImpl*>(get_mock_engine_config()));
-// }
-// // NOLINTEND(readability-function-cognitive-complexity)
+    ASSERT_THROW_HIPDNN_STATUS(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_KERNEL_CACHE,
+                                                   HIPDNN_TYPE_INT64,
+                                                   1,
+                                                   &count,
+                                                   dummy_buffer.data()),
+                               HIPDNN_STATUS_NOT_SUPPORTED);
+}
+
+TEST_F(Execution_plan_descriptor_test, GetEngineConfigThrowsIfNotFinalized)
+{
+    auto plan = get_execution_plan_descriptor();
+    ASSERT_THROW_HIPDNN_STATUS(plan->get_engine_config(), HIPDNN_STATUS_INTERNAL_ERROR);
+}
+
+TEST_F(Execution_plan_descriptor_test, GetEngineConfigReturnsPointerIfFinalized)
+{
+    auto plan = get_execution_plan_descriptor();
+    make_execution_plan_finalized();
+    auto engine_config_ptr = plan->get_engine_config();
+    ASSERT_NE(engine_config_ptr, nullptr);
+    ASSERT_EQ(static_cast<const Backend_descriptor_interface*>(engine_config_ptr.get()),
+              static_cast<const Backend_descriptor_interface*>(get_mock_engine_config()));
+}
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/backend/tests/descriptors/test_execution_plan_descriptor.cpp
+++ b/backend/tests/descriptors/test_execution_plan_descriptor.cpp
@@ -31,32 +31,38 @@ public:
     std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_config_bad_type_wrapper = nullptr;
     std::unique_ptr<hipdnnBackendDescriptor> _mock_wrong_type_wrapper = nullptr;
 
-    Execution_plan_descriptor* get_execution_plan_descriptor() const
+    std::shared_ptr<Execution_plan_descriptor> get_execution_plan_descriptor() const
     {
-        return dynamic_cast<Execution_plan_descriptor*>(_plan_wrapper->impl.get());
+        return _plan_wrapper->as_descriptor<Execution_plan_descriptor>();
     }
 
-    Mock_descriptor<Engine_config_descriptor>* get_mock_engine_config() const
+    std::shared_ptr<Mock_descriptor<Engine_config_descriptor>> get_mock_engine_config() const
     {
-        return unpack_mock_descriptor<Engine_config_descriptor>(_mock_engine_config_wrapper.get());
+        return _mock_engine_config_wrapper
+            ->as_descriptor<Mock_descriptor<Engine_config_descriptor>>();
     }
 
-    Mock_descriptor<Engine_config_descriptor>* get_mock_engine_config_bad_type() const
+    std::shared_ptr<Mock_descriptor<Engine_config_descriptor>>
+        get_mock_engine_config_bad_type() const
     {
-        return unpack_mock_descriptor<Engine_config_descriptor>(_mock_engine_config_bad_type_wrapper.get());
+        return _mock_engine_config_bad_type_wrapper
+            ->as_descriptor<Mock_descriptor<Engine_config_descriptor>>();
     }
 
-    Mock_descriptor<Execution_plan_descriptor>* get_mock_wrong_type() const
+    std::shared_ptr<Mock_descriptor<Execution_plan_descriptor>> get_mock_wrong_type() const
     {
-        return unpack_mock_descriptor<Execution_plan_descriptor>(_mock_wrong_type_wrapper.get());
+        return _mock_wrong_type_wrapper
+            ->as_descriptor<Mock_descriptor<Execution_plan_descriptor>>();
     }
 
     void SetUp() override
     {
         _plan_wrapper = create_descriptor<Execution_plan_descriptor>();
-        _mock_engine_config_wrapper = make_mock_descriptor_wrapper<Engine_config_descriptor>();
-        _mock_engine_config_bad_type_wrapper = make_mock_descriptor_wrapper<Engine_config_descriptor>();
-        _mock_wrong_type_wrapper = make_mock_descriptor_wrapper<Execution_plan_descriptor>();
+        _mock_engine_config_wrapper
+            = create_descriptor<Mock_descriptor<Engine_config_descriptor>>();
+        _mock_engine_config_bad_type_wrapper
+            = create_descriptor<Mock_descriptor<Engine_config_descriptor>>();
+        _mock_wrong_type_wrapper = create_descriptor<Mock_descriptor<Execution_plan_descriptor>>();
     }
 
     void TearDown() override
@@ -256,7 +262,7 @@ TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorEngineConfig)
                                         returned_engine_config.get_ptr()));
 
     ASSERT_EQ(count, 1);
-    ASSERT_EQ(returned_engine_config.get()->impl, _mock_engine_config_wrapper->impl);
+    ASSERT_EQ(*returned_engine_config.get(), *(_mock_engine_config_wrapper.get()));
 
     ASSERT_NO_THROW(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
@@ -264,7 +270,7 @@ TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorEngineConfig)
                                         nullptr,
                                         null_count_engine_config.get_ptr()));
 
-    ASSERT_EQ(null_count_engine_config.get()->impl, _mock_engine_config_wrapper->impl);
+    ASSERT_EQ(*null_count_engine_config.get(), *(_mock_engine_config_wrapper.get()));
 }
 
 TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorEngineConfigErrors)
@@ -318,6 +324,6 @@ TEST_F(Execution_plan_descriptor_test, GetEngineConfigReturnsPointerIfFinalized)
     auto engine_config_ptr = plan->get_engine_config();
     ASSERT_NE(engine_config_ptr, nullptr);
     ASSERT_EQ(static_cast<const Backend_descriptor_interface*>(engine_config_ptr.get()),
-              static_cast<const Backend_descriptor_interface*>(get_mock_engine_config()));
+              static_cast<const Backend_descriptor_interface*>(get_mock_engine_config().get()));
 }
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/backend/tests/descriptors/test_execution_plan_descriptor.cpp
+++ b/backend/tests/descriptors/test_execution_plan_descriptor.cpp
@@ -1,312 +1,312 @@
-// Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier: MIT
+// // Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// // SPDX-License-Identifier: MIT
 
-#include "descriptors/engine_config_descriptor.hpp"
-#include "descriptors/execution_plan_descriptor.hpp"
-#include "descriptors/scoped_descriptor.hpp"
-#include "hipdnn_backend.h"
-#include "hipdnn_exception.hpp"
-#include "mocks/mock_descriptor.hpp"
-#include "test_descriptor_utils.hpp"
-#include "test_macros.hpp"
+// #include "descriptors/engine_config_descriptor.hpp"
+// #include "descriptors/execution_plan_descriptor.hpp"
+// #include "descriptors/scoped_descriptor.hpp"
+// #include "hipdnn_backend.h"
+// #include "hipdnn_exception.hpp"
+// #include "mocks/mock_descriptor.hpp"
+// #include "test_descriptor_utils.hpp"
+// #include "test_macros.hpp"
 
-#include <gtest/gtest.h>
+// #include <gtest/gtest.h>
 
-#include <array>
-#include <memory>
+// #include <array>
+// #include <memory>
 
-using namespace hipdnn_backend;
-using namespace test_descriptor_utils;
+// using namespace hipdnn_backend;
+// using namespace test_descriptor_utils;
 
-using ::testing::_;
-using ::testing::Return;
+// using ::testing::_;
+// using ::testing::Return;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
-class Execution_plan_descriptor_test : public ::testing::Test
-{
-public:
-    std::unique_ptr<hipdnnBackendDescriptor> _plan_wrapper = nullptr;
-    hipdnnHandle_t _handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
-    std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_config_wrapper = nullptr;
-    std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_config_bad_type_wrapper = nullptr;
+// // NOLINTBEGIN(readability-function-cognitive-complexity)
+// class Execution_plan_descriptor_test : public ::testing::Test
+// {
+// public:
+//     std::unique_ptr<hipdnnBackendDescriptor> _plan_wrapper = nullptr;
+//     hipdnnHandle_t _handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
+//     std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_config_wrapper = nullptr;
+//     std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_config_bad_type_wrapper = nullptr;
 
-    Execution_plan_descriptor* get_execution_plan_descriptor() const
-    {
-        return dynamic_cast<Execution_plan_descriptor*>(_plan_wrapper->private_descriptor.get());
-    }
+//     Execution_plan_descriptor* get_execution_plan_descriptor() const
+//     {
+//         return dynamic_cast<Execution_plan_descriptor*>(_plan_wrapper->private_descriptor.get());
+//     }
 
-    Mock_descriptor* get_mock_engine_config() const
-    {
-        return unpack_mock_descriptor(_mock_engine_config_wrapper.get());
-    }
+//     Mock_descriptor* get_mock_engine_config() const
+//     {
+//         return unpack_mock_descriptor(_mock_engine_config_wrapper.get());
+//     }
 
-    Mock_descriptor* get_mock_engine_config_bad_type() const
-    {
-        return unpack_mock_descriptor(_mock_engine_config_bad_type_wrapper.get());
-    }
+//     Mock_descriptor* get_mock_engine_config_bad_type() const
+//     {
+//         return unpack_mock_descriptor(_mock_engine_config_bad_type_wrapper.get());
+//     }
 
-    void SetUp() override
-    {
-        _plan_wrapper = create_descriptor<Execution_plan_descriptor>();
-        _mock_engine_config_wrapper
-            = make_mock_descriptor_wrapper(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR);
-        _mock_engine_config_bad_type_wrapper = make_mock_descriptor_wrapper();
-    }
+//     void SetUp() override
+//     {
+//         _plan_wrapper = create_descriptor<Execution_plan_descriptor>();
+//         _mock_engine_config_wrapper
+//             = make_mock_descriptor_wrapper(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR);
+//         _mock_engine_config_bad_type_wrapper = make_mock_descriptor_wrapper();
+//     }
 
-    void TearDown() override
-    {
-        _plan_wrapper.reset();
-        _mock_engine_config_wrapper.reset();
-        _mock_engine_config_bad_type_wrapper.reset();
-    }
+//     void TearDown() override
+//     {
+//         _plan_wrapper.reset();
+//         _mock_engine_config_wrapper.reset();
+//         _mock_engine_config_bad_type_wrapper.reset();
+//     }
 
-    void make_execution_plan_finalized()
-    {
-        ASSERT_NO_THROW(set_handle());
-        ASSERT_NO_THROW(set_engine_config());
+//     void make_execution_plan_finalized()
+//     {
+//         ASSERT_NO_THROW(set_handle());
+//         ASSERT_NO_THROW(set_engine_config());
 
-        auto plan = get_execution_plan_descriptor();
-        ASSERT_NO_THROW(plan->finalize());
-    }
+//         auto plan = get_execution_plan_descriptor();
+//         ASSERT_NO_THROW(plan->finalize());
+//     }
 
-    void set_handle()
-    {
-        auto plan = get_execution_plan_descriptor();
-        plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle);
-    }
+//     void set_handle()
+//     {
+//         auto plan = get_execution_plan_descriptor();
+//         plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle);
+//     }
 
-    void set_engine_config()
-    {
-        auto plan = get_execution_plan_descriptor();
-        auto mock_engine_config = get_mock_engine_config();
-        EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(true));
-        plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                            HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                            1,
-                            &_mock_engine_config_wrapper);
-    }
-};
+//     void set_engine_config()
+//     {
+//         auto plan = get_execution_plan_descriptor();
+//         auto mock_engine_config = get_mock_engine_config();
+//         EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(true));
+//         plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+//                             HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                             1,
+//                             &_mock_engine_config_wrapper);
+//     }
+// };
 
-TEST_F(Execution_plan_descriptor_test, CreateExecutionPlanDescriptor)
-{
-    auto plan = get_execution_plan_descriptor();
-    ASSERT_NE(plan, nullptr);
-    ASSERT_FALSE(plan->is_finalized());
-    ASSERT_EQ(plan->type, HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR);
-}
+// TEST_F(Execution_plan_descriptor_test, CreateExecutionPlanDescriptor)
+// {
+//     auto plan = get_execution_plan_descriptor();
+//     ASSERT_NE(plan, nullptr);
+//     ASSERT_FALSE(plan->is_finalized());
+//     ASSERT_EQ(plan->type, HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR);
+// }
 
-TEST_F(Execution_plan_descriptor_test, SetAttrOnUnfinalizedExecutionPlanDescriptor)
-{
-    auto plan = get_execution_plan_descriptor();
-    uint64_t dummy_workspace_size;
+// TEST_F(Execution_plan_descriptor_test, SetAttrOnUnfinalizedExecutionPlanDescriptor)
+// {
+//     auto plan = get_execution_plan_descriptor();
+//     uint64_t dummy_workspace_size;
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        plan->set_attribute(
-            HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, &dummy_workspace_size),
-        HIPDNN_STATUS_NOT_SUPPORTED);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         plan->set_attribute(
+//             HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, &dummy_workspace_size),
+//         HIPDNN_STATUS_NOT_SUPPORTED);
 
-    make_execution_plan_finalized();
+//     make_execution_plan_finalized();
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        plan->set_attribute(
-            HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, &dummy_workspace_size),
-        HIPDNN_STATUS_NOT_INITIALIZED);
-}
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         plan->set_attribute(
+//             HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, &dummy_workspace_size),
+//         HIPDNN_STATUS_NOT_INITIALIZED);
+// }
 
-TEST_F(Execution_plan_descriptor_test, SetExecutionPlanDescriptorHandle)
-{
-    auto plan = get_execution_plan_descriptor();
-    hipdnnHandle_t handle = nullptr;
+// TEST_F(Execution_plan_descriptor_test, SetExecutionPlanDescriptorHandle)
+// {
+//     auto plan = get_execution_plan_descriptor();
+//     hipdnnHandle_t handle = nullptr;
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_INT64, 1, &handle),
-        HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_INT64, 1, &handle),
+//         HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 2, &handle),
-        HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 2, &handle),
+//         HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, nullptr),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, nullptr),
+//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
-    plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
-}
+//     handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
+//     plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+// }
 
-TEST_F(Execution_plan_descriptor_test, SetExecutionPlanDescriptorEngineConfig)
-{
-    auto plan = get_execution_plan_descriptor();
-    auto mock_engine_config = get_mock_engine_config();
+// TEST_F(Execution_plan_descriptor_test, SetExecutionPlanDescriptorEngineConfig)
+// {
+//     auto plan = get_execution_plan_descriptor();
+//     auto mock_engine_config = get_mock_engine_config();
 
-    ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                                                   HIPDNN_TYPE_HANDLE,
-                                                   1,
-                                                   &_mock_engine_config_wrapper),
-                               HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+//                                                    HIPDNN_TYPE_HANDLE,
+//                                                    1,
+//                                                    &_mock_engine_config_wrapper),
+//                                HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   2,
-                                                   &_mock_engine_config_wrapper),
-                               HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                    2,
+//                                                    &_mock_engine_config_wrapper),
+//                                HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        plan->set_attribute(
-            HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         plan->set_attribute(
+//             HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr),
+//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    hipdnnBackendDescriptor_t engine_config = nullptr;
-    ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   1,
-                                                   &engine_config),
-                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+//     hipdnnBackendDescriptor_t engine_config = nullptr;
+//     ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                    1,
+//                                                    &engine_config),
+//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   1,
-                                                   &_mock_engine_config_bad_type_wrapper),
-                               HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                    1,
+//                                                    &_mock_engine_config_bad_type_wrapper),
+//                                HIPDNN_STATUS_BAD_PARAM);
 
-    EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(false));
-    ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   1,
-                                                   &_mock_engine_config_wrapper),
-                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+//     EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(false));
+//     ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                    1,
+//                                                    &_mock_engine_config_wrapper),
+//                                HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
 
-    EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(true));
-    plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                        1,
-                        &_mock_engine_config_wrapper);
-}
+//     EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(true));
+//     plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+//                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                         1,
+//                         &_mock_engine_config_wrapper);
+// }
 
-TEST_F(Execution_plan_descriptor_test, FinalizeExecutionPlanDescriptor)
-{
-    auto plan = get_execution_plan_descriptor();
-    ASSERT_THROW_HIPDNN_STATUS(plan->finalize(), HIPDNN_STATUS_BAD_PARAM);
+// TEST_F(Execution_plan_descriptor_test, FinalizeExecutionPlanDescriptor)
+// {
+//     auto plan = get_execution_plan_descriptor();
+//     ASSERT_THROW_HIPDNN_STATUS(plan->finalize(), HIPDNN_STATUS_BAD_PARAM);
 
-    set_handle();
-    set_engine_config();
+//     set_handle();
+//     set_engine_config();
 
-    ASSERT_NO_THROW(plan->finalize());
+//     ASSERT_NO_THROW(plan->finalize());
 
-    ASSERT_THROW(plan->finalize(), hipdnn_backend::Hipdnn_exception);
-}
+//     ASSERT_THROW(plan->finalize(), hipdnn_backend::Hipdnn_exception);
+// }
 
-TEST_F(Execution_plan_descriptor_test, GetAttrOnUnfinalizedExecutionPlanDescriptor)
-{
-    auto plan = get_execution_plan_descriptor();
-    uint64_t dummy_workspace_size;
+// TEST_F(Execution_plan_descriptor_test, GetAttrOnUnfinalizedExecutionPlanDescriptor)
+// {
+//     auto plan = get_execution_plan_descriptor();
+//     uint64_t dummy_workspace_size;
 
-    ASSERT_THROW_HIPDNN_STATUS(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE,
-                                                   HIPDNN_TYPE_INT64,
-                                                   1,
-                                                   nullptr,
-                                                   &dummy_workspace_size),
-                               HIPDNN_STATUS_NOT_INITIALIZED);
-}
+//     ASSERT_THROW_HIPDNN_STATUS(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE,
+//                                                    HIPDNN_TYPE_INT64,
+//                                                    1,
+//                                                    nullptr,
+//                                                    &dummy_workspace_size),
+//                                HIPDNN_STATUS_NOT_INITIALIZED);
+// }
 
-TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorWorkspaceSize)
-{
-    auto plan = get_execution_plan_descriptor();
-    auto mock_engine_config = get_mock_engine_config();
-    int64_t workspace_size = 0;
+// TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorWorkspaceSize)
+// {
+//     auto plan = get_execution_plan_descriptor();
+//     auto mock_engine_config = get_mock_engine_config();
+//     int64_t workspace_size = 0;
 
-    make_execution_plan_finalized();
-    EXPECT_CALL(*mock_engine_config, get_attribute(_, _, _, _, _)).WillOnce(SetArg4ToInt64(1024));
-    plan->get_attribute(
-        HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, nullptr, &workspace_size);
-    ASSERT_EQ(workspace_size, 1024);
-}
+//     make_execution_plan_finalized();
+//     EXPECT_CALL(*mock_engine_config, get_attribute(_, _, _, _, _)).WillOnce(SetArg4ToInt64(1024));
+//     plan->get_attribute(
+//         HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, nullptr, &workspace_size);
+//     ASSERT_EQ(workspace_size, 1024);
+// }
 
-TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorEngineConfig)
-{
-    auto plan = get_execution_plan_descriptor();
+// TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorEngineConfig)
+// {
+//     auto plan = get_execution_plan_descriptor();
 
-    Scoped_descriptor returned_engine_config;
-    Scoped_descriptor null_count_engine_config;
-    int64_t count = 0;
+//     Scoped_descriptor returned_engine_config;
+//     Scoped_descriptor null_count_engine_config;
+//     int64_t count = 0;
 
-    make_execution_plan_finalized();
+//     make_execution_plan_finalized();
 
-    ASSERT_NO_THROW(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                        1,
-                                        &count,
-                                        returned_engine_config.get_ptr()));
+//     ASSERT_NO_THROW(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+//                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                         1,
+//                                         &count,
+//                                         returned_engine_config.get_ptr()));
 
-    ASSERT_EQ(count, 1);
-    ASSERT_EQ(returned_engine_config.get()->private_descriptor,
-              _mock_engine_config_wrapper->private_descriptor);
+//     ASSERT_EQ(count, 1);
+//     ASSERT_EQ(returned_engine_config.get()->private_descriptor,
+//               _mock_engine_config_wrapper->private_descriptor);
 
-    ASSERT_NO_THROW(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                        1,
-                                        nullptr,
-                                        null_count_engine_config.get_ptr()));
+//     ASSERT_NO_THROW(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+//                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                         1,
+//                                         nullptr,
+//                                         null_count_engine_config.get_ptr()));
 
-    ASSERT_EQ(null_count_engine_config.get()->private_descriptor,
-              _mock_engine_config_wrapper->private_descriptor);
-}
+//     ASSERT_EQ(null_count_engine_config.get()->private_descriptor,
+//               _mock_engine_config_wrapper->private_descriptor);
+// }
 
-TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorEngineConfigErrors)
-{
-    auto plan = get_execution_plan_descriptor();
-    hipdnnBackendDescriptor_t returned_engine_config = nullptr;
-    int64_t count = 0;
-    void* dummy = &returned_engine_config;
+// TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorEngineConfigErrors)
+// {
+//     auto plan = get_execution_plan_descriptor();
+//     hipdnnBackendDescriptor_t returned_engine_config = nullptr;
+//     int64_t count = 0;
+//     void* dummy = &returned_engine_config;
 
-    make_execution_plan_finalized();
+//     make_execution_plan_finalized();
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        plan->get_attribute(
-            HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG, HIPDNN_TYPE_INT64, 1, &count, &dummy),
-        HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         plan->get_attribute(
+//             HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG, HIPDNN_TYPE_INT64, 1, &count, &dummy),
+//         HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   0, // Too small (needs to be at least 1)
-                                                   &count,
-                                                   &dummy),
-                               HIPDNN_STATUS_BAD_PARAM);
-}
+//     ASSERT_THROW_HIPDNN_STATUS(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+//                                                    HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+//                                                    0, // Too small (needs to be at least 1)
+//                                                    &count,
+//                                                    &dummy),
+//                                HIPDNN_STATUS_BAD_PARAM);
+// }
 
-TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorUnsupportedAttr)
-{
-    auto plan = get_execution_plan_descriptor();
-    int64_t count = 0;
-    std::array<char, 256> dummy_buffer{};
+// TEST_F(Execution_plan_descriptor_test, GetExecutionPlanDescriptorUnsupportedAttr)
+// {
+//     auto plan = get_execution_plan_descriptor();
+//     int64_t count = 0;
+//     std::array<char, 256> dummy_buffer{};
 
-    make_execution_plan_finalized();
+//     make_execution_plan_finalized();
 
-    ASSERT_THROW_HIPDNN_STATUS(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_KERNEL_CACHE,
-                                                   HIPDNN_TYPE_INT64,
-                                                   1,
-                                                   &count,
-                                                   dummy_buffer.data()),
-                               HIPDNN_STATUS_NOT_SUPPORTED);
-}
+//     ASSERT_THROW_HIPDNN_STATUS(plan->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_KERNEL_CACHE,
+//                                                    HIPDNN_TYPE_INT64,
+//                                                    1,
+//                                                    &count,
+//                                                    dummy_buffer.data()),
+//                                HIPDNN_STATUS_NOT_SUPPORTED);
+// }
 
-TEST_F(Execution_plan_descriptor_test, GetEngineConfigThrowsIfNotFinalized)
-{
-    auto plan = get_execution_plan_descriptor();
-    ASSERT_THROW_HIPDNN_STATUS(plan->get_engine_config(), HIPDNN_STATUS_INTERNAL_ERROR);
-}
+// TEST_F(Execution_plan_descriptor_test, GetEngineConfigThrowsIfNotFinalized)
+// {
+//     auto plan = get_execution_plan_descriptor();
+//     ASSERT_THROW_HIPDNN_STATUS(plan->get_engine_config(), HIPDNN_STATUS_INTERNAL_ERROR);
+// }
 
-TEST_F(Execution_plan_descriptor_test, GetEngineConfigReturnsPointerIfFinalized)
-{
-    auto plan = get_execution_plan_descriptor();
-    make_execution_plan_finalized();
-    auto engine_config_ptr = plan->get_engine_config();
-    ASSERT_NE(engine_config_ptr, nullptr);
-    ASSERT_EQ(static_cast<const hipdnnPrivateBackendDescriptor*>(engine_config_ptr.get()),
-              static_cast<const hipdnnPrivateBackendDescriptor*>(get_mock_engine_config()));
-}
-// NOLINTEND(readability-function-cognitive-complexity)
+// TEST_F(Execution_plan_descriptor_test, GetEngineConfigReturnsPointerIfFinalized)
+// {
+//     auto plan = get_execution_plan_descriptor();
+//     make_execution_plan_finalized();
+//     auto engine_config_ptr = plan->get_engine_config();
+//     ASSERT_NE(engine_config_ptr, nullptr);
+//     ASSERT_EQ(static_cast<const hipdnnBackendDescriptorImpl*>(engine_config_ptr.get()),
+//               static_cast<const hipdnnBackendDescriptorImpl*>(get_mock_engine_config()));
+// }
+// // NOLINTEND(readability-function-cognitive-complexity)

--- a/backend/tests/descriptors/test_graph_descriptor.cpp
+++ b/backend/tests/descriptors/test_graph_descriptor.cpp
@@ -1,110 +1,110 @@
-// // Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// // SPDX-License-Identifier: MIT
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
-// #include "descriptors/graph_descriptor.hpp"
-// #include "flatbuffer_test_utils.hpp"
-// #include "flatbuffer_utilities.hpp"
-// #include "hipdnn_backend.h"
-// #include "hipdnn_exception.hpp"
-// #include "test_macros.hpp"
+#include "descriptors/graph_descriptor.hpp"
+#include "flatbuffer_test_utils.hpp"
+#include "flatbuffer_utilities.hpp"
+#include "hipdnn_backend.h"
+#include "hipdnn_exception.hpp"
+#include "test_macros.hpp"
 
-// #include <flatbuffers/flatbuffers.h>
-// #include <gtest/gtest.h>
-// #include <hipdnn_sdk/data_objects/graph_generated.h>
+#include <flatbuffers/flatbuffers.h>
+#include <gtest/gtest.h>
+#include <hipdnn_sdk/data_objects/graph_generated.h>
 
-// using namespace hipdnn_backend;
+using namespace hipdnn_backend;
 
-// class Graph_descriptor_test : public ::testing::Test
-// {
-// public:
-//     static flatbuffers::FlatBufferBuilder create_valid_graph()
-//     {
-//         return flatbuffer_test_utils::create_valid_graph();
-//     }
+class Graph_descriptor_test : public ::testing::Test
+{
+public:
+    static flatbuffers::FlatBufferBuilder create_valid_graph()
+    {
+        return flatbuffer_test_utils::create_valid_graph();
+    }
 
-//     static void verify_graph(const hipdnn_sdk::data_objects::GraphT& graph)
-//     {
-//         EXPECT_EQ(graph.name, "test");
-//         EXPECT_EQ(graph.compute_type, hipdnn_sdk::data_objects::DataType_FLOAT);
-//         EXPECT_EQ(graph.intermediate_type, hipdnn_sdk::data_objects::DataType_HALF);
-//         EXPECT_EQ(graph.io_type, hipdnn_sdk::data_objects::DataType_BFLOAT16);
-//         EXPECT_EQ(graph.tensors.size(), 0);
-//         EXPECT_EQ(graph.nodes.size(), 0);
-//     }
-// };
+    static void verify_graph(const hipdnn_sdk::data_objects::GraphT& graph)
+    {
+        EXPECT_EQ(graph.name, "test");
+        EXPECT_EQ(graph.compute_type, hipdnn_sdk::data_objects::DataType_FLOAT);
+        EXPECT_EQ(graph.intermediate_type, hipdnn_sdk::data_objects::DataType_HALF);
+        EXPECT_EQ(graph.io_type, hipdnn_sdk::data_objects::DataType_BFLOAT16);
+        EXPECT_EQ(graph.tensors.size(), 0);
+        EXPECT_EQ(graph.nodes.size(), 0);
+    }
+};
 
-// TEST_F(Graph_descriptor_test, SerializeDeserializeGraph)
-// {
-//     auto builder = create_valid_graph();
-//     auto serialized_graph = builder.Release();
+TEST_F(Graph_descriptor_test, SerializeDeserializeGraph)
+{
+    auto builder = create_valid_graph();
+    auto serialized_graph = builder.Release();
 
-//     Graph_descriptor descriptor;
-//     descriptor.deserialize_graph(serialized_graph.data(), serialized_graph.size());
+    Graph_descriptor descriptor;
+    descriptor.deserialize_graph(serialized_graph.data(), serialized_graph.size());
 
-//     const auto& output = descriptor.get_serialized_graph();
-//     flatbuffers::Verifier verifier(output.data(), output.size());
-//     ASSERT_TRUE(verifier.VerifyBuffer<hipdnn_sdk::data_objects::Graph>());
-// }
+    const auto& output = descriptor.get_serialized_graph();
+    flatbuffers::Verifier verifier(output.data(), output.size());
+    ASSERT_TRUE(verifier.VerifyBuffer<hipdnn_sdk::data_objects::Graph>());
+}
 
-// TEST_F(Graph_descriptor_test, WillCorrectlySetGraph)
-// {
-//     auto builder = create_valid_graph();
-//     auto serialized_graph = builder.Release();
+TEST_F(Graph_descriptor_test, WillCorrectlySetGraph)
+{
+    auto builder = create_valid_graph();
+    auto serialized_graph = builder.Release();
 
-//     Graph_descriptor descriptor;
-//     ASSERT_NO_THROW(descriptor.deserialize_graph(serialized_graph.data(), serialized_graph.size()));
+    Graph_descriptor descriptor;
+    ASSERT_NO_THROW(descriptor.deserialize_graph(serialized_graph.data(), serialized_graph.size()));
 
-//     ASSERT_THROW_HIPDNN_STATUS(descriptor.finalize(), HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(descriptor.finalize(), HIPDNN_STATUS_BAD_PARAM);
 
-//     auto handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
-//     ASSERT_NO_THROW(descriptor.set_attribute(
-//         HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle));
-//     ASSERT_NO_THROW(descriptor.finalize());
-// }
+    auto handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
+    ASSERT_NO_THROW(descriptor.set_attribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle));
+    ASSERT_NO_THROW(descriptor.finalize());
+}
 
-// TEST_F(Graph_descriptor_test, WillCorrectlySetGraphReverseOrder)
-// {
-//     auto builder = create_valid_graph();
-//     auto serialized_graph = builder.Release();
+TEST_F(Graph_descriptor_test, WillCorrectlySetGraphReverseOrder)
+{
+    auto builder = create_valid_graph();
+    auto serialized_graph = builder.Release();
 
-//     Graph_descriptor descriptor;
-//     auto handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
-//     ASSERT_NO_THROW(descriptor.set_attribute(
-//         HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle));
+    Graph_descriptor descriptor;
+    auto handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
+    ASSERT_NO_THROW(descriptor.set_attribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle));
 
-//     ASSERT_THROW_HIPDNN_STATUS(descriptor.finalize(), HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(descriptor.finalize(), HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_NO_THROW(descriptor.deserialize_graph(serialized_graph.data(), serialized_graph.size()));
-//     ASSERT_NO_THROW(descriptor.finalize());
-// }
+    ASSERT_NO_THROW(descriptor.deserialize_graph(serialized_graph.data(), serialized_graph.size()));
+    ASSERT_NO_THROW(descriptor.finalize());
+}
 
-// TEST_F(Graph_descriptor_test, WillFailToSetInvalidGraph)
-// {
-//     Graph_descriptor descriptor;
-//     ASSERT_THROW_HIPDNN_STATUS(descriptor.deserialize_graph(nullptr, 0),
-//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-// }
+TEST_F(Graph_descriptor_test, WillFailToSetInvalidGraph)
+{
+    Graph_descriptor descriptor;
+    ASSERT_THROW_HIPDNN_STATUS(descriptor.deserialize_graph(nullptr, 0),
+                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+}
 
-// TEST_F(Graph_descriptor_test, FinalizeFailInvalidGraph)
-// {
-//     Graph_descriptor descriptor;
-//     ASSERT_THROW_HIPDNN_STATUS(descriptor.finalize(), HIPDNN_STATUS_BAD_PARAM);
-// }
+TEST_F(Graph_descriptor_test, FinalizeFailInvalidGraph)
+{
+    Graph_descriptor descriptor;
+    ASSERT_THROW_HIPDNN_STATUS(descriptor.finalize(), HIPDNN_STATUS_BAD_PARAM);
+}
 
-// TEST_F(Graph_descriptor_test, GetAttributeReturnsNotSupported)
-// {
-//     Graph_descriptor descriptor;
-//     int64_t element_count = 0;
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         descriptor.get_attribute(
-//             HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_DATA_TYPE, 0, &element_count, nullptr),
-//         HIPDNN_STATUS_NOT_SUPPORTED);
-// }
+TEST_F(Graph_descriptor_test, GetAttributeReturnsNotSupported)
+{
+    Graph_descriptor descriptor;
+    int64_t element_count = 0;
+    ASSERT_THROW_HIPDNN_STATUS(
+        descriptor.get_attribute(
+            HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_DATA_TYPE, 0, &element_count, nullptr),
+        HIPDNN_STATUS_NOT_SUPPORTED);
+}
 
-// TEST_F(Graph_descriptor_test, SetAttributeReturnsNotSupported)
-// {
-//     Graph_descriptor descriptor;
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         descriptor.set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_DATA_TYPE, 0, nullptr),
-//         HIPDNN_STATUS_NOT_SUPPORTED);
-// }
+TEST_F(Graph_descriptor_test, SetAttributeReturnsNotSupported)
+{
+    Graph_descriptor descriptor;
+    ASSERT_THROW_HIPDNN_STATUS(
+        descriptor.set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_DATA_TYPE, 0, nullptr),
+        HIPDNN_STATUS_NOT_SUPPORTED);
+}

--- a/backend/tests/descriptors/test_graph_descriptor.cpp
+++ b/backend/tests/descriptors/test_graph_descriptor.cpp
@@ -1,110 +1,110 @@
-// Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier: MIT
+// // Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// // SPDX-License-Identifier: MIT
 
-#include "descriptors/graph_descriptor.hpp"
-#include "flatbuffer_test_utils.hpp"
-#include "flatbuffer_utilities.hpp"
-#include "hipdnn_backend.h"
-#include "hipdnn_exception.hpp"
-#include "test_macros.hpp"
+// #include "descriptors/graph_descriptor.hpp"
+// #include "flatbuffer_test_utils.hpp"
+// #include "flatbuffer_utilities.hpp"
+// #include "hipdnn_backend.h"
+// #include "hipdnn_exception.hpp"
+// #include "test_macros.hpp"
 
-#include <flatbuffers/flatbuffers.h>
-#include <gtest/gtest.h>
-#include <hipdnn_sdk/data_objects/graph_generated.h>
+// #include <flatbuffers/flatbuffers.h>
+// #include <gtest/gtest.h>
+// #include <hipdnn_sdk/data_objects/graph_generated.h>
 
-using namespace hipdnn_backend;
+// using namespace hipdnn_backend;
 
-class Graph_descriptor_test : public ::testing::Test
-{
-public:
-    static flatbuffers::FlatBufferBuilder create_valid_graph()
-    {
-        return flatbuffer_test_utils::create_valid_graph();
-    }
+// class Graph_descriptor_test : public ::testing::Test
+// {
+// public:
+//     static flatbuffers::FlatBufferBuilder create_valid_graph()
+//     {
+//         return flatbuffer_test_utils::create_valid_graph();
+//     }
 
-    static void verify_graph(const hipdnn_sdk::data_objects::GraphT& graph)
-    {
-        EXPECT_EQ(graph.name, "test");
-        EXPECT_EQ(graph.compute_type, hipdnn_sdk::data_objects::DataType_FLOAT);
-        EXPECT_EQ(graph.intermediate_type, hipdnn_sdk::data_objects::DataType_HALF);
-        EXPECT_EQ(graph.io_type, hipdnn_sdk::data_objects::DataType_BFLOAT16);
-        EXPECT_EQ(graph.tensors.size(), 0);
-        EXPECT_EQ(graph.nodes.size(), 0);
-    }
-};
+//     static void verify_graph(const hipdnn_sdk::data_objects::GraphT& graph)
+//     {
+//         EXPECT_EQ(graph.name, "test");
+//         EXPECT_EQ(graph.compute_type, hipdnn_sdk::data_objects::DataType_FLOAT);
+//         EXPECT_EQ(graph.intermediate_type, hipdnn_sdk::data_objects::DataType_HALF);
+//         EXPECT_EQ(graph.io_type, hipdnn_sdk::data_objects::DataType_BFLOAT16);
+//         EXPECT_EQ(graph.tensors.size(), 0);
+//         EXPECT_EQ(graph.nodes.size(), 0);
+//     }
+// };
 
-TEST_F(Graph_descriptor_test, SerializeDeserializeGraph)
-{
-    auto builder = create_valid_graph();
-    auto serialized_graph = builder.Release();
+// TEST_F(Graph_descriptor_test, SerializeDeserializeGraph)
+// {
+//     auto builder = create_valid_graph();
+//     auto serialized_graph = builder.Release();
 
-    Graph_descriptor descriptor;
-    descriptor.deserialize_graph(serialized_graph.data(), serialized_graph.size());
+//     Graph_descriptor descriptor;
+//     descriptor.deserialize_graph(serialized_graph.data(), serialized_graph.size());
 
-    const auto& output = descriptor.get_serialized_graph();
-    flatbuffers::Verifier verifier(output.data(), output.size());
-    ASSERT_TRUE(verifier.VerifyBuffer<hipdnn_sdk::data_objects::Graph>());
-}
+//     const auto& output = descriptor.get_serialized_graph();
+//     flatbuffers::Verifier verifier(output.data(), output.size());
+//     ASSERT_TRUE(verifier.VerifyBuffer<hipdnn_sdk::data_objects::Graph>());
+// }
 
-TEST_F(Graph_descriptor_test, WillCorrectlySetGraph)
-{
-    auto builder = create_valid_graph();
-    auto serialized_graph = builder.Release();
+// TEST_F(Graph_descriptor_test, WillCorrectlySetGraph)
+// {
+//     auto builder = create_valid_graph();
+//     auto serialized_graph = builder.Release();
 
-    Graph_descriptor descriptor;
-    ASSERT_NO_THROW(descriptor.deserialize_graph(serialized_graph.data(), serialized_graph.size()));
+//     Graph_descriptor descriptor;
+//     ASSERT_NO_THROW(descriptor.deserialize_graph(serialized_graph.data(), serialized_graph.size()));
 
-    ASSERT_THROW_HIPDNN_STATUS(descriptor.finalize(), HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(descriptor.finalize(), HIPDNN_STATUS_BAD_PARAM);
 
-    auto handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
-    ASSERT_NO_THROW(descriptor.set_attribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle));
-    ASSERT_NO_THROW(descriptor.finalize());
-}
+//     auto handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
+//     ASSERT_NO_THROW(descriptor.set_attribute(
+//         HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle));
+//     ASSERT_NO_THROW(descriptor.finalize());
+// }
 
-TEST_F(Graph_descriptor_test, WillCorrectlySetGraphReverseOrder)
-{
-    auto builder = create_valid_graph();
-    auto serialized_graph = builder.Release();
+// TEST_F(Graph_descriptor_test, WillCorrectlySetGraphReverseOrder)
+// {
+//     auto builder = create_valid_graph();
+//     auto serialized_graph = builder.Release();
 
-    Graph_descriptor descriptor;
-    auto handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
-    ASSERT_NO_THROW(descriptor.set_attribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle));
+//     Graph_descriptor descriptor;
+//     auto handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
+//     ASSERT_NO_THROW(descriptor.set_attribute(
+//         HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle));
 
-    ASSERT_THROW_HIPDNN_STATUS(descriptor.finalize(), HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(descriptor.finalize(), HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_NO_THROW(descriptor.deserialize_graph(serialized_graph.data(), serialized_graph.size()));
-    ASSERT_NO_THROW(descriptor.finalize());
-}
+//     ASSERT_NO_THROW(descriptor.deserialize_graph(serialized_graph.data(), serialized_graph.size()));
+//     ASSERT_NO_THROW(descriptor.finalize());
+// }
 
-TEST_F(Graph_descriptor_test, WillFailToSetInvalidGraph)
-{
-    Graph_descriptor descriptor;
-    ASSERT_THROW_HIPDNN_STATUS(descriptor.deserialize_graph(nullptr, 0),
-                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-}
+// TEST_F(Graph_descriptor_test, WillFailToSetInvalidGraph)
+// {
+//     Graph_descriptor descriptor;
+//     ASSERT_THROW_HIPDNN_STATUS(descriptor.deserialize_graph(nullptr, 0),
+//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+// }
 
-TEST_F(Graph_descriptor_test, FinalizeFailInvalidGraph)
-{
-    Graph_descriptor descriptor;
-    ASSERT_THROW_HIPDNN_STATUS(descriptor.finalize(), HIPDNN_STATUS_BAD_PARAM);
-}
+// TEST_F(Graph_descriptor_test, FinalizeFailInvalidGraph)
+// {
+//     Graph_descriptor descriptor;
+//     ASSERT_THROW_HIPDNN_STATUS(descriptor.finalize(), HIPDNN_STATUS_BAD_PARAM);
+// }
 
-TEST_F(Graph_descriptor_test, GetAttributeReturnsNotSupported)
-{
-    Graph_descriptor descriptor;
-    int64_t element_count = 0;
-    ASSERT_THROW_HIPDNN_STATUS(
-        descriptor.get_attribute(
-            HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_DATA_TYPE, 0, &element_count, nullptr),
-        HIPDNN_STATUS_NOT_SUPPORTED);
-}
+// TEST_F(Graph_descriptor_test, GetAttributeReturnsNotSupported)
+// {
+//     Graph_descriptor descriptor;
+//     int64_t element_count = 0;
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         descriptor.get_attribute(
+//             HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_DATA_TYPE, 0, &element_count, nullptr),
+//         HIPDNN_STATUS_NOT_SUPPORTED);
+// }
 
-TEST_F(Graph_descriptor_test, SetAttributeReturnsNotSupported)
-{
-    Graph_descriptor descriptor;
-    ASSERT_THROW_HIPDNN_STATUS(
-        descriptor.set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_DATA_TYPE, 0, nullptr),
-        HIPDNN_STATUS_NOT_SUPPORTED);
-}
+// TEST_F(Graph_descriptor_test, SetAttributeReturnsNotSupported)
+// {
+//     Graph_descriptor descriptor;
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         descriptor.set_attribute(HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_DATA_TYPE, 0, nullptr),
+//         HIPDNN_STATUS_NOT_SUPPORTED);
+// }

--- a/backend/tests/descriptors/test_variant_pack.cpp
+++ b/backend/tests/descriptors/test_variant_pack.cpp
@@ -1,267 +1,267 @@
-// Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier:  MIT
+// // Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// // SPDX-License-Identifier:  MIT
 
-#include "descriptors/variant_descriptor.hpp"
-#include "hipdnn_exception.hpp"
-#include "test_macros.hpp"
-#include <gtest/gtest.h>
+// #include "descriptors/variant_descriptor.hpp"
+// #include "hipdnn_exception.hpp"
+// #include "test_macros.hpp"
+// #include <gtest/gtest.h>
 
-namespace hipdnn_backend
-{
+// namespace hipdnn_backend
+// {
 
-class Initialize_variant_pack_descriptor_tests : public ::testing::Test
-{
-protected:
-    Variant_descriptor descriptor;
+// class Initialize_variant_pack_descriptor_tests : public ::testing::Test
+// {
+// protected:
+//     Variant_descriptor descriptor;
 
-    void SetUp() override
-    {
-        ASSERT_FALSE(descriptor.is_finalized());
-    }
-};
+//     void SetUp() override
+//     {
+//         ASSERT_FALSE(descriptor.is_finalized());
+//     }
+// };
 
-TEST_F(Initialize_variant_pack_descriptor_tests, ValidSetAttributes)
-{
-    std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
-                                     reinterpret_cast<void*>(0x5678),
-                                     reinterpret_cast<void*>(0x9abc)};
-    std::array<int64_t, 3> uids = {1, 2, 3};
-    void* workspace = reinterpret_cast<void*>(0xdeadbeef);
+// TEST_F(Initialize_variant_pack_descriptor_tests, ValidSetAttributes)
+// {
+//     std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
+//                                      reinterpret_cast<void*>(0x5678),
+//                                      reinterpret_cast<void*>(0x9abc)};
+//     std::array<int64_t, 3> uids = {1, 2, 3};
+//     void* workspace = reinterpret_cast<void*>(0xdeadbeef);
 
-    descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                             HIPDNN_TYPE_VOID_PTR,
-                             dev_ptrs.size(),
-                             dev_ptrs.data());
+//     descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+//                              HIPDNN_TYPE_VOID_PTR,
+//                              dev_ptrs.size(),
+//                              dev_ptrs.data());
 
-    descriptor.set_attribute(
-        HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
+//     descriptor.set_attribute(
+//         HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
 
-    descriptor.set_attribute(
-        HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
+//     descriptor.set_attribute(
+//         HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
 
-    ASSERT_NO_THROW(descriptor.finalize());
-    EXPECT_TRUE(descriptor.is_finalized());
-}
+//     ASSERT_NO_THROW(descriptor.finalize());
+//     EXPECT_TRUE(descriptor.is_finalized());
+// }
 
-TEST_F(Initialize_variant_pack_descriptor_tests, ValidSetAndGetBeforeFinalAttributes)
-{
-    std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
-                                     reinterpret_cast<void*>(0x5678),
-                                     reinterpret_cast<void*>(0x9abc)};
-    std::array<int64_t, 3> uids = {1, 2, 3};
-    void* workspace = reinterpret_cast<void*>(0xdeadbeef);
+// TEST_F(Initialize_variant_pack_descriptor_tests, ValidSetAndGetBeforeFinalAttributes)
+// {
+//     std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
+//                                      reinterpret_cast<void*>(0x5678),
+//                                      reinterpret_cast<void*>(0x9abc)};
+//     std::array<int64_t, 3> uids = {1, 2, 3};
+//     void* workspace = reinterpret_cast<void*>(0xdeadbeef);
 
-    descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                             HIPDNN_TYPE_VOID_PTR,
-                             dev_ptrs.size(),
-                             dev_ptrs.data());
+//     descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+//                              HIPDNN_TYPE_VOID_PTR,
+//                              dev_ptrs.size(),
+//                              dev_ptrs.data());
 
-    descriptor.set_attribute(
-        HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
+//     descriptor.set_attribute(
+//         HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
 
-    descriptor.set_attribute(
-        HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
-    // getting before finalized
-    std::array<void*, 3> retrieved_dev_ptrs;
-    int64_t element_count = 0;
+//     descriptor.set_attribute(
+//         HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
+//     // getting before finalized
+//     std::array<void*, 3> retrieved_dev_ptrs;
+//     int64_t element_count = 0;
 
-    ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                                                        HIPDNN_TYPE_VOID_PTR,
-                                                        retrieved_dev_ptrs.size(),
-                                                        &element_count,
-                                                        retrieved_dev_ptrs.data()),
-                               HIPDNN_STATUS_NOT_INITIALIZED);
-}
+//     ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+//                                                         HIPDNN_TYPE_VOID_PTR,
+//                                                         retrieved_dev_ptrs.size(),
+//                                                         &element_count,
+//                                                         retrieved_dev_ptrs.data()),
+//                                HIPDNN_STATUS_NOT_INITIALIZED);
+// }
 
-TEST_F(Initialize_variant_pack_descriptor_tests, InvalidSetAttributes)
-{
-    std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
-                                     reinterpret_cast<void*>(0x5678),
-                                     reinterpret_cast<void*>(0x9abc)};
-    std::array<int64_t, 3> uids = {1, 2, 3};
-    void* workspace = reinterpret_cast<void*>(0xdeadbeef);
+// TEST_F(Initialize_variant_pack_descriptor_tests, InvalidSetAttributes)
+// {
+//     std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
+//                                      reinterpret_cast<void*>(0x5678),
+//                                      reinterpret_cast<void*>(0x9abc)};
+//     std::array<int64_t, 3> uids = {1, 2, 3};
+//     void* workspace = reinterpret_cast<void*>(0xdeadbeef);
 
-    ASSERT_THROW_HIPDNN_STATUS(descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                                                        HIPDNN_TYPE_INT64,
-                                                        dev_ptrs.size(),
-                                                        dev_ptrs.data()),
-                               HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+//                                                         HIPDNN_TYPE_INT64,
+//                                                         dev_ptrs.size(),
+//                                                         dev_ptrs.data()),
+//                                HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        descriptor.set_attribute(
-            HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_VOID_PTR, uids.size(), uids.data()),
-        HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         descriptor.set_attribute(
+//             HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_VOID_PTR, uids.size(), uids.data()),
+//         HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        descriptor.set_attribute(
-            HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 2, &workspace),
-        HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         descriptor.set_attribute(
+//             HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 2, &workspace),
+//         HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(
-        descriptor.set_attribute(
-            HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS, HIPDNN_TYPE_VOID_PTR, dev_ptrs.size(), nullptr),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-}
+//     ASSERT_THROW_HIPDNN_STATUS(
+//         descriptor.set_attribute(
+//             HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS, HIPDNN_TYPE_VOID_PTR, dev_ptrs.size(), nullptr),
+//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+// }
 
-TEST_F(Initialize_variant_pack_descriptor_tests, InvalidFinalizeCounts)
-{
-    std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
-                                     reinterpret_cast<void*>(0x5678),
-                                     reinterpret_cast<void*>(0x9abc)};
-    std::array<int64_t, 2> uids = {1, 2};
-    void* workspace = reinterpret_cast<void*>(0xdeadbeef);
+// TEST_F(Initialize_variant_pack_descriptor_tests, InvalidFinalizeCounts)
+// {
+//     std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
+//                                      reinterpret_cast<void*>(0x5678),
+//                                      reinterpret_cast<void*>(0x9abc)};
+//     std::array<int64_t, 2> uids = {1, 2};
+//     void* workspace = reinterpret_cast<void*>(0xdeadbeef);
 
-    descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                             HIPDNN_TYPE_VOID_PTR,
-                             dev_ptrs.size(),
-                             dev_ptrs.data());
+//     descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+//                              HIPDNN_TYPE_VOID_PTR,
+//                              dev_ptrs.size(),
+//                              dev_ptrs.data());
 
-    descriptor.set_attribute(
-        HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
+//     descriptor.set_attribute(
+//         HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
 
-    descriptor.set_attribute(
-        HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
+//     descriptor.set_attribute(
+//         HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
 
-    ASSERT_THROW(descriptor.finalize(), Hipdnn_exception);
-    EXPECT_FALSE(descriptor.is_finalized());
-}
+//     ASSERT_THROW(descriptor.finalize(), Hipdnn_exception);
+//     EXPECT_FALSE(descriptor.is_finalized());
+// }
 
-TEST_F(Initialize_variant_pack_descriptor_tests, InvalidFinalizeUnsetParams)
-{
-    ASSERT_THROW(descriptor.finalize(), Hipdnn_exception);
-    EXPECT_FALSE(descriptor.is_finalized());
-}
+// TEST_F(Initialize_variant_pack_descriptor_tests, InvalidFinalizeUnsetParams)
+// {
+//     ASSERT_THROW(descriptor.finalize(), Hipdnn_exception);
+//     EXPECT_FALSE(descriptor.is_finalized());
+// }
 
-TEST_F(Initialize_variant_pack_descriptor_tests, InvalidGetAttributeNotFinalized)
-{
-    std::array<void*, 3> retrieved_dev_ptrs;
-    int64_t element_count = 0;
+// TEST_F(Initialize_variant_pack_descriptor_tests, InvalidGetAttributeNotFinalized)
+// {
+//     std::array<void*, 3> retrieved_dev_ptrs;
+//     int64_t element_count = 0;
 
-    ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                                                        HIPDNN_TYPE_VOID_PTR,
-                                                        retrieved_dev_ptrs.size(),
-                                                        &element_count,
-                                                        retrieved_dev_ptrs.data()),
-                               HIPDNN_STATUS_NOT_INITIALIZED);
-}
+//     ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+//                                                         HIPDNN_TYPE_VOID_PTR,
+//                                                         retrieved_dev_ptrs.size(),
+//                                                         &element_count,
+//                                                         retrieved_dev_ptrs.data()),
+//                                HIPDNN_STATUS_NOT_INITIALIZED);
+// }
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
-class Finalized_variant_pack_descriptor_tests : public ::testing::Test
-{
-protected:
-    Variant_descriptor descriptor;
-    std::array<void*, 3> _dev_ptrs = {reinterpret_cast<void*>(0x1234),
-                                      reinterpret_cast<void*>(0x5678),
-                                      reinterpret_cast<void*>(0x9abc)};
-    std::array<int64_t, 3> _uids = {1, 2, 3};
-    void* _workspace = reinterpret_cast<void*>(0xdeadbeef);
+// // NOLINTBEGIN(readability-function-cognitive-complexity)
+// class Finalized_variant_pack_descriptor_tests : public ::testing::Test
+// {
+// protected:
+//     Variant_descriptor descriptor;
+//     std::array<void*, 3> _dev_ptrs = {reinterpret_cast<void*>(0x1234),
+//                                       reinterpret_cast<void*>(0x5678),
+//                                       reinterpret_cast<void*>(0x9abc)};
+//     std::array<int64_t, 3> _uids = {1, 2, 3};
+//     void* _workspace = reinterpret_cast<void*>(0xdeadbeef);
 
-    void SetUp() override
-    {
-        descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                                 HIPDNN_TYPE_VOID_PTR,
-                                 static_cast<int64_t>(_dev_ptrs.size()),
-                                 _dev_ptrs.data());
+//     void SetUp() override
+//     {
+//         descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+//                                  HIPDNN_TYPE_VOID_PTR,
+//                                  static_cast<int64_t>(_dev_ptrs.size()),
+//                                  _dev_ptrs.data());
 
-        descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
-                                 HIPDNN_TYPE_INT64,
-                                 static_cast<int64_t>(_uids.size()),
-                                 _uids.data());
+//         descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
+//                                  HIPDNN_TYPE_INT64,
+//                                  static_cast<int64_t>(_uids.size()),
+//                                  _uids.data());
 
-        descriptor.set_attribute(
-            HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &_workspace);
+//         descriptor.set_attribute(
+//             HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &_workspace);
 
-        ASSERT_NO_THROW(descriptor.finalize());
-        EXPECT_TRUE(descriptor.is_finalized());
-    }
-};
+//         ASSERT_NO_THROW(descriptor.finalize());
+//         EXPECT_TRUE(descriptor.is_finalized());
+//     }
+// };
 
-TEST_F(Finalized_variant_pack_descriptor_tests, InvalidSetAttribute)
-{
-    ASSERT_THROW_HIPDNN_STATUS(descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                                                        HIPDNN_TYPE_VOID_PTR,
-                                                        static_cast<int64_t>(_dev_ptrs.size()),
-                                                        _dev_ptrs.data()),
-                               HIPDNN_STATUS_NOT_INITIALIZED);
-}
+// TEST_F(Finalized_variant_pack_descriptor_tests, InvalidSetAttribute)
+// {
+//     ASSERT_THROW_HIPDNN_STATUS(descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+//                                                         HIPDNN_TYPE_VOID_PTR,
+//                                                         static_cast<int64_t>(_dev_ptrs.size()),
+//                                                         _dev_ptrs.data()),
+//                                HIPDNN_STATUS_NOT_INITIALIZED);
+// }
 
-TEST_F(Finalized_variant_pack_descriptor_tests, ValidGetAttributes)
-{
-    std::array<void*, 3> retrieved_dev_ptrs;
-    std::array<int64_t, 3> retrieved_uids;
-    void* retrieved_workspace = nullptr;
-    int64_t element_count = 0;
+// TEST_F(Finalized_variant_pack_descriptor_tests, ValidGetAttributes)
+// {
+//     std::array<void*, 3> retrieved_dev_ptrs;
+//     std::array<int64_t, 3> retrieved_uids;
+//     void* retrieved_workspace = nullptr;
+//     int64_t element_count = 0;
 
-    descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                             HIPDNN_TYPE_VOID_PTR,
-                             retrieved_dev_ptrs.size(),
-                             &element_count,
-                             retrieved_dev_ptrs.data());
-    EXPECT_EQ(element_count, _dev_ptrs.size());
-    EXPECT_EQ(
-        std::memcmp(retrieved_dev_ptrs.data(), _dev_ptrs.data(), _dev_ptrs.size() * sizeof(void*)),
-        0);
+//     descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+//                              HIPDNN_TYPE_VOID_PTR,
+//                              retrieved_dev_ptrs.size(),
+//                              &element_count,
+//                              retrieved_dev_ptrs.data());
+//     EXPECT_EQ(element_count, _dev_ptrs.size());
+//     EXPECT_EQ(
+//         std::memcmp(retrieved_dev_ptrs.data(), _dev_ptrs.data(), _dev_ptrs.size() * sizeof(void*)),
+//         0);
 
-    descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
-                             HIPDNN_TYPE_INT64,
-                             retrieved_uids.size(),
-                             &element_count,
-                             retrieved_uids.data());
-    EXPECT_EQ(element_count, _uids.size());
-    EXPECT_EQ(std::memcmp(retrieved_uids.data(), _uids.data(), _uids.size() * sizeof(int64_t)), 0);
+//     descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
+//                              HIPDNN_TYPE_INT64,
+//                              retrieved_uids.size(),
+//                              &element_count,
+//                              retrieved_uids.data());
+//     EXPECT_EQ(element_count, _uids.size());
+//     EXPECT_EQ(std::memcmp(retrieved_uids.data(), _uids.data(), _uids.size() * sizeof(int64_t)), 0);
 
-    descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
-                             HIPDNN_TYPE_VOID_PTR,
-                             1,
-                             &element_count,
-                             &retrieved_workspace);
-    EXPECT_EQ(element_count, 1);
-    EXPECT_EQ(retrieved_workspace, _workspace);
-}
+//     descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
+//                              HIPDNN_TYPE_VOID_PTR,
+//                              1,
+//                              &element_count,
+//                              &retrieved_workspace);
+//     EXPECT_EQ(element_count, 1);
+//     EXPECT_EQ(retrieved_workspace, _workspace);
+// }
 
-TEST_F(Finalized_variant_pack_descriptor_tests, InvalidGetAttributes)
-{
-    std::array<void*, 3> retrieved_dev_ptrs;
-    std::array<int64_t, 3> retrieved_uids;
-    void* retrieved_workspace = nullptr;
-    int64_t element_count = 0;
+// TEST_F(Finalized_variant_pack_descriptor_tests, InvalidGetAttributes)
+// {
+//     std::array<void*, 3> retrieved_dev_ptrs;
+//     std::array<int64_t, 3> retrieved_uids;
+//     void* retrieved_workspace = nullptr;
+//     int64_t element_count = 0;
 
-    ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                                                        HIPDNN_TYPE_INT64,
-                                                        retrieved_dev_ptrs.size(),
-                                                        &element_count,
-                                                        retrieved_dev_ptrs.data()),
-                               HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+//                                                         HIPDNN_TYPE_INT64,
+//                                                         retrieved_dev_ptrs.size(),
+//                                                         &element_count,
+//                                                         retrieved_dev_ptrs.data()),
+//                                HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
-                                                        HIPDNN_TYPE_VOID_PTR,
-                                                        retrieved_uids.size(),
-                                                        &element_count,
-                                                        retrieved_uids.data()),
-                               HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
+//                                                         HIPDNN_TYPE_VOID_PTR,
+//                                                         retrieved_uids.size(),
+//                                                         &element_count,
+//                                                         retrieved_uids.data()),
+//                                HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
-                                                        HIPDNN_TYPE_VOID_PTR,
-                                                        2,
-                                                        &element_count,
-                                                        &retrieved_workspace),
-                               HIPDNN_STATUS_BAD_PARAM);
+//     ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
+//                                                         HIPDNN_TYPE_VOID_PTR,
+//                                                         2,
+//                                                         &element_count,
+//                                                         &retrieved_workspace),
+//                                HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                                                        HIPDNN_TYPE_VOID_PTR,
-                                                        retrieved_dev_ptrs.size(),
-                                                        &element_count,
-                                                        nullptr),
-                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+//     ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+//                                                         HIPDNN_TYPE_VOID_PTR,
+//                                                         retrieved_dev_ptrs.size(),
+//                                                         &element_count,
+//                                                         nullptr),
+//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                                                        HIPDNN_TYPE_VOID_PTR,
-                                                        retrieved_dev_ptrs.size(),
-                                                        nullptr,
-                                                        retrieved_dev_ptrs.data()),
-                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-}
+//     ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+//                                                         HIPDNN_TYPE_VOID_PTR,
+//                                                         retrieved_dev_ptrs.size(),
+//                                                         nullptr,
+//                                                         retrieved_dev_ptrs.data()),
+//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+// }
 
-// NOLINTEND(readability-function-cognitive-complexity)
+// // NOLINTEND(readability-function-cognitive-complexity)
 
-} // namespace hipdnn_backend
+// } // namespace hipdnn_backend

--- a/backend/tests/descriptors/test_variant_pack.cpp
+++ b/backend/tests/descriptors/test_variant_pack.cpp
@@ -1,267 +1,267 @@
-// // Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// // SPDX-License-Identifier:  MIT
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
-// #include "descriptors/variant_descriptor.hpp"
-// #include "hipdnn_exception.hpp"
-// #include "test_macros.hpp"
-// #include <gtest/gtest.h>
+#include "descriptors/variant_descriptor.hpp"
+#include "hipdnn_exception.hpp"
+#include "test_macros.hpp"
+#include <gtest/gtest.h>
 
-// namespace hipdnn_backend
-// {
+namespace hipdnn_backend
+{
 
-// class Initialize_variant_pack_descriptor_tests : public ::testing::Test
-// {
-// protected:
-//     Variant_descriptor descriptor;
+class Initialize_variant_pack_descriptor_tests : public ::testing::Test
+{
+protected:
+    Variant_descriptor descriptor;
 
-//     void SetUp() override
-//     {
-//         ASSERT_FALSE(descriptor.is_finalized());
-//     }
-// };
+    void SetUp() override
+    {
+        ASSERT_FALSE(descriptor.is_finalized());
+    }
+};
 
-// TEST_F(Initialize_variant_pack_descriptor_tests, ValidSetAttributes)
-// {
-//     std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
-//                                      reinterpret_cast<void*>(0x5678),
-//                                      reinterpret_cast<void*>(0x9abc)};
-//     std::array<int64_t, 3> uids = {1, 2, 3};
-//     void* workspace = reinterpret_cast<void*>(0xdeadbeef);
+TEST_F(Initialize_variant_pack_descriptor_tests, ValidSetAttributes)
+{
+    std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
+                                     reinterpret_cast<void*>(0x5678),
+                                     reinterpret_cast<void*>(0x9abc)};
+    std::array<int64_t, 3> uids = {1, 2, 3};
+    void* workspace = reinterpret_cast<void*>(0xdeadbeef);
 
-//     descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-//                              HIPDNN_TYPE_VOID_PTR,
-//                              dev_ptrs.size(),
-//                              dev_ptrs.data());
+    descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                             HIPDNN_TYPE_VOID_PTR,
+                             dev_ptrs.size(),
+                             dev_ptrs.data());
 
-//     descriptor.set_attribute(
-//         HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
+    descriptor.set_attribute(
+        HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
 
-//     descriptor.set_attribute(
-//         HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
+    descriptor.set_attribute(
+        HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
 
-//     ASSERT_NO_THROW(descriptor.finalize());
-//     EXPECT_TRUE(descriptor.is_finalized());
-// }
+    ASSERT_NO_THROW(descriptor.finalize());
+    EXPECT_TRUE(descriptor.is_finalized());
+}
 
-// TEST_F(Initialize_variant_pack_descriptor_tests, ValidSetAndGetBeforeFinalAttributes)
-// {
-//     std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
-//                                      reinterpret_cast<void*>(0x5678),
-//                                      reinterpret_cast<void*>(0x9abc)};
-//     std::array<int64_t, 3> uids = {1, 2, 3};
-//     void* workspace = reinterpret_cast<void*>(0xdeadbeef);
+TEST_F(Initialize_variant_pack_descriptor_tests, ValidSetAndGetBeforeFinalAttributes)
+{
+    std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
+                                     reinterpret_cast<void*>(0x5678),
+                                     reinterpret_cast<void*>(0x9abc)};
+    std::array<int64_t, 3> uids = {1, 2, 3};
+    void* workspace = reinterpret_cast<void*>(0xdeadbeef);
 
-//     descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-//                              HIPDNN_TYPE_VOID_PTR,
-//                              dev_ptrs.size(),
-//                              dev_ptrs.data());
+    descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                             HIPDNN_TYPE_VOID_PTR,
+                             dev_ptrs.size(),
+                             dev_ptrs.data());
 
-//     descriptor.set_attribute(
-//         HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
+    descriptor.set_attribute(
+        HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
 
-//     descriptor.set_attribute(
-//         HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
-//     // getting before finalized
-//     std::array<void*, 3> retrieved_dev_ptrs;
-//     int64_t element_count = 0;
+    descriptor.set_attribute(
+        HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
+    // getting before finalized
+    std::array<void*, 3> retrieved_dev_ptrs;
+    int64_t element_count = 0;
 
-//     ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-//                                                         HIPDNN_TYPE_VOID_PTR,
-//                                                         retrieved_dev_ptrs.size(),
-//                                                         &element_count,
-//                                                         retrieved_dev_ptrs.data()),
-//                                HIPDNN_STATUS_NOT_INITIALIZED);
-// }
+    ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                                                        HIPDNN_TYPE_VOID_PTR,
+                                                        retrieved_dev_ptrs.size(),
+                                                        &element_count,
+                                                        retrieved_dev_ptrs.data()),
+                               HIPDNN_STATUS_NOT_INITIALIZED);
+}
 
-// TEST_F(Initialize_variant_pack_descriptor_tests, InvalidSetAttributes)
-// {
-//     std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
-//                                      reinterpret_cast<void*>(0x5678),
-//                                      reinterpret_cast<void*>(0x9abc)};
-//     std::array<int64_t, 3> uids = {1, 2, 3};
-//     void* workspace = reinterpret_cast<void*>(0xdeadbeef);
+TEST_F(Initialize_variant_pack_descriptor_tests, InvalidSetAttributes)
+{
+    std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
+                                     reinterpret_cast<void*>(0x5678),
+                                     reinterpret_cast<void*>(0x9abc)};
+    std::array<int64_t, 3> uids = {1, 2, 3};
+    void* workspace = reinterpret_cast<void*>(0xdeadbeef);
 
-//     ASSERT_THROW_HIPDNN_STATUS(descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-//                                                         HIPDNN_TYPE_INT64,
-//                                                         dev_ptrs.size(),
-//                                                         dev_ptrs.data()),
-//                                HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                                                        HIPDNN_TYPE_INT64,
+                                                        dev_ptrs.size(),
+                                                        dev_ptrs.data()),
+                               HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         descriptor.set_attribute(
-//             HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_VOID_PTR, uids.size(), uids.data()),
-//         HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(
+        descriptor.set_attribute(
+            HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_VOID_PTR, uids.size(), uids.data()),
+        HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         descriptor.set_attribute(
-//             HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 2, &workspace),
-//         HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(
+        descriptor.set_attribute(
+            HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 2, &workspace),
+        HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(
-//         descriptor.set_attribute(
-//             HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS, HIPDNN_TYPE_VOID_PTR, dev_ptrs.size(), nullptr),
-//         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-// }
+    ASSERT_THROW_HIPDNN_STATUS(
+        descriptor.set_attribute(
+            HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS, HIPDNN_TYPE_VOID_PTR, dev_ptrs.size(), nullptr),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+}
 
-// TEST_F(Initialize_variant_pack_descriptor_tests, InvalidFinalizeCounts)
-// {
-//     std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
-//                                      reinterpret_cast<void*>(0x5678),
-//                                      reinterpret_cast<void*>(0x9abc)};
-//     std::array<int64_t, 2> uids = {1, 2};
-//     void* workspace = reinterpret_cast<void*>(0xdeadbeef);
+TEST_F(Initialize_variant_pack_descriptor_tests, InvalidFinalizeCounts)
+{
+    std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
+                                     reinterpret_cast<void*>(0x5678),
+                                     reinterpret_cast<void*>(0x9abc)};
+    std::array<int64_t, 2> uids = {1, 2};
+    void* workspace = reinterpret_cast<void*>(0xdeadbeef);
 
-//     descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-//                              HIPDNN_TYPE_VOID_PTR,
-//                              dev_ptrs.size(),
-//                              dev_ptrs.data());
+    descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                             HIPDNN_TYPE_VOID_PTR,
+                             dev_ptrs.size(),
+                             dev_ptrs.data());
 
-//     descriptor.set_attribute(
-//         HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
+    descriptor.set_attribute(
+        HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
 
-//     descriptor.set_attribute(
-//         HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
+    descriptor.set_attribute(
+        HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
 
-//     ASSERT_THROW(descriptor.finalize(), Hipdnn_exception);
-//     EXPECT_FALSE(descriptor.is_finalized());
-// }
+    ASSERT_THROW(descriptor.finalize(), Hipdnn_exception);
+    EXPECT_FALSE(descriptor.is_finalized());
+}
 
-// TEST_F(Initialize_variant_pack_descriptor_tests, InvalidFinalizeUnsetParams)
-// {
-//     ASSERT_THROW(descriptor.finalize(), Hipdnn_exception);
-//     EXPECT_FALSE(descriptor.is_finalized());
-// }
+TEST_F(Initialize_variant_pack_descriptor_tests, InvalidFinalizeUnsetParams)
+{
+    ASSERT_THROW(descriptor.finalize(), Hipdnn_exception);
+    EXPECT_FALSE(descriptor.is_finalized());
+}
 
-// TEST_F(Initialize_variant_pack_descriptor_tests, InvalidGetAttributeNotFinalized)
-// {
-//     std::array<void*, 3> retrieved_dev_ptrs;
-//     int64_t element_count = 0;
+TEST_F(Initialize_variant_pack_descriptor_tests, InvalidGetAttributeNotFinalized)
+{
+    std::array<void*, 3> retrieved_dev_ptrs;
+    int64_t element_count = 0;
 
-//     ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-//                                                         HIPDNN_TYPE_VOID_PTR,
-//                                                         retrieved_dev_ptrs.size(),
-//                                                         &element_count,
-//                                                         retrieved_dev_ptrs.data()),
-//                                HIPDNN_STATUS_NOT_INITIALIZED);
-// }
+    ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                                                        HIPDNN_TYPE_VOID_PTR,
+                                                        retrieved_dev_ptrs.size(),
+                                                        &element_count,
+                                                        retrieved_dev_ptrs.data()),
+                               HIPDNN_STATUS_NOT_INITIALIZED);
+}
 
-// // NOLINTBEGIN(readability-function-cognitive-complexity)
-// class Finalized_variant_pack_descriptor_tests : public ::testing::Test
-// {
-// protected:
-//     Variant_descriptor descriptor;
-//     std::array<void*, 3> _dev_ptrs = {reinterpret_cast<void*>(0x1234),
-//                                       reinterpret_cast<void*>(0x5678),
-//                                       reinterpret_cast<void*>(0x9abc)};
-//     std::array<int64_t, 3> _uids = {1, 2, 3};
-//     void* _workspace = reinterpret_cast<void*>(0xdeadbeef);
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+class Finalized_variant_pack_descriptor_tests : public ::testing::Test
+{
+protected:
+    Variant_descriptor descriptor;
+    std::array<void*, 3> _dev_ptrs = {reinterpret_cast<void*>(0x1234),
+                                      reinterpret_cast<void*>(0x5678),
+                                      reinterpret_cast<void*>(0x9abc)};
+    std::array<int64_t, 3> _uids = {1, 2, 3};
+    void* _workspace = reinterpret_cast<void*>(0xdeadbeef);
 
-//     void SetUp() override
-//     {
-//         descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-//                                  HIPDNN_TYPE_VOID_PTR,
-//                                  static_cast<int64_t>(_dev_ptrs.size()),
-//                                  _dev_ptrs.data());
+    void SetUp() override
+    {
+        descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                                 HIPDNN_TYPE_VOID_PTR,
+                                 static_cast<int64_t>(_dev_ptrs.size()),
+                                 _dev_ptrs.data());
 
-//         descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
-//                                  HIPDNN_TYPE_INT64,
-//                                  static_cast<int64_t>(_uids.size()),
-//                                  _uids.data());
+        descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
+                                 HIPDNN_TYPE_INT64,
+                                 static_cast<int64_t>(_uids.size()),
+                                 _uids.data());
 
-//         descriptor.set_attribute(
-//             HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &_workspace);
+        descriptor.set_attribute(
+            HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &_workspace);
 
-//         ASSERT_NO_THROW(descriptor.finalize());
-//         EXPECT_TRUE(descriptor.is_finalized());
-//     }
-// };
+        ASSERT_NO_THROW(descriptor.finalize());
+        EXPECT_TRUE(descriptor.is_finalized());
+    }
+};
 
-// TEST_F(Finalized_variant_pack_descriptor_tests, InvalidSetAttribute)
-// {
-//     ASSERT_THROW_HIPDNN_STATUS(descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-//                                                         HIPDNN_TYPE_VOID_PTR,
-//                                                         static_cast<int64_t>(_dev_ptrs.size()),
-//                                                         _dev_ptrs.data()),
-//                                HIPDNN_STATUS_NOT_INITIALIZED);
-// }
+TEST_F(Finalized_variant_pack_descriptor_tests, InvalidSetAttribute)
+{
+    ASSERT_THROW_HIPDNN_STATUS(descriptor.set_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                                                        HIPDNN_TYPE_VOID_PTR,
+                                                        static_cast<int64_t>(_dev_ptrs.size()),
+                                                        _dev_ptrs.data()),
+                               HIPDNN_STATUS_NOT_INITIALIZED);
+}
 
-// TEST_F(Finalized_variant_pack_descriptor_tests, ValidGetAttributes)
-// {
-//     std::array<void*, 3> retrieved_dev_ptrs;
-//     std::array<int64_t, 3> retrieved_uids;
-//     void* retrieved_workspace = nullptr;
-//     int64_t element_count = 0;
+TEST_F(Finalized_variant_pack_descriptor_tests, ValidGetAttributes)
+{
+    std::array<void*, 3> retrieved_dev_ptrs;
+    std::array<int64_t, 3> retrieved_uids;
+    void* retrieved_workspace = nullptr;
+    int64_t element_count = 0;
 
-//     descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-//                              HIPDNN_TYPE_VOID_PTR,
-//                              retrieved_dev_ptrs.size(),
-//                              &element_count,
-//                              retrieved_dev_ptrs.data());
-//     EXPECT_EQ(element_count, _dev_ptrs.size());
-//     EXPECT_EQ(
-//         std::memcmp(retrieved_dev_ptrs.data(), _dev_ptrs.data(), _dev_ptrs.size() * sizeof(void*)),
-//         0);
+    descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                             HIPDNN_TYPE_VOID_PTR,
+                             retrieved_dev_ptrs.size(),
+                             &element_count,
+                             retrieved_dev_ptrs.data());
+    EXPECT_EQ(element_count, _dev_ptrs.size());
+    EXPECT_EQ(
+        std::memcmp(retrieved_dev_ptrs.data(), _dev_ptrs.data(), _dev_ptrs.size() * sizeof(void*)),
+        0);
 
-//     descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
-//                              HIPDNN_TYPE_INT64,
-//                              retrieved_uids.size(),
-//                              &element_count,
-//                              retrieved_uids.data());
-//     EXPECT_EQ(element_count, _uids.size());
-//     EXPECT_EQ(std::memcmp(retrieved_uids.data(), _uids.data(), _uids.size() * sizeof(int64_t)), 0);
+    descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
+                             HIPDNN_TYPE_INT64,
+                             retrieved_uids.size(),
+                             &element_count,
+                             retrieved_uids.data());
+    EXPECT_EQ(element_count, _uids.size());
+    EXPECT_EQ(std::memcmp(retrieved_uids.data(), _uids.data(), _uids.size() * sizeof(int64_t)), 0);
 
-//     descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
-//                              HIPDNN_TYPE_VOID_PTR,
-//                              1,
-//                              &element_count,
-//                              &retrieved_workspace);
-//     EXPECT_EQ(element_count, 1);
-//     EXPECT_EQ(retrieved_workspace, _workspace);
-// }
+    descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
+                             HIPDNN_TYPE_VOID_PTR,
+                             1,
+                             &element_count,
+                             &retrieved_workspace);
+    EXPECT_EQ(element_count, 1);
+    EXPECT_EQ(retrieved_workspace, _workspace);
+}
 
-// TEST_F(Finalized_variant_pack_descriptor_tests, InvalidGetAttributes)
-// {
-//     std::array<void*, 3> retrieved_dev_ptrs;
-//     std::array<int64_t, 3> retrieved_uids;
-//     void* retrieved_workspace = nullptr;
-//     int64_t element_count = 0;
+TEST_F(Finalized_variant_pack_descriptor_tests, InvalidGetAttributes)
+{
+    std::array<void*, 3> retrieved_dev_ptrs;
+    std::array<int64_t, 3> retrieved_uids;
+    void* retrieved_workspace = nullptr;
+    int64_t element_count = 0;
 
-//     ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-//                                                         HIPDNN_TYPE_INT64,
-//                                                         retrieved_dev_ptrs.size(),
-//                                                         &element_count,
-//                                                         retrieved_dev_ptrs.data()),
-//                                HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                                                        HIPDNN_TYPE_INT64,
+                                                        retrieved_dev_ptrs.size(),
+                                                        &element_count,
+                                                        retrieved_dev_ptrs.data()),
+                               HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
-//                                                         HIPDNN_TYPE_VOID_PTR,
-//                                                         retrieved_uids.size(),
-//                                                         &element_count,
-//                                                         retrieved_uids.data()),
-//                                HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
+                                                        HIPDNN_TYPE_VOID_PTR,
+                                                        retrieved_uids.size(),
+                                                        &element_count,
+                                                        retrieved_uids.data()),
+                               HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
-//                                                         HIPDNN_TYPE_VOID_PTR,
-//                                                         2,
-//                                                         &element_count,
-//                                                         &retrieved_workspace),
-//                                HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
+                                                        HIPDNN_TYPE_VOID_PTR,
+                                                        2,
+                                                        &element_count,
+                                                        &retrieved_workspace),
+                               HIPDNN_STATUS_BAD_PARAM);
 
-//     ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-//                                                         HIPDNN_TYPE_VOID_PTR,
-//                                                         retrieved_dev_ptrs.size(),
-//                                                         &element_count,
-//                                                         nullptr),
-//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                                                        HIPDNN_TYPE_VOID_PTR,
+                                                        retrieved_dev_ptrs.size(),
+                                                        &element_count,
+                                                        nullptr),
+                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-//     ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-//                                                         HIPDNN_TYPE_VOID_PTR,
-//                                                         retrieved_dev_ptrs.size(),
-//                                                         nullptr,
-//                                                         retrieved_dev_ptrs.data()),
-//                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-// }
+    ASSERT_THROW_HIPDNN_STATUS(descriptor.get_attribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                                                        HIPDNN_TYPE_VOID_PTR,
+                                                        retrieved_dev_ptrs.size(),
+                                                        nullptr,
+                                                        retrieved_dev_ptrs.data()),
+                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+}
 
-// // NOLINTEND(readability-function-cognitive-complexity)
+// NOLINTEND(readability-function-cognitive-complexity)
 
-// } // namespace hipdnn_backend
+} // namespace hipdnn_backend


### PR DESCRIPTION
## Proposed changes

Backend descriptor and the wrapper were difficult to use, and had some ick because we were leaking the impl.
Swapped to CRTP to improve casting logic, static_asserts, and make things auto-magically safe for how we are using the templates. Added some logic in as well to standardize checks for unpacking.
