### PR TITLE
[ALMIOPEN-135]: Check target now uses gtest intead of ctest by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,39 +62,7 @@ include(cmake/Dependencies.cmake)
 include(cmake/ClangCheck.cmake)
 include(cmake/ClangTidy.cmake)
 include(cmake/Sanitizers.cmake)
-
-hipdnn_add_dependency(GTest v1.16.0)
-
-enable_testing() # Cmake wont discover or run tests without this line
-
-
-set(CHECK_COMMAND_GLOBAL "" CACHE INTERNAL "Accumulated check commands" FORCE)
-set(CHECK_DEPENDS_GLOBAL "" CACHE INTERNAL "Accumulated check depends" FORCE)
-function(append_test_to_check_target TARGET WORKING_DIR)
-    message(STATUS "Appending check target: ${TARGET} in working directory: ${WORKING_DIR}")
-
-    set(NEW_COMMAND "")
-    if("${CHECK_COMMAND_GLOBAL}" STREQUAL "")
-        set(NEW_COMMAND cd ${WORKING_DIR} && ./${TARGET})
-    else()
-        set(NEW_COMMAND && cd ${WORKING_DIR} && ./${TARGET})
-    endif()
-    set(CHECK_COMMAND_GLOBAL ${CHECK_COMMAND_GLOBAL} ${NEW_COMMAND} CACHE INTERNAL "Accumulated check targets" FORCE)
-    set(CHECK_DEPENDS_GLOBAL ${CHECK_DEPENDS_GLOBAL} ${TARGET} CACHE INTERNAL "Accumulated check depends" FORCE)    
-endfunction()
-
-function(finalize_custom_check_target)
-    add_custom_target(
-        check
-        COMMAND ${CHECK_COMMAND_GLOBAL}
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        DEPENDS ${CHECK_DEPENDS_GLOBAL}
-        VERBATIM)
-endfunction()
-
-# Add a check target which will run all tests discovered by gtest_discover_tests via ctest. 
-add_custom_target(check_ctest COMMAND ${TEST_ENVIRONMENT} ${CMAKE_CTEST_COMMAND} --output-on-failure -C ${CMAKE_CFG_INTDIR})
-
+include(cmake/Tests.cmake)
 
 # Add global compile options
 set(EXTRA_COMPILE_OPTIONS)
@@ -152,7 +120,7 @@ if(HIP_DNN_BUILD_PLUGINS)
 endif()
 
 # keep this after all build folder have been added so they have a chance to register their tests
-# using append_check_target
+# using append_test_to_check_target
 finalize_custom_check_target()
 
 if(CODE_COVERAGE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,8 +67,28 @@ hipdnn_add_dependency(GTest v1.16.0)
 
 enable_testing() # Cmake wont discover or run tests without this line
 
+
+set(CHECK_COMMAND_GLOBAL "ls" CACHE INTERNAL "Accumulated check commands" FORCE)
+set(CHECK_DEPENDS_GLOBAL "" CACHE INTERNAL "Accumulated check depends" FORCE)
+function(append_check_target TARGET WORKING_DIR)
+    message(STATUS "Appending check target: ${TARGET} in working directory: ${WORKING_DIR}")
+
+    set(CHECK_COMMAND_GLOBAL ${CHECK_COMMAND_GLOBAL} && cd ${WORKING_DIR} && ./${TARGET} CACHE INTERNAL "Accumulated check targets" FORCE)
+    set(CHECK_DEPENDS_GLOBAL ${CHECK_DEPENDS_GLOBAL} ${TARGET} CACHE INTERNAL "Accumulated check depends" FORCE)    
+endfunction()
+
+function(create_custom_check_target)
+    add_custom_target(
+        check
+        COMMAND ${CHECK_COMMAND_GLOBAL}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        DEPENDS ${CHECK_DEPENDS_GLOBAL}
+        VERBATIM)
+endfunction()
+
 # Add a check target which will run all tests discovered by gtest_discover_tests via ctest. 
-add_custom_target(check COMMAND ${TEST_ENVIRONMENT} ${CMAKE_CTEST_COMMAND} --output-on-failure -C ${CMAKE_CFG_INTDIR})
+add_custom_target(check_ctest COMMAND ${TEST_ENVIRONMENT} ${CMAKE_CTEST_COMMAND} --output-on-failure -C ${CMAKE_CFG_INTDIR})
+
 
 # Add global compile options
 set(EXTRA_COMPILE_OPTIONS)
@@ -124,6 +144,16 @@ add_subdirectory(tests)
 if(HIP_DNN_BUILD_PLUGINS)
     add_subdirectory(plugins)
 endif()
+
+# keep this after all build folder have been added so they have a chance to register their tests
+# using append_check_target
+create_custom_check_target()
+#add_custom_target(
+#    check2 
+#    COMMAND ${CHECK_COMMAND_GLOBAL}
+#    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+#    DEPENDS ${CHECK_DEPENDS_GLOBAL}
+#    VERBATIM)
 
 if(CODE_COVERAGE)
     set(PLUGINS_COMMAND "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,16 +68,22 @@ hipdnn_add_dependency(GTest v1.16.0)
 enable_testing() # Cmake wont discover or run tests without this line
 
 
-set(CHECK_COMMAND_GLOBAL "ls" CACHE INTERNAL "Accumulated check commands" FORCE)
+set(CHECK_COMMAND_GLOBAL "" CACHE INTERNAL "Accumulated check commands" FORCE)
 set(CHECK_DEPENDS_GLOBAL "" CACHE INTERNAL "Accumulated check depends" FORCE)
-function(append_check_target TARGET WORKING_DIR)
+function(append_test_to_check_target TARGET WORKING_DIR)
     message(STATUS "Appending check target: ${TARGET} in working directory: ${WORKING_DIR}")
 
-    set(CHECK_COMMAND_GLOBAL ${CHECK_COMMAND_GLOBAL} && cd ${WORKING_DIR} && ./${TARGET} CACHE INTERNAL "Accumulated check targets" FORCE)
+    set(NEW_COMMAND "")
+    if("${CHECK_COMMAND_GLOBAL}" STREQUAL "")
+        set(NEW_COMMAND cd ${WORKING_DIR} && ./${TARGET})
+    else()
+        set(NEW_COMMAND && cd ${WORKING_DIR} && ./${TARGET})
+    endif()
+    set(CHECK_COMMAND_GLOBAL ${CHECK_COMMAND_GLOBAL} ${NEW_COMMAND} CACHE INTERNAL "Accumulated check targets" FORCE)
     set(CHECK_DEPENDS_GLOBAL ${CHECK_DEPENDS_GLOBAL} ${TARGET} CACHE INTERNAL "Accumulated check depends" FORCE)    
 endfunction()
 
-function(create_custom_check_target)
+function(finalize_custom_check_target)
     add_custom_target(
         check
         COMMAND ${CHECK_COMMAND_GLOBAL}
@@ -147,45 +153,22 @@ endif()
 
 # keep this after all build folder have been added so they have a chance to register their tests
 # using append_check_target
-create_custom_check_target()
-#add_custom_target(
-#    check2 
-#    COMMAND ${CHECK_COMMAND_GLOBAL}
-#    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-#    DEPENDS ${CHECK_DEPENDS_GLOBAL}
-#    VERBATIM)
+finalize_custom_check_target()
 
 if(CODE_COVERAGE)
-    set(PLUGINS_COMMAND "")
     if(HIP_DNN_BUILD_PLUGINS)
-        set(PLUGIN_CODE_COVERAGE_DEPENDS miopen_legacy_plugin_tests)
         set(MIOPEN_PLUGIN_CODE_COVERAGE_OBJECT -object ./plugins/miopen_legacy_plugin/libmiopen_legacy_plugin.so -object ./plugins/miopen_legacy_plugin/tests/miopen_legacy_plugin_tests)
-        set(PLUGINS_COMMAND cd ${CMAKE_BINARY_DIR}/plugins/miopen_legacy_plugin/tests && ./miopen_legacy_plugin_tests)
     endif()
 
     set(CODE_COVERAGE_IGNORE_REGEX "\(.*deps.*\)|\(.*tests.*\)|\(.*sdk/include/hipdnn_sdk/data_objects.*\)|\(.*sdk/include/hipdnn_sdk/test_utilities.*\)|\(.*sdk/include/hipdnn_sdk/plugin/test_utils.*\)")
     set(CODE_COVERAGE_OBJECTS -object ./backend/src/libhipdnn_backend.so -object ./backend/tests/hipdnn_backend_tests -object ./frontend/tests/hipdnn_frontend_tests -object ./tests/backend/public_hipdnn_backend_tests -object ./sdk/tests/hipdnn_sdk_tests ${MIOPEN_PLUGIN_CODE_COVERAGE_OBJECT})
     
-    set(CODE_COVERAGE_DEPENDS hipdnn_backend_tests hipdnn_frontend_tests public_hipdnn_backend_tests hipdnn_sdk_tests ${PLUGIN_CODE_COVERAGE_DEPENDS})
-
     add_custom_target(
         code_coverage
-        # Use absolute paths for each cd command, since Make and Ninja execute from different directories
-        COMMAND cd ${CMAKE_BINARY_DIR}/backend/tests && ./hipdnn_backend_tests
-        COMMAND cd ${CMAKE_BINARY_DIR}/frontend/tests && ./hipdnn_frontend_tests
-        COMMAND cd ${CMAKE_BINARY_DIR}/tests/backend && ./public_hipdnn_backend_tests
-        COMMAND cd ${CMAKE_BINARY_DIR}/sdk/tests && ./hipdnn_sdk_tests
-        COMMAND ${PLUGINS_COMMAND}
-
         COMMAND cd ${CMAKE_BINARY_DIR} && find . -name "*.profraw" -print0 | xargs -0 /opt/rocm/llvm/bin/llvm-profdata merge -sparse -o ./hipdnn.profdata
         COMMAND /opt/rocm/llvm/bin/llvm-cov report ${CODE_COVERAGE_OBJECTS} -instr-profile=./hipdnn.profdata -ignore-filename-regex=\"${CODE_COVERAGE_IGNORE_REGEX}\" > ./code_cov_hipdnn.report
         COMMAND /opt/rocm/llvm/bin/llvm-cov show -Xdemangler=/opt/rocm/llvm/bin/llvm-cxxfilt ${CODE_COVERAGE_OBJECTS} -instr-profile=./hipdnn.profdata -ignore-filename-regex=\"${CODE_COVERAGE_IGNORE_REGEX}\" --format=html --output-dir=./hipdnn_coverage_html
-        # We cant depend on the make check target due to the fact that ctest runs each test in a separate process
-        # this causes the .profraw file to get rewritten every time a test executes.  This means we only get coverage
-        # for the test that runs last.  The current workaround is to simply invoke the gtests directly.
-        # This is not ideal but it works for now.
-        #DEPENDS check
-        DEPENDS ${CODE_COVERAGE_DEPENDS}
+        DEPENDS check
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         COMMENT "Generating code coverage report"
     )

--- a/backend/tests/CMakeLists.txt
+++ b/backend/tests/CMakeLists.txt
@@ -84,10 +84,4 @@ target_compile_options(hipdnn_test_engine_plugin1 PRIVATE ${HIPDNN_WARNING_COMPI
 clang_tidy_check(hipdnn_test_engine_plugin1)
 add_dependencies(hipdnn_backend_tests hipdnn_test_engine_plugin1)
 
-append_test_to_check_target(hipdnn_backend_tests ${CMAKE_CURRENT_BINARY_DIR})
-add_dependencies(check_ctest hipdnn_backend_tests)
-gtest_discover_tests(
-    hipdnn_backend_tests
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DISCOVERY_MODE PRE_TEST
-)
+add_target_to_check_targets(hipdnn_backend_tests ${CMAKE_CURRENT_BINARY_DIR})

--- a/backend/tests/CMakeLists.txt
+++ b/backend/tests/CMakeLists.txt
@@ -84,7 +84,8 @@ target_compile_options(hipdnn_test_engine_plugin1 PRIVATE ${HIPDNN_WARNING_COMPI
 clang_tidy_check(hipdnn_test_engine_plugin1)
 add_dependencies(hipdnn_backend_tests hipdnn_test_engine_plugin1)
 
-add_dependencies(check hipdnn_backend_tests)
+append_check_target(hipdnn_backend_tests ${CMAKE_CURRENT_BINARY_DIR})
+add_dependencies(check_ctest hipdnn_backend_tests)
 gtest_discover_tests(
     hipdnn_backend_tests
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/backend/tests/CMakeLists.txt
+++ b/backend/tests/CMakeLists.txt
@@ -84,7 +84,7 @@ target_compile_options(hipdnn_test_engine_plugin1 PRIVATE ${HIPDNN_WARNING_COMPI
 clang_tidy_check(hipdnn_test_engine_plugin1)
 add_dependencies(hipdnn_backend_tests hipdnn_test_engine_plugin1)
 
-append_check_target(hipdnn_backend_tests ${CMAKE_CURRENT_BINARY_DIR})
+append_test_to_check_target(hipdnn_backend_tests ${CMAKE_CURRENT_BINARY_DIR})
 add_dependencies(check_ctest hipdnn_backend_tests)
 gtest_discover_tests(
     hipdnn_backend_tests

--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -1,0 +1,44 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+hipdnn_add_dependency(GTest v1.16.0)
+include(GoogleTest)
+
+set(CHECK_COMMAND_GLOBAL "" CACHE INTERNAL "Accumulated check commands" FORCE)
+set(CHECK_DEPENDS_GLOBAL "" CACHE INTERNAL "Accumulated check depends" FORCE)
+function(append_test_to_check_target TARGET WORKING_DIR)
+    message(STATUS "Appending check target: ${TARGET} in working directory: ${WORKING_DIR}")
+
+    set(NEW_COMMAND "")
+    if("${CHECK_COMMAND_GLOBAL}" STREQUAL "")
+    set(NEW_COMMAND cd ${WORKING_DIR} && ./${TARGET})
+    else()
+    set(NEW_COMMAND && cd ${WORKING_DIR} && ./${TARGET})
+    endif()
+    set(CHECK_COMMAND_GLOBAL ${CHECK_COMMAND_GLOBAL} ${NEW_COMMAND} CACHE INTERNAL "Accumulated check targets" FORCE)
+    set(CHECK_DEPENDS_GLOBAL ${CHECK_DEPENDS_GLOBAL} ${TARGET} CACHE INTERNAL "Accumulated check depends" FORCE)    
+endfunction()
+
+function(finalize_custom_check_target)
+add_custom_target(
+    check
+    COMMAND ${CHECK_COMMAND_GLOBAL}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    DEPENDS ${CHECK_DEPENDS_GLOBAL}
+    VERBATIM)
+endfunction()
+
+enable_testing() # Cmake wont discover or run tests without this line
+
+# Add a check_ctest target which will run all tests discovered by gtest_discover_tests via ctest. 
+add_custom_target(check_ctest COMMAND ${TEST_ENVIRONMENT} ${CMAKE_CTEST_COMMAND} --output-on-failure -C ${CMAKE_CFG_INTDIR})
+
+function(add_target_to_check_targets TARGET WORKING_DIR)
+    append_test_to_check_target(${TARGET} ${WORKING_DIR})
+    add_dependencies(check_ctest ${TARGET})
+    gtest_discover_tests(
+        ${TARGET}
+        WORKING_DIRECTORY ${WORKING_DIR}
+        DISCOVERY_MODE PRE_TEST
+    )
+endfunction()

--- a/frontend/tests/CMakeLists.txt
+++ b/frontend/tests/CMakeLists.txt
@@ -49,10 +49,4 @@ clang_tidy_check(hipdnn_frontend_tests)
 
 add_dependencies(hipdnn_frontend_tests generate_hipdnn_sdk_headers)
 
-append_test_to_check_target(hipdnn_frontend_tests ${CMAKE_CURRENT_BINARY_DIR})
-add_dependencies(check_ctest hipdnn_frontend_tests)
-gtest_discover_tests(
-    hipdnn_frontend_tests
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DISCOVERY_MODE PRE_TEST
-)
+add_target_to_check_targets(hipdnn_frontend_tests ${CMAKE_CURRENT_BINARY_DIR})

--- a/frontend/tests/CMakeLists.txt
+++ b/frontend/tests/CMakeLists.txt
@@ -48,7 +48,9 @@ target_link_libraries(hipdnn_frontend_tests
 clang_tidy_check(hipdnn_frontend_tests)
 
 add_dependencies(hipdnn_frontend_tests generate_hipdnn_sdk_headers)
-add_dependencies(check hipdnn_frontend_tests)
+
+append_check_target(hipdnn_frontend_tests ${CMAKE_CURRENT_BINARY_DIR})
+add_dependencies(check_ctest hipdnn_frontend_tests)
 gtest_discover_tests(
     hipdnn_frontend_tests
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/frontend/tests/CMakeLists.txt
+++ b/frontend/tests/CMakeLists.txt
@@ -49,7 +49,7 @@ clang_tidy_check(hipdnn_frontend_tests)
 
 add_dependencies(hipdnn_frontend_tests generate_hipdnn_sdk_headers)
 
-append_check_target(hipdnn_frontend_tests ${CMAKE_CURRENT_BINARY_DIR})
+append_test_to_check_target(hipdnn_frontend_tests ${CMAKE_CURRENT_BINARY_DIR})
 add_dependencies(check_ctest hipdnn_frontend_tests)
 gtest_discover_tests(
     hipdnn_frontend_tests

--- a/plugins/miopen_legacy_plugin/tests/CMakeLists.txt
+++ b/plugins/miopen_legacy_plugin/tests/CMakeLists.txt
@@ -57,11 +57,5 @@ target_include_directories(miopen_legacy_plugin_tests PRIVATE
 if(BUILD_PLUGIN_AS_DEPENDENCY)
     clang_tidy_check(miopen_legacy_plugin_tests)
     
-    append_test_to_check_target(miopen_legacy_plugin_tests ${CMAKE_CURRENT_BINARY_DIR})
-    add_dependencies(check_ctest miopen_legacy_plugin_tests)
-    gtest_discover_tests(
-        miopen_legacy_plugin_tests
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        DISCOVERY_MODE PRE_TEST
-    )
+    add_target_to_check_targets(miopen_legacy_plugin_tests ${CMAKE_CURRENT_BINARY_DIR})
 endif()

--- a/plugins/miopen_legacy_plugin/tests/CMakeLists.txt
+++ b/plugins/miopen_legacy_plugin/tests/CMakeLists.txt
@@ -57,7 +57,7 @@ target_include_directories(miopen_legacy_plugin_tests PRIVATE
 if(BUILD_PLUGIN_AS_DEPENDENCY)
     clang_tidy_check(miopen_legacy_plugin_tests)
     
-    append_check_target(miopen_legacy_plugin_tests ${CMAKE_CURRENT_BINARY_DIR})
+    append_test_to_check_target(miopen_legacy_plugin_tests ${CMAKE_CURRENT_BINARY_DIR})
     add_dependencies(check_ctest miopen_legacy_plugin_tests)
     gtest_discover_tests(
         miopen_legacy_plugin_tests

--- a/plugins/miopen_legacy_plugin/tests/CMakeLists.txt
+++ b/plugins/miopen_legacy_plugin/tests/CMakeLists.txt
@@ -57,7 +57,8 @@ target_include_directories(miopen_legacy_plugin_tests PRIVATE
 if(BUILD_PLUGIN_AS_DEPENDENCY)
     clang_tidy_check(miopen_legacy_plugin_tests)
     
-    add_dependencies(check miopen_legacy_plugin_tests)
+    append_check_target(miopen_legacy_plugin_tests ${CMAKE_CURRENT_BINARY_DIR})
+    add_dependencies(check_ctest miopen_legacy_plugin_tests)
     gtest_discover_tests(
         miopen_legacy_plugin_tests
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -47,7 +47,9 @@ target_link_libraries(hipdnn_sdk_tests
     ${CMAKE_DL_LIBS}
 )
 
-add_dependencies(check hipdnn_sdk_tests)
+
+append_check_target(hipdnn_sdk_tests ${CMAKE_CURRENT_BINARY_DIR})
+add_dependencies(check_ctest hipdnn_sdk_tests)
 gtest_discover_tests(
     hipdnn_sdk_tests
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(hipdnn_sdk_tests
 )
 
 
-append_check_target(hipdnn_sdk_tests ${CMAKE_CURRENT_BINARY_DIR})
+append_test_to_check_target(hipdnn_sdk_tests ${CMAKE_CURRENT_BINARY_DIR})
 add_dependencies(check_ctest hipdnn_sdk_tests)
 gtest_discover_tests(
     hipdnn_sdk_tests

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -47,11 +47,5 @@ target_link_libraries(hipdnn_sdk_tests
     ${CMAKE_DL_LIBS}
 )
 
+add_target_to_check_targets(hipdnn_sdk_tests ${CMAKE_CURRENT_BINARY_DIR})
 
-append_test_to_check_target(hipdnn_sdk_tests ${CMAKE_CURRENT_BINARY_DIR})
-add_dependencies(check_ctest hipdnn_sdk_tests)
-gtest_discover_tests(
-    hipdnn_sdk_tests
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DISCOVERY_MODE PRE_TEST
-)

--- a/tests/backend/CMakeLists.txt
+++ b/tests/backend/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(public_hipdnn_backend_tests
     hip::host
 )
 
-append_check_target(public_hipdnn_backend_tests ${CMAKE_CURRENT_BINARY_DIR})
+append_test_to_check_target(public_hipdnn_backend_tests ${CMAKE_CURRENT_BINARY_DIR})
 clang_tidy_check(public_hipdnn_backend_tests)
 add_dependencies(check_ctest public_hipdnn_backend_tests)
 gtest_discover_tests(

--- a/tests/backend/CMakeLists.txt
+++ b/tests/backend/CMakeLists.txt
@@ -28,15 +28,10 @@ target_link_libraries(public_hipdnn_backend_tests
     hip::host
 )
 
-append_test_to_check_target(public_hipdnn_backend_tests ${CMAKE_CURRENT_BINARY_DIR})
-clang_tidy_check(public_hipdnn_backend_tests)
-add_dependencies(check_ctest public_hipdnn_backend_tests)
-gtest_discover_tests(
-    public_hipdnn_backend_tests
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DISCOVERY_MODE PRE_TEST
-)
 target_include_directories(public_hipdnn_backend_tests
     PRIVATE
     ${HIPDNN_TEST_INCLUDE_DIRS}
 )
+
+clang_tidy_check(public_hipdnn_backend_tests)
+add_target_to_check_targets(public_hipdnn_backend_tests ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/backend/CMakeLists.txt
+++ b/tests/backend/CMakeLists.txt
@@ -28,8 +28,9 @@ target_link_libraries(public_hipdnn_backend_tests
     hip::host
 )
 
-add_dependencies(check public_hipdnn_backend_tests)
+append_check_target(public_hipdnn_backend_tests ${CMAKE_CURRENT_BINARY_DIR})
 clang_tidy_check(public_hipdnn_backend_tests)
+add_dependencies(check_ctest public_hipdnn_backend_tests)
 gtest_discover_tests(
     public_hipdnn_backend_tests
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
## Proposed changes

Ctest runner is quite slow when running all the tests so swap over to gtest.  To make it so we dont need to manually update the test list I added a simple mechanism that accumulates the test targets before creating the check target at the end of configure.  The check target can now be used for code coverage.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [ ] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [ ] I have ran the tests, and they are all passing locally
- [ ] I have ran the tests with ASAN, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] I have ran `make format` & `make check_format` to ensure the changes have been formatted
