### PR TITLE
[ALMIOPEN-131]: Set the stream on miopen when its set via the plugin engine api

### DIFF
--- a/plugins/miopen_legacy_plugin/hipdnn_engine_plugin_handle.hpp
+++ b/plugins/miopen_legacy_plugin/hipdnn_engine_plugin_handle.hpp
@@ -5,6 +5,8 @@
 
 #include <miopen/miopen.h>
 
+#include <hipdnn_sdk/plugin/plugin_exception.hpp>
+
 #include "miopen_container.hpp"
 
 struct hipdnnEnginePluginHandle
@@ -13,11 +15,35 @@ public:
     virtual ~hipdnnEnginePluginHandle() = default;
 
     miopenHandle_t miopen_handle = nullptr;
-    hipStream_t stream = nullptr;
+
+    void set_stream(hipStream_t stream)
+    {
+        _stream = stream;
+        miopenStatus_t status = miopenSetStream(miopen_handle, stream);
+        if(status != miopenStatusSuccess)
+        {
+            _stream = nullptr;
+            throw hipdnn_plugin::Hipdnn_plugin_exception(
+                HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR, "Failed set the stream on the MIOpen handle");
+        }
+    }
+
+    hipStream_t get_stream() const
+    {
+        if(_stream == nullptr)
+        {
+            throw hipdnn_plugin::Hipdnn_plugin_exception(HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+                                                         "Stream is not set on the MIOpen handle");
+        }
+        return _stream;
+    }
 
     std::shared_ptr<miopen_legacy_plugin::Miopen_container> miopen_container;
     miopen_legacy_plugin::Engine_manager& get_engine_manager()
     {
         return miopen_container->get_engine_manager();
     }
+
+private:
+    hipStream_t _stream = nullptr;
 };

--- a/plugins/miopen_legacy_plugin/hipdnn_engine_plugin_handle.hpp
+++ b/plugins/miopen_legacy_plugin/hipdnn_engine_plugin_handle.hpp
@@ -8,6 +8,7 @@
 #include <hipdnn_sdk/plugin/plugin_exception.hpp>
 
 #include "miopen_container.hpp"
+#include "miopen_utils.hpp"
 
 struct hipdnnEnginePluginHandle
 {
@@ -18,14 +19,8 @@ public:
 
     void set_stream(hipStream_t stream)
     {
+        THROW_ON_MIOPEN_FAILURE(miopenSetStream(miopen_handle, stream));
         _stream = stream;
-        miopenStatus_t status = miopenSetStream(miopen_handle, stream);
-        if(status != miopenStatusSuccess)
-        {
-            _stream = nullptr;
-            throw hipdnn_plugin::Hipdnn_plugin_exception(
-                HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR, "Failed set the stream on the MIOpen handle");
-        }
     }
 
     hipStream_t get_stream() const

--- a/plugins/miopen_legacy_plugin/miopen_legacy_plugin.cpp
+++ b/plugins/miopen_legacy_plugin/miopen_legacy_plugin.cpp
@@ -177,7 +177,7 @@ hipdnnPluginStatus_t hipdnnEnginePluginSetStream(hipdnnEnginePluginHandle_t hand
     return hipdnn_plugin::try_catch([&, api_name = __func__]() {
         throw_if_null(handle);
 
-        handle->stream = stream;
+        handle->set_stream(stream);
 
         LOG_API_SUCCESS(api_name, "");
     });

--- a/plugins/miopen_legacy_plugin/tests/test_miopen_legacy_engine_plugin_api.cpp
+++ b/plugins/miopen_legacy_plugin/tests/test_miopen_legacy_engine_plugin_api.cpp
@@ -90,7 +90,7 @@ TEST(MiopenLegacyEnginePluginApiTest, EnginePluginSetStreamValidStream)
 
     auto stream = reinterpret_cast<hipStream_t>(0x1234);
     EXPECT_EQ(hipdnnEnginePluginSetStream(handle, stream), HIPDNN_PLUGIN_STATUS_SUCCESS);
-    EXPECT_EQ(handle->stream, stream);
+    EXPECT_EQ(handle->get_stream(), stream);
 
     EXPECT_EQ(hipdnnEnginePluginDestroy(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
 }


### PR DESCRIPTION
## Proposed changes

fix issue where miopen doesnt get the stream supplied to the plugin

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [ ] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [ ] I have ran the tests, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] I have ran `make format` & `make check_format` to ensure the changes have been formatted
