### PR TITLE
Engine config descriptor integration, and changes to support it

### DIFF
--- a/backend/src/descriptors/backend_descriptor.hpp
+++ b/backend/src/descriptors/backend_descriptor.hpp
@@ -99,6 +99,15 @@ struct hipdnnBackendDescriptor : public Backend_descriptor_interface
             "Failed to cast backend descriptor: Null descriptor provided.");
     }
 
+    // Unsafe version of as_descriptor that does not perform type checks.
+    // Use with caution, as it can lead to undefined behavior if the types do not match
+    // This is intended for internal mock usage, and not anywhere esle in the codebase.
+    template <typename Child_descriptor>
+    std::shared_ptr<Child_descriptor> as_descriptor_unsafe()
+    {
+        return std::static_pointer_cast<Child_descriptor>(_impl);
+    }
+
     bool is_valid();
 
     hipdnnBackendDescriptorType_t get_type() const override;

--- a/backend/src/descriptors/engine_config_descriptor.cpp
+++ b/backend/src/descriptors/engine_config_descriptor.cpp
@@ -4,8 +4,11 @@
 #include "engine_config_descriptor.hpp"
 #include "engine_descriptor.hpp"
 #include "error.hpp"
+#include "graph_descriptor.hpp"
 #include "hipdnn_backend_descriptor_type.h"
 #include "hipdnn_exception.hpp"
+#include <handle/handle.hpp>
+#include <hipdnn_sdk/data_objects/engine_config_generated.h>
 
 namespace hipdnn_backend
 {
@@ -20,6 +23,23 @@ void Engine_config_descriptor::finalize()
                   HIPDNN_STATUS_BAD_PARAM,
                   "Engine_config_descriptor::finalize() failed: Engine is not set.");
 
+    auto graph = _engine->get_graph();
+    auto handle = graph->get_handle();
+    auto plugin_resource_manager = handle->get_plugin_resource_manager();
+
+    auto engine_id = _engine->get_engine_id();
+
+    auto engine_config_plugin_data = get_serialized_engine_config();
+    auto workspace_size = static_cast<int64_t>(plugin_resource_manager->get_workspace_size(
+        engine_id, &engine_config_plugin_data, graph.get()));
+
+    THROW_IF_LT(workspace_size,
+                0,
+                HIPDNN_STATUS_INTERNAL_ERROR,
+                "Engine_config_descriptor::set_max_workspace_size() failed: "
+                "Max workspace size cannot be negative.");
+
+    _max_workspace_size = workspace_size;
     hipdnnBackendDescriptorImpl<Engine_config_descriptor>::finalize();
 }
 
@@ -165,25 +185,6 @@ void Engine_config_descriptor::set_engine(hipdnnBackendAttributeType_t attribute
     _engine = engine;
 }
 
-void Engine_config_descriptor::set_max_workspace_size(int64_t workspace_size)
-{
-    // This should only be called from the plugin manager, so all errors should be
-    // internal errors rather than user errors.
-
-    THROW_IF_FALSE(is_finalized(),
-                   HIPDNN_STATUS_INTERNAL_ERROR,
-                   "Engine_config_descriptor::set_max_workspace_size() failed: "
-                   "Not finalized.");
-
-    THROW_IF_LT(workspace_size,
-                0,
-                HIPDNN_STATUS_INTERNAL_ERROR,
-                "Engine_config_descriptor::set_max_workspace_size() failed: "
-                "Max workspace size cannot be negative.");
-
-    _max_workspace_size = workspace_size;
-}
-
 std::shared_ptr<const Engine_descriptor> Engine_config_descriptor::get_engine() const
 {
     THROW_IF_FALSE(is_finalized(),
@@ -196,4 +197,25 @@ hipdnnBackendDescriptorType_t Engine_config_descriptor::get_static_type()
 {
     return HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR;
 }
+
+const hipdnnPluginConstData_t& Engine_config_descriptor::get_serialized_engine_config()
+{
+    if(_engine_config_buffer.size() == 0)
+    {
+        THROW_IF_NULL(_engine,
+                      HIPDNN_STATUS_INTERNAL_ERROR,
+                      "Graph_descriptor::get_serialized_graph: graph is null");
+
+        flatbuffers::FlatBufferBuilder builder;
+        hipdnn_sdk::data_objects::EngineConfigBuilder engine_config_builder(builder);
+        engine_config_builder.add_engine_id(_engine->get_engine_id());
+        builder.Finish(engine_config_builder.Finish());
+        _engine_config_buffer = builder.Release();
+        _serialized_engine_config
+            = {.ptr = _engine_config_buffer.data(), .size = _engine_config_buffer.size()};
+    }
+
+    return _serialized_engine_config;
+}
+
 } // namespace hipdnn_backend

--- a/backend/src/descriptors/engine_config_descriptor.hpp
+++ b/backend/src/descriptors/engine_config_descriptor.hpp
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "backend_descriptor.hpp"
+#include <flatbuffers/detached_buffer.h>
+#include <hipdnn_sdk/plugin/plugin_api_data_types.h>
 
 namespace hipdnn_backend
 {
@@ -15,6 +17,8 @@ class Engine_config_descriptor : public hipdnnBackendDescriptorImpl<Engine_confi
 private:
     std::shared_ptr<const Engine_descriptor> _engine;
     int64_t _max_workspace_size = INVALID_WORKSPACE_SIZE;
+    hipdnnPluginConstData_t _serialized_engine_config;
+    flatbuffers::DetachedBuffer _engine_config_buffer;
 
     void set_engine(hipdnnBackendAttributeType_t attribute_type,
                     int64_t element_count,
@@ -29,6 +33,8 @@ private:
                                 int64_t requested_element_count,
                                 int64_t* element_count,
                                 void* array_of_elements) const;
+
+    const hipdnnPluginConstData_t& get_serialized_engine_config();
 
 public:
     static constexpr int64_t INVALID_WORKSPACE_SIZE = -1;
@@ -46,12 +52,10 @@ public:
                        int64_t element_count,
                        const void* array_of_elements) override;
 
-    void set_max_workspace_size(int64_t max_workspace_size);
-
-    // Throws an exception if the descriptor is not finalized.
-    std::shared_ptr<const Engine_descriptor> get_engine() const;
-
     static hipdnnBackendDescriptorType_t get_static_type();
+
+    // Throws an exception if the descriptor is not finalized before calling these.
+    std::shared_ptr<const Engine_descriptor> get_engine() const;
 };
 
 } // namespace hipdnn_backend

--- a/backend/src/descriptors/engine_descriptor.hpp
+++ b/backend/src/descriptors/engine_descriptor.hpp
@@ -50,8 +50,8 @@ public:
                        const void* array_of_elements) override;
 
     // These getters throw an exception if the descriptor is not finalized.
-    std::shared_ptr<const Graph_descriptor> get_graph() const;
-    int64_t get_engine_id() const;
+    virtual std::shared_ptr<const Graph_descriptor> get_graph() const;
+    virtual int64_t get_engine_id() const;
 
     static hipdnnBackendDescriptorType_t get_static_type();
 };

--- a/backend/src/descriptors/graph_descriptor.cpp
+++ b/backend/src/descriptors/graph_descriptor.cpp
@@ -98,7 +98,7 @@ void Graph_descriptor::deserialize_graph(const uint8_t* serialized_graph, size_t
     _serialized_graph.assign(serialized_graph, serialized_graph + graph_byte_size);
 }
 
-const std::vector<uint8_t>& Graph_descriptor::get_serialized_graph()
+const std::vector<uint8_t>& Graph_descriptor::get_serialized_graph() const
 {
     if(_serialized_graph.empty())
     {
@@ -121,6 +121,12 @@ const std::vector<uint8_t>& Graph_descriptor::get_serialized_graph()
 hipdnnBackendDescriptorType_t Graph_descriptor::get_static_type()
 {
     return HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR;
+}
+
+hipdnnHandle_t Graph_descriptor::get_handle() const
+{
+    THROW_IF_NULL(_handle, HIPDNN_STATUS_BAD_PARAM, "Graph_descriptor::get_handle: handle is null");
+    return _handle;
 }
 
 } // namespace hipdnn_backend

--- a/backend/src/descriptors/graph_descriptor.hpp
+++ b/backend/src/descriptors/graph_descriptor.hpp
@@ -17,7 +17,7 @@ class Graph_descriptor : public hipdnnBackendDescriptorImpl<Graph_descriptor>
 private:
     std::unique_ptr<hipdnn_sdk::data_objects::GraphT> _graph;
     hipdnnHandle_t _handle = nullptr;
-    std::vector<uint8_t> _serialized_graph;
+    mutable std::vector<uint8_t> _serialized_graph;
 
     void set_handle(hipdnnBackendAttributeType_t attribute_type,
                     int64_t element_count,
@@ -39,7 +39,8 @@ public:
 
     void deserialize_graph(const uint8_t* serialized_graph, size_t graph_byte_size);
 
-    const std::vector<uint8_t>& get_serialized_graph();
+    const std::vector<uint8_t>& get_serialized_graph() const;
+    virtual hipdnnHandle_t get_handle() const;
 
     static hipdnnBackendDescriptorType_t get_static_type();
 };

--- a/backend/src/handle/handle.cpp
+++ b/backend/src/handle/handle.cpp
@@ -3,12 +3,26 @@
 
 #include "handle.hpp"
 
+using namespace hipdnn_backend::plugin;
+
+hipdnnHandle::hipdnnHandle()
+    : _plugin_resource_manager(Engine_plugin_resource_manager::create())
+{
+}
+
 void hipdnnHandle::set_stream(hipStream_t stream)
 {
     _stream = stream;
+    _plugin_resource_manager->set_stream(stream);
 }
 
 hipStream_t hipdnnHandle::get_stream() const
 {
     return _stream;
+}
+
+std::shared_ptr<hipdnn_backend::plugin::Engine_plugin_resource_manager>
+    hipdnnHandle::get_plugin_resource_manager() const
+{
+    return _plugin_resource_manager;
 }

--- a/backend/src/handle/handle.hpp
+++ b/backend/src/handle/handle.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "plugin/engine_plugin_resource_manager.hpp"
 #include <cstdint>
 #include <hip/hip_runtime.h>
 #include <memory>
@@ -10,8 +11,15 @@
 struct hipdnnHandle // NOLINT
 {
 public:
+    hipdnnHandle();
     virtual ~hipdnnHandle() = default;
-    void set_stream(hipStream_t stream);
-    hipStream_t get_stream() const;
+    virtual void set_stream(hipStream_t stream);
+    virtual hipStream_t get_stream() const;
+    virtual std::shared_ptr<hipdnn_backend::plugin::Engine_plugin_resource_manager>
+        get_plugin_resource_manager() const;
+
+private:
     hipStream_t _stream = nullptr;
+    std::shared_ptr<hipdnn_backend::plugin::Engine_plugin_resource_manager>
+        _plugin_resource_manager;
 };

--- a/backend/src/hipdnn_backend.cpp
+++ b/backend/src/hipdnn_backend.cpp
@@ -169,13 +169,7 @@ HIPDNN_BACKEND_EXPORT hipdnnStatus_t hipdnnBackendFinalize(hipdnnBackendDescript
 
         descriptor->finalize();
 
-        if(descriptor->get_type() == HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR)
-        {
-            Plugin_manager plugin_manager;
-            plugin_manager.initialize();
-            plugin_manager.finalize_engine_config(descriptor);
-        }
-        else if(descriptor->get_type() == HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR)
+        if(descriptor->get_type() == HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR)
         {
             Plugin_manager plugin_manager;
             plugin_manager.initialize();

--- a/backend/src/plugin/engine_plugin_resource_manager.cpp
+++ b/backend/src/plugin/engine_plugin_resource_manager.cpp
@@ -81,6 +81,11 @@ std::shared_ptr<Engine_plugin_resource_manager> Engine_plugin_resource_manager::
     return std::make_shared<Engine_plugin_resource_manager>(pm);
 }
 
+Engine_plugin_resource_manager::Engine_plugin_resource_manager()
+    : _pm(std::make_shared<Engine_plugin_manager>())
+{
+}
+
 Engine_plugin_resource_manager::Engine_plugin_resource_manager(
     std::shared_ptr<Engine_plugin_manager>& pm)
     : _pm(pm)
@@ -212,12 +217,12 @@ std::unique_ptr<Engine_details_wrapper>
 }
 
 // TODO: Pack engine_config
-// TODO: Get engine_id from engine_config
 size_t
     Engine_plugin_resource_manager::get_workspace_size(int64_t engine_id,
                                                        const hipdnnPluginConstData_t* engine_config,
-                                                       Graph_descriptor* graph_desc) const
+                                                       const Graph_descriptor* graph_desc) const
 {
+    // TODO : swap the serialized type to be hipdnnPluginConstData_t.
     const auto& serialized_graph = graph_desc->get_serialized_graph();
     const hipdnnPluginConstData_t serialized_graph_data{serialized_graph.data(),
                                                         serialized_graph.size()};
@@ -278,136 +283,6 @@ void Engine_plugin_resource_manager::execute_op_graph(
     plugin->execute_op_graph(
         handle, execution_context, workspace, device_buffers, num_device_buffers);
 }
-
-#if 0
-void Engine_plugin_resource_manager::finalize_engine(hipdnnBackendDescriptor_t desc) const
-{
-    assert(desc->type == HIPDNN_BACKEND_ENGINE_DESCRIPTOR);
-    auto engine_desc = static_cast<Engine_descriptor*>(desc);
-
-    engine_desc->finalize();
-
-    hipdnnBackendDescriptor_t graph;
-    engine_desc->get_attribute(
-        HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, &graph);
-    auto graph_desc = static_cast<Graph_descriptor*>(graph);
-
-    int64_t engine_id;
-    engine_desc->get_attribute(
-        HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, &engine_id);
-
-    auto engine_ids = get_applicable_engine_ids(graph_desc);
-    if(std::ranges::find(engine_ids, engine_id) == engine_ids.end())
-    {
-        throw Hipdnn_exception(HIPDNN_STATUS_BAD_PARAM,
-                               "Engine ID " + std::to_string(engine_id)
-                                   + " is not in a valid range of engine IDs");
-    }
-
-    // TODO: Get engine details
-    // This will be implemented at the integration stage
-}
-#endif
-
-#if 0
-void Engine_plugin_resource_manager::finalize_engine_config(hipdnnBackendDescriptor_t desc) const
-{
-    assert(desc->type == HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR);
-    auto config_desc = static_cast<Engine_config_descriptor*>(desc);
-
-    config_desc->finalize();
-
-    hipdnnBackendDescriptor_t engine;
-    config_desc->get_attribute(
-        HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, &engine);
-
-    int64_t engine_id;
-    engine->get_attribute(
-        HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, &engine_id);
-
-    hipdnnBackendDescriptor_t graph;
-    engine->get_attribute(
-        HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, &graph);
-    auto graph_desc = static_cast<Graph_descriptor*>(graph);
-
-    // TODO: Move to the engine config descriptor
-    // Now we have only one parameter in the engine config, but we will add more parameters later.
-    flatbuffers::FlatBufferBuilder builder;
-    auto engine_config = hipdnn_sdk::data_objects::CreateEngineConfig(builder, engine_id);
-    builder.Finish(engine_config);
-    hipdnnPluginConstData_t engine_config_data{builder.GetBufferPointer(), builder.GetSize()};
-
-    auto workspace_size = get_workspace_size(engine_id, &engine_config_data, graph_desc);
-    // TODO: Rename set_max_workspace_size() to set_workspace_size()
-    // TODO: Use size_t instead of int64_t for workspace size
-    // This will be implemented at the integration stage
-    config_desc->set_max_workspace_size(static_cast<int64_t>(workspace_size));
-}
-#endif
-
-#if 0
-void Engine_plugin_resource_manager::finalize_engine_heuristic(hipdnnBackendDescriptor_t desc) const
-{
-    assert(desc->type == HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR);
-    auto heur_desc = static_cast<Engine_heuristic_descriptor*>(desc);
-
-    heur_desc->finalize();
-
-    hipdnnBackendDescriptor_t graph;
-    heur_desc->get_attribute(
-        HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, &graph);
-    assert(graph != nullptr);
-    auto graph_desc = static_cast<Graph_descriptor*>(graph);
-
-    auto engine_ids = get_applicable_engine_ids(graph_desc);
-    heur_desc->set_engine_ids(engine_ids);
-
-    // TODO: Get engine details
-}
-#endif
-
-#if 0
-// NOLINTNEXTLINE (readability-convert-member-functions-to-static)
-void Engine_plugin_resource_manager::finalize_execution_plan(hipdnnBackendDescriptor_t desc) const
-{
-    assert(desc->type == HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR);
-    auto exec_plan_desc = static_cast<Execution_plan_descriptor*>(desc);
-
-    exec_plan_desc->finalize();
-
-    hipdnnBackendDescriptor_t config;
-    exec_plan_desc->get_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                                  HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                  1,
-                                  nullptr,
-                                  &config);
-
-    hipdnnBackendDescriptor_t engine;
-    config->get_attribute(
-        HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, &engine);
-
-    int64_t engine_id;
-    engine->get_attribute(
-        HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, &engine_id);
-
-    hipdnnBackendDescriptor_t graph;
-    engine->get_attribute(
-        HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, &graph);
-    auto graph_desc = static_cast<Graph_descriptor*>(graph);
-
-    // TODO: Move to the engine config descriptor
-    // Now we have only one parameter in the engine config, but we will add more parameters later.
-    flatbuffers::FlatBufferBuilder builder;
-    auto engine_config = hipdnn_sdk::data_objects::CreateEngineConfig(builder, engine_id);
-    builder.Finish(engine_config);
-    hipdnnPluginConstData_t engine_config_data{builder.GetBufferPointer(), builder.GetSize()};
-
-    // TODO: Get execution context
-    // This will be implemented at the integration stage
-    std::ignore = graph_desc;
-    std::ignore = engine_config_data;
-}
-#endif
 
 void Engine_plugin_resource_manager::execute_op_graph(hipdnnBackendDescriptor_t execution_plan,
                                                       hipdnnBackendDescriptor_t variant_pack) const

--- a/backend/src/plugin/engine_plugin_resource_manager.hpp
+++ b/backend/src/plugin/engine_plugin_resource_manager.hpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 #include <hip/hip_runtime.h>
 #include <hipdnn_sdk/plugin/plugin_api_data_types.h>
@@ -35,6 +36,10 @@ class Engine_execution_context_wrapper;
 
 class Engine_plugin_resource_manager
 {
+protected:
+    // Protected constructor for mock testing
+    Engine_plugin_resource_manager();
+
 public:
     // MT-safe static functions
     // Load plugins from a specific path, for testing purposes
@@ -42,7 +47,7 @@ public:
     static std::shared_ptr<Engine_plugin_resource_manager> create();
 
     Engine_plugin_resource_manager(std::shared_ptr<Engine_plugin_manager>& pm);
-    ~Engine_plugin_resource_manager();
+    virtual ~Engine_plugin_resource_manager();
 
     // Prevent copying
     Engine_plugin_resource_manager(const Engine_plugin_resource_manager&) = delete;
@@ -53,19 +58,14 @@ public:
     Engine_plugin_resource_manager& operator=(Engine_plugin_resource_manager&& other) noexcept;
 
     // MT-unsafe instance methods
-    void set_stream(hipStream_t stream) const;
+    virtual void set_stream(hipStream_t stream) const;
 
-    // TODO: Move to the descriptors
-    // This will be moved to the descriptors in the integration stage
-#if 0
-    void finalize_engine(hipdnnBackendDescriptor_t desc) const;
-    void finalize_engine_config(hipdnnBackendDescriptor_t desc) const;
-    void finalize_engine_heuristic(hipdnnBackendDescriptor_t desc) const;
-    void finalize_execution_plan(hipdnnBackendDescriptor_t desc) const;
-#endif
+    virtual void execute_op_graph(hipdnnBackendDescriptor_t execution_plan,
+                                  hipdnnBackendDescriptor_t variant_pack) const;
 
-    void execute_op_graph(hipdnnBackendDescriptor_t execution_plan,
-                          hipdnnBackendDescriptor_t variant_pack) const;
+    virtual size_t get_workspace_size(int64_t engine_id,
+                                      const hipdnnPluginConstData_t* engine_config,
+                                      const Graph_descriptor* graph_desc) const;
 
 private:
     // MT-unsafe instance methods
@@ -79,10 +79,6 @@ private:
         get_engine_details(const std::shared_ptr<Engine_plugin_resource_manager>& rm,
                            int64_t engine_id,
                            Graph_descriptor* graph_desc);
-
-    size_t get_workspace_size(int64_t engine_id,
-                              const hipdnnPluginConstData_t* engine_config,
-                              Graph_descriptor* graph_desc) const;
 
     hipdnnEnginePluginExecutionContext_t
         create_execution_context(int64_t engine_id,

--- a/backend/src/plugin/plugin_manager.cpp
+++ b/backend/src/plugin/plugin_manager.cpp
@@ -60,29 +60,6 @@ void Plugin_manager::finalize_engine_heuristic(hipdnnBackendDescriptor_t desc)
     heuristic->set_engine_ids(engine_ids);
 }
 
-void Plugin_manager::finalize_engine_config(hipdnnBackendDescriptor_t desc)
-{
-    auto config_desc = desc->as_descriptor<Engine_config_descriptor>();
-
-    auto engine_desc = config_desc->get_engine();
-
-    auto graph_desc = engine_desc->get_graph();
-
-    int64_t engine_id = engine_desc->get_engine_id();
-
-    auto plugin = get_plugin(engine_id);
-
-    // TODO - We need to construct + store the engine config fbs with the properties that the user of the API set for the engine config,
-    // and then pass that to the plugin as well here.
-    auto applicable_engines = plugin->get_applicable_engines(graph_desc.get());
-    THROW_IF_FALSE(applicable_engines.contains(engine_id),
-                   HIPDNN_STATUS_BAD_PARAM,
-                   std::string("Plugin does not support engine id: ") + std::to_string(engine_id));
-
-    config_desc->set_max_workspace_size(
-        plugin->get_max_workspace_size(graph_desc.get(), engine_id));
-}
-
 std::set<int64_t> Plugin_manager::get_applicable_engines(const Graph_descriptor* graph)
 {
     std::set<int64_t> applicable_engines;

--- a/backend/src/plugin/plugin_manager.hpp
+++ b/backend/src/plugin/plugin_manager.hpp
@@ -20,12 +20,6 @@ struct Plugin_manager
     // the wrapper hipDNNPlugin objects
     void initialize(/* heuristics */);
 
-    // This queries the workspace details for the given engine config, and then sets the
-    // workspace in the Engine_config_descriptor.  This should throw if
-    // an error occurs that prevents the workspace size from being set on the engine
-    // config.
-    void finalize_engine_config(hipdnnBackendDescriptor_t desc);
-
     // This populates the ordered results of the applicable engines inside the heuristic descriptor.
     void finalize_engine_heuristic(hipdnnBackendDescriptor_t desc);
 

--- a/backend/tests/CMakeLists.txt
+++ b/backend/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(hipdnn_backend_tests
     ${CMAKE_DL_LIBS}
 )
 
+
 target_compile_definitions(hipdnn_backend_tests PRIVATE HIPDNN_BACKEND_COMPILATION)
 target_compile_options(hipdnn_backend_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 clang_tidy_check(hipdnn_backend_tests)

--- a/backend/tests/descriptors/mocks/mock_descriptor.hpp
+++ b/backend/tests/descriptors/mocks/mock_descriptor.hpp
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "descriptors/backend_descriptor.hpp"
+#include "descriptors/engine_descriptor.hpp"
+#include "descriptors/graph_descriptor.hpp"
 
 #include <gmock/gmock.h>
 
@@ -35,6 +37,65 @@ public:
     static hipdnnBackendDescriptorType_t get_static_type()
     {
         return Desc_type::get_static_type();
+    }
+};
+
+class Mock_engine_descriptor : public Engine_descriptor
+{
+public:
+    MOCK_METHOD(void, finalize, (), (override));
+    MOCK_METHOD(bool, is_finalized, (), (const, override));
+    MOCK_METHOD(void,
+                set_attribute,
+                (hipdnnBackendAttributeName_t attribute_name,
+                 hipdnnBackendAttributeType_t attribute_type,
+                 int64_t element_count,
+                 const void* array_of_element),
+                (override));
+    MOCK_METHOD(void,
+                get_attribute,
+                (hipdnnBackendAttributeName_t attribute_name,
+                 hipdnnBackendAttributeType_t attribute_type,
+                 int64_t requested_element_count,
+                 int64_t* element_count,
+                 void* array_of_elements),
+                (const, override));
+
+    MOCK_METHOD(std::shared_ptr<const Graph_descriptor>, get_graph, (), (const, override));
+    MOCK_METHOD(int64_t, get_engine_id, (), (const, override));
+
+    static hipdnnBackendDescriptorType_t get_static_type()
+    {
+        return HIPDNN_BACKEND_ENGINE_DESCRIPTOR;
+    }
+};
+
+class Mock_graph_descriptor : public Graph_descriptor
+{
+public:
+    MOCK_METHOD(void, finalize, (), (override));
+    MOCK_METHOD(bool, is_finalized, (), (const, override));
+    MOCK_METHOD(void,
+                set_attribute,
+                (hipdnnBackendAttributeName_t attribute_name,
+                 hipdnnBackendAttributeType_t attribute_type,
+                 int64_t element_count,
+                 const void* array_of_element),
+                (override));
+    MOCK_METHOD(void,
+                get_attribute,
+                (hipdnnBackendAttributeName_t attribute_name,
+                 hipdnnBackendAttributeType_t attribute_type,
+                 int64_t requested_element_count,
+                 int64_t* element_count,
+                 void* array_of_elements),
+                (const, override));
+
+    MOCK_METHOD(hipdnnHandle_t, get_handle, (), (const, override));
+
+    static hipdnnBackendDescriptorType_t get_static_type()
+    {
+        return HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR;
     }
 };
 

--- a/backend/tests/descriptors/mocks/mock_engine_plugin_resource_manager.hpp
+++ b/backend/tests/descriptors/mocks/mock_engine_plugin_resource_manager.hpp
@@ -1,0 +1,28 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include "plugin/engine_plugin_resource_manager.hpp"
+#include <gmock/gmock.h>
+
+namespace hipdnn_backend
+{
+namespace plugin
+{
+struct Mock_engine_plugin_resource_manager : Engine_plugin_resource_manager
+{
+    MOCK_METHOD(void, set_stream, (hipStream_t stream), (const, override));
+    MOCK_METHOD(void,
+                execute_op_graph,
+                (hipdnnBackendDescriptor_t execution_plan, hipdnnBackendDescriptor_t variant_pack),
+                (const, override));
+    MOCK_METHOD(size_t,
+                get_workspace_size,
+                (int64_t engine_id,
+                 const hipdnnPluginConstData_t* engine_config,
+                 const hipdnn_backend::Graph_descriptor* graph_desc),
+                (const, override));
+};
+}
+}

--- a/backend/tests/descriptors/mocks/mock_handle.hpp
+++ b/backend/tests/descriptors/mocks/mock_handle.hpp
@@ -1,0 +1,17 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include "handle/handle.hpp"
+#include <gmock/gmock.h>
+
+struct Mock_handle : hipdnnHandle
+{
+    MOCK_METHOD(void, set_stream, (hipStream_t stream), (override));
+    MOCK_METHOD(hipStream_t, get_stream, (), (const, override));
+    MOCK_METHOD(std::shared_ptr<hipdnn_backend::plugin::Engine_plugin_resource_manager>,
+                get_plugin_resource_manager,
+                (),
+                (const, override));
+};

--- a/backend/tests/descriptors/test_engine_config_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_config_descriptor.cpp
@@ -3,9 +3,12 @@
 
 #include "descriptors/engine_config_descriptor.hpp"
 #include "descriptors/engine_descriptor.hpp"
+#include "descriptors/graph_descriptor.hpp"
 #include "descriptors/scoped_descriptor.hpp"
 #include "hipdnn_backend.h"
 #include "mocks/mock_descriptor.hpp"
+#include "mocks/mock_engine_plugin_resource_manager.hpp"
+#include "mocks/mock_handle.hpp"
 #include "test_descriptor_utils.hpp"
 #include "test_macros.hpp"
 
@@ -14,6 +17,8 @@
 #include <memory>
 
 using namespace hipdnn_backend;
+using namespace plugin;
+using namespace ::testing;
 
 using ::testing::Return;
 
@@ -24,20 +29,29 @@ public:
     std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_wrapper = nullptr;
     std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_bad_type_wrapper = nullptr;
     std::unique_ptr<hipdnnBackendDescriptor> _mock_wrong_type_wrapper = nullptr;
+    std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_wrapper = nullptr;
+    std::unique_ptr<Mock_handle> _mock_handle = nullptr;
+    std::shared_ptr<Mock_engine_plugin_resource_manager> _mock_engine_plugin_resource_manager
+        = nullptr;
 
     std::shared_ptr<Engine_config_descriptor> get_engine_config_descriptor() const
     {
-        return _engine_config_wrapper->as_descriptor<Engine_config_descriptor>();
+        return _engine_config_wrapper->as_descriptor_unsafe<Engine_config_descriptor>();
     }
 
-    std::shared_ptr<Mock_descriptor<Engine_descriptor>> get_mock_engine() const
+    std::shared_ptr<Mock_engine_descriptor> get_mock_engine() const
     {
-        return _mock_engine_wrapper->as_descriptor<Mock_descriptor<Engine_descriptor>>();
+        return _mock_engine_wrapper->as_descriptor_unsafe<Mock_engine_descriptor>();
     }
 
-    std::shared_ptr<Mock_descriptor<Engine_descriptor>> get_mock_engine_bad_type() const
+    std::shared_ptr<Mock_engine_descriptor> get_mock_engine_bad_type() const
     {
-        return _mock_engine_bad_type_wrapper->as_descriptor<Mock_descriptor<Engine_descriptor>>();
+        return _mock_engine_bad_type_wrapper->as_descriptor_unsafe<Mock_engine_descriptor>();
+    }
+
+    std::shared_ptr<Mock_graph_descriptor> get_mock_graph_descriptor() const
+    {
+        return _mock_graph_wrapper->as_descriptor_unsafe<Mock_graph_descriptor>();
     }
 
     void set_engine() const
@@ -50,16 +64,20 @@ public:
                                                           &_mock_engine_wrapper));
     }
 
-    void set_max_workspace_size() const
-    {
-        ASSERT_NO_THROW(get_engine_config_descriptor()->set_max_workspace_size(1024));
-    }
-
     void make_engine_config_finalized() const
     {
         set_engine();
+        EXPECT_CALL(*get_mock_engine(), is_finalized()).WillRepeatedly(Return(true));
+        EXPECT_CALL(*get_mock_engine(), get_engine_id()).WillRepeatedly(Return(1));
+        EXPECT_CALL(*get_mock_engine(), get_graph())
+            .WillRepeatedly(Return(get_mock_graph_descriptor()));
+        EXPECT_CALL(*get_mock_graph_descriptor(), get_handle())
+            .WillOnce(Return(_mock_handle.get()));
+        EXPECT_CALL(*_mock_handle, get_plugin_resource_manager())
+            .WillOnce(Return(_mock_engine_plugin_resource_manager));
+        EXPECT_CALL(*_mock_engine_plugin_resource_manager, get_workspace_size(_, _, _))
+            .WillOnce(Return(1024));
         ASSERT_NO_THROW(get_engine_config_descriptor()->finalize());
-        set_max_workspace_size();
     }
 
 protected:
@@ -67,12 +85,15 @@ protected:
     {
         _engine_config_wrapper
             = test_descriptor_utils::create_descriptor<Engine_config_descriptor>();
-        _mock_engine_wrapper
-            = test_descriptor_utils::create_descriptor<Mock_descriptor<Engine_descriptor>>();
+        _mock_engine_wrapper = test_descriptor_utils::create_descriptor<Mock_engine_descriptor>();
         _mock_engine_bad_type_wrapper
-            = test_descriptor_utils::create_descriptor<Mock_descriptor<Engine_descriptor>>();
+            = test_descriptor_utils::create_descriptor<Mock_engine_descriptor>();
         _mock_wrong_type_wrapper
             = test_descriptor_utils::create_descriptor<Mock_descriptor<Engine_config_descriptor>>();
+        _mock_graph_wrapper = test_descriptor_utils::create_descriptor<Mock_graph_descriptor>();
+        _mock_handle = std::make_unique<Mock_handle>();
+        _mock_engine_plugin_resource_manager
+            = std::make_shared<Mock_engine_plugin_resource_manager>();
     }
 };
 
@@ -132,22 +153,6 @@ TEST_F(Engine_config_descriptor_test, SetEngineConfigDescriptorEngine)
         HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &_mock_engine_wrapper));
 }
 
-TEST_F(Engine_config_descriptor_test, SetEngineConfigDescriptorMaxWorkspaceSize)
-{
-    auto engine_config = get_engine_config_descriptor();
-    int64_t workspace_size = 1024;
-    int64_t bad_workspace_size = -1024;
-
-    ASSERT_THROW_HIPDNN_STATUS(engine_config->set_max_workspace_size(bad_workspace_size),
-                               HIPDNN_STATUS_INTERNAL_ERROR);
-
-    ASSERT_THROW_HIPDNN_STATUS(engine_config->set_max_workspace_size(workspace_size),
-                               HIPDNN_STATUS_INTERNAL_ERROR);
-
-    make_engine_config_finalized();
-    ASSERT_NO_THROW(engine_config->set_max_workspace_size(workspace_size));
-}
-
 TEST_F(Engine_config_descriptor_test, SetAttrOnFinalizedEngineConfigDescriptor)
 {
     auto engine_config = get_engine_config_descriptor();
@@ -164,10 +169,7 @@ TEST_F(Engine_config_descriptor_test, FinalizeEngineConfigDescriptor)
     auto engine_config = get_engine_config_descriptor();
     ASSERT_THROW_HIPDNN_STATUS(engine_config->finalize(), HIPDNN_STATUS_BAD_PARAM);
 
-    set_engine();
-
-    ASSERT_NO_THROW(engine_config->finalize());
-    set_max_workspace_size();
+    make_engine_config_finalized();
 }
 
 TEST_F(Engine_config_descriptor_test, GetAttrOnUnfinalizedEngineConfigDescriptor)


### PR DESCRIPTION
## Proposed changes

Add engine config descriptor integration logic, remove stubbed integration logic, update tests to support it.

Note: It breaks public API tests since we are missing testing plugins to provide equivalent results as before.
