### PR TITLE
default miopen plugin build on.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_CXX_STANDARD 20)
 option(HIP_DNN_BUILD_BACKEND "Build the backend code" ON)
 option(HIP_DNN_BUILD_FRONTEND "Build the frontend code" ON)
 option(HIP_DNN_SKIP_TESTS "Skips building all tests" OFF)
-option(HIP_DNN_BUILD_PLUGINS "Builds the plugins as part of the main cmake" OFF)
+option(HIP_DNN_BUILD_PLUGINS "Builds the plugins as part of the main cmake" ON)
 
 option(CODE_COVERAGE "Build with code coverage flags" OFF)
 option(ENABLE_CLANG_TIDY "Enable Clang-Tidy checks" ON)

--- a/plugins/miopen_legacy_plugin/tests/test_miopen_legacy_engine_plugin_api.cpp
+++ b/plugins/miopen_legacy_plugin/tests/test_miopen_legacy_engine_plugin_api.cpp
@@ -88,11 +88,13 @@ TEST(MiopenLegacyEnginePluginApiTest, EnginePluginSetStreamValidStream)
     hipdnnEnginePluginHandle_t handle = nullptr;
     EXPECT_EQ(hipdnnEnginePluginCreate(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
 
-    auto stream = reinterpret_cast<hipStream_t>(0x1234);
+    hipStream_t stream = nullptr;
+    EXPECT_EQ(hipStreamCreate(&stream), hipSuccess);
     EXPECT_EQ(hipdnnEnginePluginSetStream(handle, stream), HIPDNN_PLUGIN_STATUS_SUCCESS);
     EXPECT_EQ(handle->get_stream(), stream);
 
     EXPECT_EQ(hipdnnEnginePluginDestroy(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(hipStreamDestroy(stream), hipSuccess);
 }
 
 TEST(MiopenLegacyEnginePluginApiTest, EnginePluginGetApplicableEngineIdsNull)

--- a/sdk/include/hipdnn_sdk/plugin/plugin_api_data_types.h
+++ b/sdk/include/hipdnn_sdk/plugin/plugin_api_data_types.h
@@ -51,7 +51,7 @@ typedef enum
 } hipdnnPluginType_t;
 
 /**
- * @brief Structure for describing a constant data buffer. 
+ * @brief Structure for describing a constant data buffer.
  *
  * This structure provides a way to pass buffer information (a pointer and a size) into and out of functions.
  */

--- a/sdk/include/hipdnn_sdk/plugin/plugin_api_data_types.h
+++ b/sdk/include/hipdnn_sdk/plugin/plugin_api_data_types.h
@@ -51,7 +51,7 @@ typedef enum
 } hipdnnPluginType_t;
 
 /**
- * @brief Structure for describing a constant data buffer.
+ * @brief Structure for describing a constant data buffer. 
  *
  * This structure provides a way to pass buffer information (a pointer and a size) into and out of functions.
  */


### PR DESCRIPTION
## Proposed changes

make plugins build on the CI by default.  They were turned off until the CI image had the miopen devel package installed. This should now be working.

This PR MUST pass all 3 CI checks before merging. 

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [ ] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [ ] I have ran the tests, and they are all passing locally
- [ ] I have ran the tests with ASAN, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] I have ran `make format` & `make check_format` to ensure the changes have been formatted
