### PR TITLE
Engine plugin resource manager: engine descriptor integration

### DIFF
--- a/backend/src/CMakeLists.txt
+++ b/backend/src/CMakeLists.txt
@@ -37,6 +37,9 @@ target_include_directories(hipdnn_backend_private
 
 target_compile_options(hipdnn_backend_private PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 target_link_libraries(hipdnn_backend_private PUBLIC hip::host hipdnn_sdk)
+if(NOT WIN32)
+target_link_libraries(hipdnn_backend_private PRIVATE dl)
+endif()
 target_compile_definitions(hipdnn_backend_private PRIVATE HIPDNN_BACKEND_COMPILATION)
 
 clang_tidy_check(hipdnn_backend_private)

--- a/backend/src/descriptors/backend_descriptor.hpp
+++ b/backend/src/descriptors/backend_descriptor.hpp
@@ -17,7 +17,8 @@ struct Backend_descriptor_interface
                                hipdnnBackendAttributeType_t attribute_type,
                                int64_t requested_element_count,
                                int64_t* element_count,
-                               void* array_of_elements) const = 0;
+                               void* array_of_elements) const
+        = 0;
     virtual void set_attribute(hipdnnBackendAttributeName_t attribute_name,
                                hipdnnBackendAttributeType_t attribute_type,
                                int64_t element_count,

--- a/backend/src/descriptors/backend_descriptor.hpp
+++ b/backend/src/descriptors/backend_descriptor.hpp
@@ -17,8 +17,7 @@ struct Backend_descriptor_interface
                                hipdnnBackendAttributeType_t attribute_type,
                                int64_t requested_element_count,
                                int64_t* element_count,
-                               void* array_of_elements) const
-        = 0;
+                               void* array_of_elements) const = 0;
     virtual void set_attribute(hipdnnBackendAttributeName_t attribute_name,
                                hipdnnBackendAttributeType_t attribute_type,
                                int64_t element_count,

--- a/backend/src/descriptors/engine_config_descriptor.cpp
+++ b/backend/src/descriptors/engine_config_descriptor.cpp
@@ -5,9 +5,9 @@
 #include "engine_descriptor.hpp"
 #include "error.hpp"
 #include "graph_descriptor.hpp"
+#include "handle/handle.hpp"
 #include "hipdnn_backend_descriptor_type.h"
 #include "hipdnn_exception.hpp"
-#include <handle/handle.hpp>
 #include <hipdnn_sdk/data_objects/engine_config_generated.h>
 
 namespace hipdnn_backend

--- a/backend/src/descriptors/engine_descriptor.cpp
+++ b/backend/src/descriptors/engine_descriptor.cpp
@@ -4,6 +4,7 @@
 #include "engine_descriptor.hpp"
 #include "error.hpp"
 #include "graph_descriptor.hpp"
+#include "handle/handle.hpp"
 #include "hipdnn_backend_descriptor_type.h"
 #include "hipdnn_exception.hpp"
 
@@ -22,6 +23,17 @@ void Engine_descriptor::finalize()
     THROW_IF_FALSE(_engine_id_set,
                    HIPDNN_STATUS_BAD_PARAM,
                    "Engine_descriptor::finalize() failed: Engine id is not set.");
+
+    auto handle = _graph->get_handle();
+    auto plugin_resource_manager = handle->get_plugin_resource_manager();
+
+    auto engine_ids = plugin_resource_manager->get_applicable_engine_ids(_graph.get());
+    if(std::ranges::find(engine_ids, _engine_id) == engine_ids.end())
+    {
+        throw Hipdnn_exception(HIPDNN_STATUS_BAD_PARAM, "Engine_descriptor::finalize() failed: Engine id is not in a valid range of engine IDs");
+    }
+
+    _engine_details = plugin::Engine_plugin_resource_manager::get_engine_details(plugin_resource_manager, _engine_id, _graph.get());
 
     hipdnnBackendDescriptorImpl<Engine_descriptor>::finalize();
 }

--- a/backend/src/descriptors/engine_descriptor.cpp
+++ b/backend/src/descriptors/engine_descriptor.cpp
@@ -30,13 +30,10 @@ void Engine_descriptor::finalize()
     auto engine_ids = plugin_resource_manager->get_applicable_engine_ids(_graph.get());
     if(std::ranges::find(engine_ids, _engine_id) == engine_ids.end())
     {
-        throw Hipdnn_exception(HIPDNN_STATUS_BAD_PARAM,
-                               "Engine_descriptor::finalize() failed: Engine id is not in a valid "
-                               "range of engine IDs");
+        throw Hipdnn_exception(HIPDNN_STATUS_BAD_PARAM, "Engine_descriptor::finalize() failed: Engine id is not in a valid range of engine IDs");
     }
 
-    _engine_details = plugin::Engine_plugin_resource_manager::get_engine_details(
-        plugin_resource_manager, _engine_id, _graph.get());
+    _engine_details = plugin::Engine_plugin_resource_manager::get_engine_details(plugin_resource_manager, _engine_id, _graph.get());
 
     hipdnnBackendDescriptorImpl<Engine_descriptor>::finalize();
 }

--- a/backend/src/descriptors/engine_descriptor.cpp
+++ b/backend/src/descriptors/engine_descriptor.cpp
@@ -30,10 +30,13 @@ void Engine_descriptor::finalize()
     auto engine_ids = plugin_resource_manager->get_applicable_engine_ids(_graph.get());
     if(std::ranges::find(engine_ids, _engine_id) == engine_ids.end())
     {
-        throw Hipdnn_exception(HIPDNN_STATUS_BAD_PARAM, "Engine_descriptor::finalize() failed: Engine id is not in a valid range of engine IDs");
+        throw Hipdnn_exception(HIPDNN_STATUS_BAD_PARAM,
+                               "Engine_descriptor::finalize() failed: Engine id is not in a valid "
+                               "range of engine IDs");
     }
 
-    _engine_details = plugin::Engine_plugin_resource_manager::get_engine_details(plugin_resource_manager, _engine_id, _graph.get());
+    _engine_details = plugin::Engine_plugin_resource_manager::get_engine_details(
+        plugin_resource_manager, _engine_id, _graph.get());
 
     hipdnnBackendDescriptorImpl<Engine_descriptor>::finalize();
 }

--- a/backend/src/descriptors/engine_descriptor.hpp
+++ b/backend/src/descriptors/engine_descriptor.hpp
@@ -10,12 +10,18 @@ namespace hipdnn_backend
 
 class Graph_descriptor;
 
+namespace plugin
+{
+class Engine_details_wrapper;
+}
+
 class Engine_descriptor : public hipdnnBackendDescriptorImpl<Engine_descriptor>
 {
 private:
     std::shared_ptr<const Graph_descriptor> _graph;
     int64_t _engine_id;
     bool _engine_id_set = false;
+    std::shared_ptr<const plugin::Engine_details_wrapper> _engine_details;
 
     void set_graph(hipdnnBackendAttributeType_t attribute_type,
                    int64_t element_count,

--- a/backend/src/plugin/engine_plugin_resource_manager.cpp
+++ b/backend/src/plugin/engine_plugin_resource_manager.cpp
@@ -149,8 +149,8 @@ void Engine_plugin_resource_manager::set_stream(hipStream_t stream) const
     }
 }
 
-std::vector<int64_t> Engine_plugin_resource_manager::get_applicable_engine_ids(
-    const Graph_descriptor* graph_desc) const
+std::vector<int64_t>
+    Engine_plugin_resource_manager::get_applicable_engine_ids(const Graph_descriptor* graph_desc) const
 {
     const auto& serialized_graph = graph_desc->get_serialized_graph();
     const hipdnnPluginConstData_t serialized_graph_data{serialized_graph.data(),
@@ -180,9 +180,7 @@ std::vector<int64_t> Engine_plugin_resource_manager::get_applicable_engine_ids(
 }
 
 void Engine_plugin_resource_manager::get_engine_details(
-    int64_t engine_id,
-    const Graph_descriptor* graph_desc,
-    hipdnnPluginConstData_t* engine_details) const
+    int64_t engine_id, const Graph_descriptor* graph_desc, hipdnnPluginConstData_t* engine_details) const
 {
     const auto& serialized_graph = graph_desc->get_serialized_graph();
     const hipdnnPluginConstData_t serialized_graph_data{serialized_graph.data(),
@@ -210,10 +208,10 @@ void Engine_plugin_resource_manager::destroy_engine_details(
     plugin->destroy_engine_details(handle, engine_details);
 }
 
-std::shared_ptr<const Engine_details_wrapper> Engine_plugin_resource_manager::get_engine_details(
-    const std::shared_ptr<Engine_plugin_resource_manager>& rm,
-    int64_t engine_id,
-    const Graph_descriptor* graph_desc)
+std::shared_ptr<const Engine_details_wrapper>
+    Engine_plugin_resource_manager::get_engine_details(const std::shared_ptr<Engine_plugin_resource_manager>& rm,
+                       int64_t engine_id,
+                       const Graph_descriptor* graph_desc)
 {
     return std::make_shared<Engine_details_wrapper>(rm, engine_id, graph_desc);
 }

--- a/backend/src/plugin/engine_plugin_resource_manager.cpp
+++ b/backend/src/plugin/engine_plugin_resource_manager.cpp
@@ -150,7 +150,7 @@ void Engine_plugin_resource_manager::set_stream(hipStream_t stream) const
 }
 
 std::vector<int64_t>
-    Engine_plugin_resource_manager::get_applicable_engine_ids(Graph_descriptor* graph_desc) const
+    Engine_plugin_resource_manager::get_applicable_engine_ids(const Graph_descriptor* graph_desc) const
 {
     const auto& serialized_graph = graph_desc->get_serialized_graph();
     const hipdnnPluginConstData_t serialized_graph_data{serialized_graph.data(),
@@ -180,7 +180,7 @@ std::vector<int64_t>
 }
 
 void Engine_plugin_resource_manager::get_engine_details(
-    int64_t engine_id, Graph_descriptor* graph_desc, hipdnnPluginConstData_t* engine_details) const
+    int64_t engine_id, const Graph_descriptor* graph_desc, hipdnnPluginConstData_t* engine_details) const
 {
     const auto& serialized_graph = graph_desc->get_serialized_graph();
     const hipdnnPluginConstData_t serialized_graph_data{serialized_graph.data(),
@@ -208,15 +208,14 @@ void Engine_plugin_resource_manager::destroy_engine_details(
     plugin->destroy_engine_details(handle, engine_details);
 }
 
-std::unique_ptr<Engine_details_wrapper>
-    get_engine_details(const std::shared_ptr<Engine_plugin_resource_manager>& rm,
+std::shared_ptr<const Engine_details_wrapper>
+    Engine_plugin_resource_manager::get_engine_details(const std::shared_ptr<Engine_plugin_resource_manager>& rm,
                        int64_t engine_id,
-                       Graph_descriptor* graph_desc)
+                       const Graph_descriptor* graph_desc)
 {
-    return std::make_unique<Engine_details_wrapper>(rm, engine_id, graph_desc);
+    return std::make_shared<Engine_details_wrapper>(rm, engine_id, graph_desc);
 }
 
-// TODO: Pack engine_config
 size_t
     Engine_plugin_resource_manager::get_workspace_size(int64_t engine_id,
                                                        const hipdnnPluginConstData_t* engine_config,
@@ -238,7 +237,7 @@ size_t
 hipdnnEnginePluginExecutionContext_t Engine_plugin_resource_manager::create_execution_context(
     int64_t engine_id,
     const hipdnnPluginConstData_t* engine_config,
-    Graph_descriptor* graph_desc) const
+    const Graph_descriptor* graph_desc) const
 {
     const auto& serialized_graph = graph_desc->get_serialized_graph();
     const hipdnnPluginConstData_t serialized_graph_data{serialized_graph.data(),
@@ -259,14 +258,14 @@ void Engine_plugin_resource_manager::destroy_execution_context(
     plugin->destroy_execution_context(handle, execution_context);
 }
 
-std::unique_ptr<Engine_execution_context_wrapper>
+std::shared_ptr<const Engine_execution_context_wrapper>
     Engine_plugin_resource_manager::create_execution_context(
         const std::shared_ptr<Engine_plugin_resource_manager>& rm,
         int64_t engine_id,
         const hipdnnPluginConstData_t* engine_config,
-        Graph_descriptor* graph_desc)
+        const Graph_descriptor* graph_desc)
 {
-    return std::make_unique<Engine_execution_context_wrapper>(
+    return std::make_shared<Engine_execution_context_wrapper>(
         rm, engine_id, engine_config, graph_desc);
 }
 
@@ -338,7 +337,7 @@ void Engine_plugin_resource_manager::execute_op_graph(hipdnnBackendDescriptor_t 
 Engine_details_wrapper::Engine_details_wrapper(
     const std::shared_ptr<Engine_plugin_resource_manager>& rm,
     int64_t engine_id,
-    Graph_descriptor* graph_desc)
+    const Graph_descriptor* graph_desc)
     : _rm(rm)
 {
     _rm->get_engine_details(engine_id, graph_desc, &_engine_details_data);
@@ -401,7 +400,7 @@ Engine_execution_context_wrapper::Engine_execution_context_wrapper(
     const std::shared_ptr<Engine_plugin_resource_manager>& rm,
     int64_t engine_id,
     const hipdnnPluginConstData_t* engine_config,
-    Graph_descriptor* graph_desc)
+    const Graph_descriptor* graph_desc)
     : _rm(rm)
     , _engine_id(engine_id)
 {

--- a/backend/src/plugin/engine_plugin_resource_manager.cpp
+++ b/backend/src/plugin/engine_plugin_resource_manager.cpp
@@ -149,8 +149,8 @@ void Engine_plugin_resource_manager::set_stream(hipStream_t stream) const
     }
 }
 
-std::vector<int64_t>
-    Engine_plugin_resource_manager::get_applicable_engine_ids(const Graph_descriptor* graph_desc) const
+std::vector<int64_t> Engine_plugin_resource_manager::get_applicable_engine_ids(
+    const Graph_descriptor* graph_desc) const
 {
     const auto& serialized_graph = graph_desc->get_serialized_graph();
     const hipdnnPluginConstData_t serialized_graph_data{serialized_graph.data(),
@@ -180,7 +180,9 @@ std::vector<int64_t>
 }
 
 void Engine_plugin_resource_manager::get_engine_details(
-    int64_t engine_id, const Graph_descriptor* graph_desc, hipdnnPluginConstData_t* engine_details) const
+    int64_t engine_id,
+    const Graph_descriptor* graph_desc,
+    hipdnnPluginConstData_t* engine_details) const
 {
     const auto& serialized_graph = graph_desc->get_serialized_graph();
     const hipdnnPluginConstData_t serialized_graph_data{serialized_graph.data(),
@@ -208,10 +210,10 @@ void Engine_plugin_resource_manager::destroy_engine_details(
     plugin->destroy_engine_details(handle, engine_details);
 }
 
-std::shared_ptr<const Engine_details_wrapper>
-    Engine_plugin_resource_manager::get_engine_details(const std::shared_ptr<Engine_plugin_resource_manager>& rm,
-                       int64_t engine_id,
-                       const Graph_descriptor* graph_desc)
+std::shared_ptr<const Engine_details_wrapper> Engine_plugin_resource_manager::get_engine_details(
+    const std::shared_ptr<Engine_plugin_resource_manager>& rm,
+    int64_t engine_id,
+    const Graph_descriptor* graph_desc)
 {
     return std::make_shared<Engine_details_wrapper>(rm, engine_id, graph_desc);
 }

--- a/backend/src/plugin/engine_plugin_resource_manager.hpp
+++ b/backend/src/plugin/engine_plugin_resource_manager.hpp
@@ -60,7 +60,8 @@ public:
     // MT-unsafe instance methods
     // virtual for gMock testing
     virtual void set_stream(hipStream_t stream) const;
-    virtual std::vector<int64_t> get_applicable_engine_ids(const Graph_descriptor* graph_desc) const;
+    virtual std::vector<int64_t>
+        get_applicable_engine_ids(const Graph_descriptor* graph_desc) const;
     virtual size_t get_workspace_size(int64_t engine_id,
                                       const hipdnnPluginConstData_t* engine_config,
                                       const Graph_descriptor* graph_desc) const;
@@ -82,9 +83,10 @@ protected:
     // MT-unsafe instance methods
     // protected virtual for gMock testing
     virtual void get_engine_details(int64_t engine_id,
-                            const Graph_descriptor* graph_desc,
-                            hipdnnPluginConstData_t* engine_details) const;
-    virtual void destroy_engine_details(int64_t engine_id, hipdnnPluginConstData_t* engine_details) const;
+                                    const Graph_descriptor* graph_desc,
+                                    hipdnnPluginConstData_t* engine_details) const;
+    virtual void destroy_engine_details(int64_t engine_id,
+                                        hipdnnPluginConstData_t* engine_details) const;
 
 private:
     // MT-unsafe instance methods

--- a/backend/src/plugin/engine_plugin_resource_manager.hpp
+++ b/backend/src/plugin/engine_plugin_resource_manager.hpp
@@ -58,8 +58,9 @@ public:
     Engine_plugin_resource_manager& operator=(Engine_plugin_resource_manager&& other) noexcept;
 
     // MT-unsafe instance methods
+    // virtual for gMock testing
     virtual void set_stream(hipStream_t stream) const;
-    std::vector<int64_t> get_applicable_engine_ids(const Graph_descriptor* graph_desc) const;
+    virtual std::vector<int64_t> get_applicable_engine_ids(const Graph_descriptor* graph_desc) const;
     virtual size_t get_workspace_size(int64_t engine_id,
                                       const hipdnnPluginConstData_t* engine_config,
                                       const Graph_descriptor* graph_desc) const;
@@ -77,13 +78,16 @@ public:
                                  const hipdnnPluginConstData_t* engine_config,
                                  const Graph_descriptor* graph_desc);
 
-private:
+protected:
     // MT-unsafe instance methods
-    void get_engine_details(int64_t engine_id,
+    // protected virtual for gMock testing
+    virtual void get_engine_details(int64_t engine_id,
                             const Graph_descriptor* graph_desc,
                             hipdnnPluginConstData_t* engine_details) const;
-    void destroy_engine_details(int64_t engine_id, hipdnnPluginConstData_t* engine_details) const;
+    virtual void destroy_engine_details(int64_t engine_id, hipdnnPluginConstData_t* engine_details) const;
 
+private:
+    // MT-unsafe instance methods
     hipdnnEnginePluginExecutionContext_t
         create_execution_context(int64_t engine_id,
                                  const hipdnnPluginConstData_t* engine_config,

--- a/backend/src/plugin/engine_plugin_resource_manager.hpp
+++ b/backend/src/plugin/engine_plugin_resource_manager.hpp
@@ -59,38 +59,37 @@ public:
 
     // MT-unsafe instance methods
     virtual void set_stream(hipStream_t stream) const;
-
-    virtual void execute_op_graph(hipdnnBackendDescriptor_t execution_plan,
-                                  hipdnnBackendDescriptor_t variant_pack) const;
-
+    std::vector<int64_t> get_applicable_engine_ids(const Graph_descriptor* graph_desc) const;
     virtual size_t get_workspace_size(int64_t engine_id,
                                       const hipdnnPluginConstData_t* engine_config,
                                       const Graph_descriptor* graph_desc) const;
 
-private:
-    // MT-unsafe instance methods
-    std::vector<int64_t> get_applicable_engine_ids(Graph_descriptor* graph_desc) const;
+    virtual void execute_op_graph(hipdnnBackendDescriptor_t execution_plan,
+                                  hipdnnBackendDescriptor_t variant_pack) const;
 
-    void get_engine_details(int64_t engine_id,
-                            Graph_descriptor* graph_desc,
-                            hipdnnPluginConstData_t* engine_details) const;
-    void destroy_engine_details(int64_t engine_id, hipdnnPluginConstData_t* engine_details) const;
-    static std::unique_ptr<Engine_details_wrapper>
+    static std::shared_ptr<const Engine_details_wrapper>
         get_engine_details(const std::shared_ptr<Engine_plugin_resource_manager>& rm,
                            int64_t engine_id,
-                           Graph_descriptor* graph_desc);
+                           const Graph_descriptor* graph_desc);
+    static std::shared_ptr<const Engine_execution_context_wrapper>
+        create_execution_context(const std::shared_ptr<Engine_plugin_resource_manager>& rm,
+                                 int64_t engine_id,
+                                 const hipdnnPluginConstData_t* engine_config,
+                                 const Graph_descriptor* graph_desc);
+
+private:
+    // MT-unsafe instance methods
+    void get_engine_details(int64_t engine_id,
+                            const Graph_descriptor* graph_desc,
+                            hipdnnPluginConstData_t* engine_details) const;
+    void destroy_engine_details(int64_t engine_id, hipdnnPluginConstData_t* engine_details) const;
 
     hipdnnEnginePluginExecutionContext_t
         create_execution_context(int64_t engine_id,
                                  const hipdnnPluginConstData_t* engine_config,
-                                 Graph_descriptor* graph_desc) const;
+                                 const Graph_descriptor* graph_desc) const;
     void destroy_execution_context(int64_t engine_id,
                                    hipdnnEnginePluginExecutionContext_t execution_context) const;
-    static std::unique_ptr<Engine_execution_context_wrapper>
-        create_execution_context(const std::shared_ptr<Engine_plugin_resource_manager>& rm,
-                                 int64_t engine_id,
-                                 const hipdnnPluginConstData_t* engine_config,
-                                 Graph_descriptor* graph_desc);
 
     void execute_op_graph(int64_t engine_id,
                           hipdnnEnginePluginExecutionContext_t execution_context,
@@ -112,7 +111,7 @@ class Engine_details_wrapper
 public:
     Engine_details_wrapper(const std::shared_ptr<Engine_plugin_resource_manager>& rm,
                            int64_t engine_id,
-                           Graph_descriptor* graph_desc);
+                           const Graph_descriptor* graph_desc);
     ~Engine_details_wrapper();
 
     // Prevent copying
@@ -137,7 +136,7 @@ public:
     Engine_execution_context_wrapper(const std::shared_ptr<Engine_plugin_resource_manager>& rm,
                                      int64_t engine_id,
                                      const hipdnnPluginConstData_t* engine_config,
-                                     Graph_descriptor* graph_desc);
+                                     const Graph_descriptor* graph_desc);
     ~Engine_execution_context_wrapper();
 
     // Prevent copying

--- a/backend/tests/descriptors/mocks/mock_engine_plugin_resource_manager.hpp
+++ b/backend/tests/descriptors/mocks/mock_engine_plugin_resource_manager.hpp
@@ -33,7 +33,9 @@ public:
 protected:
     MOCK_METHOD(void,
                 get_engine_details,
-                (int64_t engine_id, const hipdnn_backend::Graph_descriptor* graph_desc, hipdnnPluginConstData_t* engine_details),
+                (int64_t engine_id,
+                 const hipdnn_backend::Graph_descriptor* graph_desc,
+                 hipdnnPluginConstData_t* engine_details),
                 (const, override));
     MOCK_METHOD(void,
                 destroy_engine_details,

--- a/backend/tests/descriptors/mocks/mock_engine_plugin_resource_manager.hpp
+++ b/backend/tests/descriptors/mocks/mock_engine_plugin_resource_manager.hpp
@@ -10,12 +10,18 @@ namespace hipdnn_backend
 {
 namespace plugin
 {
-struct Mock_engine_plugin_resource_manager : Engine_plugin_resource_manager
+
+class Mock_engine_plugin_resource_manager : public Engine_plugin_resource_manager
 {
+public:
     MOCK_METHOD(void, set_stream, (hipStream_t stream), (const, override));
     MOCK_METHOD(void,
                 execute_op_graph,
                 (hipdnnBackendDescriptor_t execution_plan, hipdnnBackendDescriptor_t variant_pack),
+                (const, override));
+    MOCK_METHOD(std::vector<int64_t>,
+                get_applicable_engine_ids,
+                (const hipdnn_backend::Graph_descriptor* graph_desc),
                 (const, override));
     MOCK_METHOD(size_t,
                 get_workspace_size,
@@ -23,6 +29,17 @@ struct Mock_engine_plugin_resource_manager : Engine_plugin_resource_manager
                  const hipdnnPluginConstData_t* engine_config,
                  const hipdnn_backend::Graph_descriptor* graph_desc),
                 (const, override));
+
+protected:
+    MOCK_METHOD(void,
+                get_engine_details,
+                (int64_t engine_id, const hipdnn_backend::Graph_descriptor* graph_desc, hipdnnPluginConstData_t* engine_details),
+                (const, override));
+    MOCK_METHOD(void,
+                destroy_engine_details,
+                (int64_t engine_id, hipdnnPluginConstData_t* engine_details),
+                (const, override));
 };
+
 }
 }

--- a/backend/tests/descriptors/test_engine_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_descriptor.cpp
@@ -7,6 +7,8 @@
 #include "hipdnn_backend.h"
 #include "hipdnn_exception.hpp"
 #include "mocks/mock_descriptor.hpp"
+#include "mocks/mock_engine_plugin_resource_manager.hpp"
+#include "mocks/mock_handle.hpp"
 #include "test_descriptor_utils.hpp"
 #include "test_macros.hpp"
 
@@ -15,6 +17,8 @@
 #include <memory>
 
 using namespace hipdnn_backend;
+using namespace plugin;
+using namespace ::testing;
 
 using ::testing::Return;
 
@@ -25,21 +29,23 @@ public:
     std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_wrapper = nullptr;
     std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_bad_type_wrapper = nullptr;
     std::unique_ptr<hipdnnBackendDescriptor> _mock_wrong_type_wrapper = nullptr;
+    std::unique_ptr<Mock_handle> _mock_handle = nullptr;
+    std::shared_ptr<Mock_engine_plugin_resource_manager> _mock_engine_plugin_resource_manager
+        = nullptr;
 
-    Engine_descriptor* get_engine_descriptor() const
+    std::shared_ptr<Engine_descriptor> get_engine_descriptor() const
     {
-        return _engine_wrapper->as_descriptor<Engine_descriptor>().get();
+        return _engine_wrapper->as_descriptor_unsafe<Engine_descriptor>();
     }
 
-    Mock_descriptor<Graph_descriptor>* get_mock_graph() const
+    std::shared_ptr<Mock_graph_descriptor> get_mock_graph() const
     {
-        return _mock_graph_wrapper->as_descriptor<Mock_descriptor<Graph_descriptor>>().get();
+        return _mock_graph_wrapper->as_descriptor_unsafe<Mock_graph_descriptor>();
     }
 
-    Mock_descriptor<Graph_descriptor>* get_mock_graph_bad_type() const
+    std::shared_ptr<Mock_graph_descriptor> get_mock_graph_bad_type() const
     {
-        return _mock_graph_bad_type_wrapper->as_descriptor<Mock_descriptor<Graph_descriptor>>()
-            .get();
+        return _mock_graph_bad_type_wrapper->as_descriptor_unsafe<Mock_graph_descriptor>();
     }
 
     void set_graph() const
@@ -62,6 +68,12 @@ public:
     {
         set_graph();
         set_global_index();
+        EXPECT_CALL(*get_mock_graph(), get_handle())
+            .WillOnce(Return(_mock_handle.get()));
+        EXPECT_CALL(*_mock_handle, get_plugin_resource_manager())
+            .WillOnce(Return(_mock_engine_plugin_resource_manager));
+        EXPECT_CALL(*_mock_engine_plugin_resource_manager, get_applicable_engine_ids(_))
+            .WillOnce(Return(std::vector<int64_t>{0}));
         ASSERT_NO_THROW(get_engine_descriptor()->finalize());
     }
 
@@ -70,11 +82,14 @@ protected:
     {
         _engine_wrapper = test_descriptor_utils::create_descriptor<Engine_descriptor>();
         _mock_graph_wrapper
-            = test_descriptor_utils::create_descriptor<Mock_descriptor<Graph_descriptor>>();
+            = test_descriptor_utils::create_descriptor<Mock_graph_descriptor>();
         _mock_graph_bad_type_wrapper
-            = test_descriptor_utils::create_descriptor<Mock_descriptor<Graph_descriptor>>();
+            = test_descriptor_utils::create_descriptor<Mock_graph_descriptor>();
         _mock_wrong_type_wrapper
-            = test_descriptor_utils::create_descriptor<Mock_descriptor<Engine_descriptor>>();
+            = test_descriptor_utils::create_descriptor<Mock_engine_descriptor>();
+        _mock_handle = std::make_unique<Mock_handle>();
+        _mock_engine_plugin_resource_manager
+            = std::make_shared<Mock_engine_plugin_resource_manager>();
     }
 };
 
@@ -177,10 +192,7 @@ TEST_F(Engine_descriptor_test, FinalizeEngineDescriptor)
     auto engine = get_engine_descriptor();
     ASSERT_THROW_HIPDNN_STATUS(engine->finalize(), HIPDNN_STATUS_BAD_PARAM);
 
-    set_graph();
-    set_global_index();
-
-    ASSERT_NO_THROW(engine->finalize());
+    make_engine_finalized();
 
     ASSERT_THROW_HIPDNN_STATUS(engine->finalize(), HIPDNN_STATUS_BAD_PARAM);
 }
@@ -299,7 +311,7 @@ TEST_F(Engine_descriptor_test, GetGraphReturnsPointerIfFinalized)
     auto graph_ptr = engine->get_graph();
     ASSERT_NE(graph_ptr, nullptr);
     ASSERT_EQ(static_cast<const Backend_descriptor_interface*>(graph_ptr.get()),
-              static_cast<const Backend_descriptor_interface*>(get_mock_graph()));
+              static_cast<const Backend_descriptor_interface*>(get_mock_graph().get()));
 }
 
 TEST_F(Engine_descriptor_test, GetEngineIdThrowsIfNotFinalized)

--- a/backend/tests/descriptors/test_engine_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_descriptor.cpp
@@ -68,8 +68,7 @@ public:
     {
         set_graph();
         set_global_index();
-        EXPECT_CALL(*get_mock_graph(), get_handle())
-            .WillOnce(Return(_mock_handle.get()));
+        EXPECT_CALL(*get_mock_graph(), get_handle()).WillOnce(Return(_mock_handle.get()));
         EXPECT_CALL(*_mock_handle, get_plugin_resource_manager())
             .WillOnce(Return(_mock_engine_plugin_resource_manager));
         EXPECT_CALL(*_mock_engine_plugin_resource_manager, get_applicable_engine_ids(_))
@@ -81,8 +80,7 @@ protected:
     void SetUp() override
     {
         _engine_wrapper = test_descriptor_utils::create_descriptor<Engine_descriptor>();
-        _mock_graph_wrapper
-            = test_descriptor_utils::create_descriptor<Mock_graph_descriptor>();
+        _mock_graph_wrapper = test_descriptor_utils::create_descriptor<Mock_graph_descriptor>();
         _mock_graph_bad_type_wrapper
             = test_descriptor_utils::create_descriptor<Mock_graph_descriptor>();
         _mock_wrong_type_wrapper


### PR DESCRIPTION
## Proposed changes

Add engine descriptor integration logic, remove stubbed integration logic, update tests to support it.

Note: It breaks public API tests since we are missing testing plugins to provide equivalent results as before.