### PR TITLE
Make tensor IDs in the flatbuffer schemas strongly typed

### DIFF
--- a/frontend/include/hipdnn_frontend/attributes/batchnorm_attributes.hpp
+++ b/frontend/include/hipdnn_frontend/attributes/batchnorm_attributes.hpp
@@ -36,6 +36,7 @@ public:
         next_running_variance = 4
     };
 
+    // TODO: This can just be an array, right?
     std::unordered_map<input_names, std::shared_ptr<Tensor_attributes>> inputs;
     std::unordered_map<output_names, std::shared_ptr<Tensor_attributes>> outputs;
     std::vector<std::shared_ptr<Tensor_attributes>> peer_stats;
@@ -159,12 +160,12 @@ public:
     flatbuffers::Offset<hipdnn_sdk::data_objects::BatchnormAttributes>
         pack_attributes(flatbuffers::FlatBufferBuilder& builder) const
     {
-        auto peer_stats_vector = std::vector<int64_t>{};
+        auto peer_stats_vector = std::vector<hipdnn_sdk::data_objects::TensorID>{};
         for(const auto& peer_stat : peer_stats)
         {
             if(peer_stat)
             {
-                peer_stats_vector.emplace_back(peer_stat->get_uid());
+                peer_stats_vector.emplace_back(peer_stat->get_id());
             }
         }
 
@@ -178,24 +179,19 @@ public:
 
         return hipdnn_sdk::data_objects::CreateBatchnormAttributesDirect(
             builder,
-            get_x()->get_uid(),
-            get_scale()->get_uid(),
-            get_bias()->get_uid(),
-            get_epsilon()->get_uid(),
+            &get_x()->get_id(),
+            &get_scale()->get_id(),
+            &get_bias()->get_id(),
+            &get_epsilon()->get_id(),
             &peer_stats_vector,
-            prev_running_mean ? flatbuffers::Optional<int64_t>(prev_running_mean->get_uid())
-                              : flatbuffers::nullopt,
-            prev_running_variance ? flatbuffers::Optional<int64_t>(prev_running_variance->get_uid())
-                                  : flatbuffers::nullopt,
-            momentum ? flatbuffers::Optional<int64_t>(momentum->get_uid()) : flatbuffers::nullopt,
-            get_y()->get_uid(),
-            mean ? flatbuffers::Optional<int64_t>(mean->get_uid()) : flatbuffers::nullopt,
-            inv_variance ? flatbuffers::Optional<int64_t>(inv_variance->get_uid())
-                         : flatbuffers::nullopt,
-            next_running_mean ? flatbuffers::Optional<int64_t>(next_running_mean->get_uid())
-                              : flatbuffers::nullopt,
-            next_running_variance ? flatbuffers::Optional<int64_t>(next_running_variance->get_uid())
-                                  : flatbuffers::nullopt);
+            &prev_running_mean->get_id(),
+            &prev_running_variance->get_id(),
+            &momentum->get_id(),
+            &get_y()->get_id(),
+            &mean->get_id(),
+            &inv_variance->get_id(),
+            &next_running_mean->get_id(),
+            &next_running_variance->get_id());
     }
 
 private:

--- a/frontend/include/hipdnn_frontend/attributes/tensor_attributes.hpp
+++ b/frontend/include/hipdnn_frontend/attributes/tensor_attributes.hpp
@@ -58,7 +58,12 @@ public:
 
     int64_t get_uid() const
     {
-        return _uid;
+        return _id.value();
+    }
+
+    const hipdnn_sdk::data_objects::TensorID& get_id() const
+    {
+        return _id;
     }
 
     const std::string& get_name() const
@@ -98,13 +103,13 @@ public:
 
     bool has_uid() const
     {
-        return _uid_set;
+        return _id_set;
     }
 
     Tensor_attributes& set_uid(int64_t uid)
     {
-        _uid = uid;
-        _uid_set = true;
+        _id = uid;
+        _id_set = true;
         return *this;
     }
 
@@ -145,8 +150,8 @@ public:
 
     Tensor_attributes& clear_uid()
     {
-        _uid = 0;
-        _uid_set = false;
+        _id = 0;
+        _id_set = false;
         return *this;
     }
 
@@ -213,7 +218,7 @@ public:
             _value);
 
         return hipdnn_sdk::data_objects::CreateTensorAttributesDirect(builder,
-                                                                      _uid,
+                                                                      &_id,
                                                                       _name.c_str(),
                                                                       to_sdk_type(_data_type),
                                                                       &_stride,
@@ -224,8 +229,8 @@ public:
     }
 
 private:
-    int64_t _uid = 0;
-    bool _uid_set = false;
+    hipdnn_sdk::data_objects::TensorID _id;
+    bool _id_set = false;   // TODO: Can this be an optional instead?
     std::string _name;
     DataType_t _data_type = DataType_t::NOT_SET;
     std::vector<int64_t> _stride;

--- a/frontend/tests/test_batchnorm_attributes.cpp
+++ b/frontend/tests/test_batchnorm_attributes.cpp
@@ -283,22 +283,22 @@ TEST(BatchnormAttributesTests, PackAttributes)
     auto batchnorm_attributes_fb
         = flatbuffers::GetRoot<hipdnn_sdk::data_objects::BatchnormAttributes>(buffer);
 
-    EXPECT_EQ(batchnorm_attributes_fb->x(), 1);
-    EXPECT_EQ(batchnorm_attributes_fb->y(), 2);
-    EXPECT_EQ(batchnorm_attributes_fb->scale(), 3);
-    EXPECT_EQ(batchnorm_attributes_fb->bias(), 4);
-    EXPECT_EQ(batchnorm_attributes_fb->prev_running_mean(), 5);
-    EXPECT_EQ(batchnorm_attributes_fb->prev_running_variance(), 6);
-    EXPECT_EQ(batchnorm_attributes_fb->momentum(), 7);
-    EXPECT_EQ(batchnorm_attributes_fb->mean(), 8);
-    EXPECT_EQ(batchnorm_attributes_fb->inv_variance(), 9);
-    EXPECT_EQ(batchnorm_attributes_fb->next_running_mean(), 10);
-    EXPECT_EQ(batchnorm_attributes_fb->next_running_variance(), 11);
-    EXPECT_EQ(batchnorm_attributes_fb->epsilon(), 14);
+    EXPECT_EQ(batchnorm_attributes_fb->x()->value(), 1);
+    EXPECT_EQ(batchnorm_attributes_fb->y()->value(), 2);
+    EXPECT_EQ(batchnorm_attributes_fb->scale()->value(), 3);
+    EXPECT_EQ(batchnorm_attributes_fb->bias()->value(), 4);
+    EXPECT_EQ(batchnorm_attributes_fb->prev_running_mean()->value(), 5);
+    EXPECT_EQ(batchnorm_attributes_fb->prev_running_variance()->value(), 6);
+    EXPECT_EQ(batchnorm_attributes_fb->momentum()->value(), 7);
+    EXPECT_EQ(batchnorm_attributes_fb->mean()->value(), 8);
+    EXPECT_EQ(batchnorm_attributes_fb->inv_variance()->value(), 9);
+    EXPECT_EQ(batchnorm_attributes_fb->next_running_mean()->value(), 10);
+    EXPECT_EQ(batchnorm_attributes_fb->next_running_variance()->value(), 11);
+    EXPECT_EQ(batchnorm_attributes_fb->epsilon()->value(), 14);
 
     ASSERT_EQ(batchnorm_attributes_fb->peer_stats()->size(), 2);
-    EXPECT_EQ(batchnorm_attributes_fb->peer_stats()->Get(0), 12);
-    EXPECT_EQ(batchnorm_attributes_fb->peer_stats()->Get(1), 13);
+    EXPECT_EQ(batchnorm_attributes_fb->peer_stats()->Get(0)->value(), 12);
+    EXPECT_EQ(batchnorm_attributes_fb->peer_stats()->Get(1)->value(), 13);
 }
 
 TEST(BatchnormAttributesTests, PackAttributesWithoutOptionalValues)
@@ -333,19 +333,19 @@ TEST(BatchnormAttributesTests, PackAttributesWithoutOptionalValues)
     auto batchnorm_attributes_fb
         = flatbuffers::GetRoot<hipdnn_sdk::data_objects::BatchnormAttributes>(buffer);
 
-    EXPECT_EQ(batchnorm_attributes_fb->x(), 1);
-    EXPECT_EQ(batchnorm_attributes_fb->y(), 2);
-    EXPECT_EQ(batchnorm_attributes_fb->scale(), 3);
-    EXPECT_EQ(batchnorm_attributes_fb->bias(), 4);
-    EXPECT_EQ(batchnorm_attributes_fb->epsilon(), 5);
+    EXPECT_EQ(batchnorm_attributes_fb->x()->value(), 1);
+    EXPECT_EQ(batchnorm_attributes_fb->y()->value(), 2);
+    EXPECT_EQ(batchnorm_attributes_fb->scale()->value(), 3);
+    EXPECT_EQ(batchnorm_attributes_fb->bias()->value(), 4);
+    EXPECT_EQ(batchnorm_attributes_fb->epsilon()->value(), 5);
 
-    EXPECT_EQ(batchnorm_attributes_fb->prev_running_mean(), flatbuffers::nullopt);
-    EXPECT_EQ(batchnorm_attributes_fb->prev_running_variance(), flatbuffers::nullopt);
-    EXPECT_EQ(batchnorm_attributes_fb->momentum(), flatbuffers::nullopt);
-    EXPECT_EQ(batchnorm_attributes_fb->mean(), flatbuffers::nullopt);
-    EXPECT_EQ(batchnorm_attributes_fb->inv_variance(), flatbuffers::nullopt);
-    EXPECT_EQ(batchnorm_attributes_fb->next_running_mean(), flatbuffers::nullopt);
-    EXPECT_EQ(batchnorm_attributes_fb->next_running_variance(), flatbuffers::nullopt);
+    EXPECT_EQ(batchnorm_attributes_fb->prev_running_mean(), nullptr);
+    EXPECT_EQ(batchnorm_attributes_fb->prev_running_variance(), nullptr);
+    EXPECT_EQ(batchnorm_attributes_fb->momentum(), nullptr);
+    EXPECT_EQ(batchnorm_attributes_fb->mean(), nullptr);
+    EXPECT_EQ(batchnorm_attributes_fb->inv_variance(), nullptr);
+    EXPECT_EQ(batchnorm_attributes_fb->next_running_mean(), nullptr);
+    EXPECT_EQ(batchnorm_attributes_fb->next_running_variance(), nullptr);
 
     ASSERT_EQ(batchnorm_attributes_fb->peer_stats()->size(), 0);
 }

--- a/frontend/tests/test_batchnorm_node.cpp
+++ b/frontend/tests/test_batchnorm_node.cpp
@@ -214,11 +214,11 @@ TEST(BatchnormNodeTests, PackNode)
     auto packed_attributes = node_flatbuffer->attributes_as_BatchnormAttributes();
     ASSERT_NE(packed_attributes, nullptr);
 
-    EXPECT_EQ(packed_attributes->x(), x_tensor->get_uid());
-    EXPECT_EQ(packed_attributes->y(), y_tensor->get_uid());
-    EXPECT_EQ(packed_attributes->scale(), scale_tensor->get_uid());
-    EXPECT_EQ(packed_attributes->bias(), bias_tensor->get_uid());
-    EXPECT_EQ(packed_attributes->epsilon(), epsilon_tensor->get_uid());
+    EXPECT_EQ(packed_attributes->x()->value(), x_tensor->get_id().value());
+    EXPECT_EQ(packed_attributes->y()->value(), y_tensor->get_id().value());
+    EXPECT_EQ(packed_attributes->scale()->value(), scale_tensor->get_id().value());
+    EXPECT_EQ(packed_attributes->bias()->value(), bias_tensor->get_id().value());
+    EXPECT_EQ(packed_attributes->epsilon()->value(), epsilon_tensor->get_id().value());
 }
 
 TEST(BatchnormNodeTests, GatherhipdnnTensorIds)

--- a/frontend/tests/test_graph.cpp
+++ b/frontend/tests/test_graph.cpp
@@ -255,7 +255,7 @@ static void validate_tensor(const Tensor_attributes& tensor,
                             const hipdnn_sdk::data_objects::TensorAttributesT& serialized_tensor)
 {
     EXPECT_EQ(tensor.get_name(), serialized_tensor.name);
-    EXPECT_EQ(tensor.get_uid(), serialized_tensor.uid);
+    EXPECT_EQ(tensor.get_uid(), serialized_tensor.id->value());
     EXPECT_EQ(to_sdk_type(tensor.get_data_type()), serialized_tensor.data_type);
     EXPECT_EQ(tensor.get_dim(), serialized_tensor.dims);
     EXPECT_EQ(tensor.get_stride(), serialized_tensor.strides);
@@ -314,7 +314,7 @@ TEST_F(Graph_test_fixture, BuildAndSerializeBatchnormInferenceGraph)
     std::unordered_map<int64_t, hipdnn_sdk::data_objects::TensorAttributesT> tensor_lookup;
     for(auto& tensor : deserialized_graph->tensors)
     {
-        tensor_lookup[tensor->uid] = *tensor;
+        tensor_lookup[tensor->id->value()] = *tensor;
     }
 
     validate_tensor(*x, tensor_lookup[x->get_uid()]);
@@ -402,7 +402,7 @@ TEST_F(Graph_test_fixture, BuildAndSerializeBatchnormGraph)
     std::unordered_map<int64_t, hipdnn_sdk::data_objects::TensorAttributesT> tensor_lookup;
     for(auto& tensor : deserialized_graph->tensors)
     {
-        tensor_lookup[tensor->uid] = *tensor;
+        tensor_lookup[tensor->id->value()] = *tensor;
     }
 
     validate_tensor(*x, tensor_lookup[x->get_uid()]);
@@ -423,19 +423,19 @@ TEST_F(Graph_test_fixture, BuildAndSerializeBatchnormGraph)
               hipdnn_sdk::data_objects::NodeAttributes::NodeAttributes_BatchnormAttributes);
     auto deserialized_batchnorm_attributes
         = deserialized_graph->nodes[0]->attributes.AsBatchnormAttributes();
-    EXPECT_EQ(deserialized_batchnorm_attributes->x, x->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->scale, scale->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->bias, bias->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->epsilon, epsilon->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->prev_running_mean, prev_running_mean->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->prev_running_variance,
+    EXPECT_EQ(deserialized_batchnorm_attributes->x->value(), x->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->scale->value(), scale->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->bias->value(), bias->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->epsilon->value(), epsilon->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->prev_running_mean->value(), prev_running_mean->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->prev_running_variance->value(),
               prev_running_variance->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->momentum, momentum->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->y, y->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->mean, mean->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->inv_variance, inv_variance->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->next_running_mean, next_running_mean->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->next_running_variance,
+    EXPECT_EQ(deserialized_batchnorm_attributes->momentum->value(), momentum->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->y->value(), y->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->mean->value(), mean->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->inv_variance->value(), inv_variance->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->next_running_mean->value(), next_running_mean->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->next_running_variance->value(),
               next_running_variance->get_uid());
 }
 
@@ -509,7 +509,7 @@ TEST_F(Graph_test_fixture, BuildAndSerializeBatchnormAndPointwiseGraph)
     std::unordered_map<int64_t, hipdnn_sdk::data_objects::TensorAttributesT> tensor_lookup;
     for(auto& tensor : deserialized_graph->tensors)
     {
-        tensor_lookup[tensor->uid] = *tensor;
+        tensor_lookup[tensor->id->value()] = *tensor;
     }
 
     validate_tensor(*x, tensor_lookup[x->get_uid()]);
@@ -531,19 +531,19 @@ TEST_F(Graph_test_fixture, BuildAndSerializeBatchnormAndPointwiseGraph)
               hipdnn_sdk::data_objects::NodeAttributes::NodeAttributes_BatchnormAttributes);
     auto deserialized_batchnorm_attributes
         = deserialized_graph->nodes[0]->attributes.AsBatchnormAttributes();
-    EXPECT_EQ(deserialized_batchnorm_attributes->x, x->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->scale, scale->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->bias, bias->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->epsilon, epsilon->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->prev_running_mean, prev_running_mean->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->prev_running_variance,
+    EXPECT_EQ(deserialized_batchnorm_attributes->x->value(), x->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->scale->value(), scale->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->bias->value(), bias->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->epsilon->value(), epsilon->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->prev_running_mean->value(), prev_running_mean->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->prev_running_variance->value(),
               prev_running_variance->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->momentum, momentum->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->y, y->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->mean, mean->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->inv_variance, inv_variance->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->next_running_mean, next_running_mean->get_uid());
-    EXPECT_EQ(deserialized_batchnorm_attributes->next_running_variance,
+    EXPECT_EQ(deserialized_batchnorm_attributes->momentum->value(), momentum->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->y->value(), y->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->mean->value(), mean->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->inv_variance->value(), inv_variance->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->next_running_mean->value(), next_running_mean->get_uid());
+    EXPECT_EQ(deserialized_batchnorm_attributes->next_running_variance->value(),
               next_running_variance->get_uid());
 
     EXPECT_EQ(deserialized_graph->nodes[1]->name, "PointwiseNode");
@@ -598,7 +598,7 @@ TEST_F(Graph_test_fixture, BuildAndSerializePointwiseGraph)
     std::unordered_map<int64_t, hipdnn_sdk::data_objects::TensorAttributesT> tensor_lookup;
     for(auto& tensor : deserialized_graph->tensors)
     {
-        tensor_lookup[tensor->uid] = *tensor;
+        tensor_lookup[tensor->id->value()] = *tensor;
     }
 
     validate_tensor(*in_0, tensor_lookup[in_0->get_uid()]);
@@ -673,7 +673,7 @@ TEST_F(Graph_test_fixture, BuildAndSerializePointwiseAndBatchnormInferenceGraph)
     std::unordered_map<int64_t, hipdnn_sdk::data_objects::TensorAttributesT> tensor_lookup;
     for(auto& tensor : deserialized_graph->tensors)
     {
-        tensor_lookup[tensor->uid] = *tensor;
+        tensor_lookup[tensor->id->value()] = *tensor;
     }
 
     validate_tensor(*x, tensor_lookup[x->get_uid()]);
@@ -765,7 +765,7 @@ TEST_F(Graph_test_fixture, BuildAndSerializeBatchnormBackwardGraph)
     std::unordered_map<int64_t, hipdnn_sdk::data_objects::TensorAttributesT> tensor_lookup;
     for(auto& tensor : deserialized_graph->tensors)
     {
-        tensor_lookup[tensor->uid] = *tensor;
+        tensor_lookup[tensor->id->value()] = *tensor;
     }
 
     validate_tensor(*dy, tensor_lookup[dy->get_uid()]);
@@ -855,7 +855,7 @@ TEST_F(Graph_test_fixture, BuildAndSerializePointwiseAndBatchnormBackwardGraph)
     std::unordered_map<int64_t, hipdnn_sdk::data_objects::TensorAttributesT> tensor_lookup;
     for(auto& tensor : deserialized_graph->tensors)
     {
-        tensor_lookup[tensor->uid] = *tensor;
+        tensor_lookup[tensor->id->value()] = *tensor;
     }
 
     validate_tensor(*x_pointwise, tensor_lookup[x_pointwise->get_uid()]);

--- a/frontend/tests/test_tensor_attributes.cpp
+++ b/frontend/tests/test_tensor_attributes.cpp
@@ -118,7 +118,7 @@ TEST(TensorAttributesTests, PackAttributes)
     auto unpacked = std::unique_ptr<hipdnn_sdk::data_objects::TensorAttributesT>(
         tensor_attributes_flatbuffer->UnPack());
 
-    EXPECT_EQ(unpacked->uid, 1);
+    EXPECT_EQ(unpacked->id->value(), 1);
     EXPECT_EQ(unpacked->name, "PackedTensor");
     EXPECT_EQ(unpacked->data_type, hipdnn_sdk::data_objects::DataType_FLOAT);
     EXPECT_EQ(unpacked->strides, std::vector<int64_t>({1, 2, 3}));

--- a/frontend/tests/test_tensor_value_attributes.cpp
+++ b/frontend/tests/test_tensor_value_attributes.cpp
@@ -50,7 +50,7 @@ TEST(TensorValueAttributesTests, PackUnpackFloat)
     auto buffer_pointer = builder.GetBufferPointer();
     auto fb_tensor = flatbuffers::GetRoot<TensorAttributes>(buffer_pointer);
 
-    EXPECT_EQ(fb_tensor->uid(), 7);
+    EXPECT_EQ(fb_tensor->id()->value(), 7);
     EXPECT_STREQ(fb_tensor->name()->c_str(), "value_tensor");
     EXPECT_EQ(fb_tensor->data_type(), DataType_FLOAT);
     EXPECT_EQ(fb_tensor->strides()->size(), 2u);
@@ -63,7 +63,7 @@ TEST(TensorValueAttributesTests, PackUnpackFloat)
     EXPECT_FLOAT_EQ(fval->value(), std::numbers::e_v<float>);
 
     auto unpacked = std::unique_ptr<TensorAttributesT>(fb_tensor->UnPack());
-    EXPECT_EQ(unpacked->uid, 7);
+    EXPECT_EQ(unpacked->id->value(), 7);
     EXPECT_EQ(unpacked->name, "value_tensor");
     EXPECT_EQ(unpacked->data_type, DataType_FLOAT);
 

--- a/sdk/include/hipdnn_sdk/data_objects/batchnorm_attributes_generated.h
+++ b/sdk/include/hipdnn_sdk/data_objects/batchnorm_attributes_generated.h
@@ -13,6 +13,8 @@ static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
               FLATBUFFERS_VERSION_REVISION == 21,
              "Non-compatible flatbuffers version included");
 
+#include "tensor_attributes_generated.h"
+
 namespace hipdnn_sdk {
 namespace data_objects {
 
@@ -25,19 +27,23 @@ bool operator!=(const BatchnormAttributesT &lhs, const BatchnormAttributesT &rhs
 
 struct BatchnormAttributesT : public ::flatbuffers::NativeTable {
   typedef BatchnormAttributes TableType;
-  int64_t x = 0;
-  int64_t scale = 0;
-  int64_t bias = 0;
-  int64_t epsilon = 0;
-  std::vector<int64_t> peer_stats{};
-  ::flatbuffers::Optional<int64_t> prev_running_mean = ::flatbuffers::nullopt;
-  ::flatbuffers::Optional<int64_t> prev_running_variance = ::flatbuffers::nullopt;
-  ::flatbuffers::Optional<int64_t> momentum = ::flatbuffers::nullopt;
-  int64_t y = 0;
-  ::flatbuffers::Optional<int64_t> mean = ::flatbuffers::nullopt;
-  ::flatbuffers::Optional<int64_t> inv_variance = ::flatbuffers::nullopt;
-  ::flatbuffers::Optional<int64_t> next_running_mean = ::flatbuffers::nullopt;
-  ::flatbuffers::Optional<int64_t> next_running_variance = ::flatbuffers::nullopt;
+  std::unique_ptr<hipdnn_sdk::data_objects::TensorID> x{};
+  std::unique_ptr<hipdnn_sdk::data_objects::TensorID> scale{};
+  std::unique_ptr<hipdnn_sdk::data_objects::TensorID> bias{};
+  std::unique_ptr<hipdnn_sdk::data_objects::TensorID> epsilon{};
+  std::vector<hipdnn_sdk::data_objects::TensorID> peer_stats{};
+  std::unique_ptr<hipdnn_sdk::data_objects::TensorID> prev_running_mean{};
+  std::unique_ptr<hipdnn_sdk::data_objects::TensorID> prev_running_variance{};
+  std::unique_ptr<hipdnn_sdk::data_objects::TensorID> momentum{};
+  std::unique_ptr<hipdnn_sdk::data_objects::TensorID> y{};
+  std::unique_ptr<hipdnn_sdk::data_objects::TensorID> mean{};
+  std::unique_ptr<hipdnn_sdk::data_objects::TensorID> inv_variance{};
+  std::unique_ptr<hipdnn_sdk::data_objects::TensorID> next_running_mean{};
+  std::unique_ptr<hipdnn_sdk::data_objects::TensorID> next_running_variance{};
+  BatchnormAttributesT() = default;
+  BatchnormAttributesT(const BatchnormAttributesT &o);
+  BatchnormAttributesT(BatchnormAttributesT&&) FLATBUFFERS_NOEXCEPT = default;
+  BatchnormAttributesT &operator=(BatchnormAttributesT o) FLATBUFFERS_NOEXCEPT;
 };
 
 struct BatchnormAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
@@ -58,100 +64,100 @@ struct BatchnormAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tabl
     VT_NEXT_RUNNING_MEAN = 26,
     VT_NEXT_RUNNING_VARIANCE = 28
   };
-  int64_t x() const {
-    return GetField<int64_t>(VT_X, 0);
+  const hipdnn_sdk::data_objects::TensorID *x() const {
+    return GetStruct<const hipdnn_sdk::data_objects::TensorID *>(VT_X);
   }
-  bool mutate_x(int64_t _x = 0) {
-    return SetField<int64_t>(VT_X, _x, 0);
+  hipdnn_sdk::data_objects::TensorID *mutable_x() {
+    return GetStruct<hipdnn_sdk::data_objects::TensorID *>(VT_X);
   }
-  int64_t scale() const {
-    return GetField<int64_t>(VT_SCALE, 0);
+  const hipdnn_sdk::data_objects::TensorID *scale() const {
+    return GetStruct<const hipdnn_sdk::data_objects::TensorID *>(VT_SCALE);
   }
-  bool mutate_scale(int64_t _scale = 0) {
-    return SetField<int64_t>(VT_SCALE, _scale, 0);
+  hipdnn_sdk::data_objects::TensorID *mutable_scale() {
+    return GetStruct<hipdnn_sdk::data_objects::TensorID *>(VT_SCALE);
   }
-  int64_t bias() const {
-    return GetField<int64_t>(VT_BIAS, 0);
+  const hipdnn_sdk::data_objects::TensorID *bias() const {
+    return GetStruct<const hipdnn_sdk::data_objects::TensorID *>(VT_BIAS);
   }
-  bool mutate_bias(int64_t _bias = 0) {
-    return SetField<int64_t>(VT_BIAS, _bias, 0);
+  hipdnn_sdk::data_objects::TensorID *mutable_bias() {
+    return GetStruct<hipdnn_sdk::data_objects::TensorID *>(VT_BIAS);
   }
-  int64_t epsilon() const {
-    return GetField<int64_t>(VT_EPSILON, 0);
+  const hipdnn_sdk::data_objects::TensorID *epsilon() const {
+    return GetStruct<const hipdnn_sdk::data_objects::TensorID *>(VT_EPSILON);
   }
-  bool mutate_epsilon(int64_t _epsilon = 0) {
-    return SetField<int64_t>(VT_EPSILON, _epsilon, 0);
+  hipdnn_sdk::data_objects::TensorID *mutable_epsilon() {
+    return GetStruct<hipdnn_sdk::data_objects::TensorID *>(VT_EPSILON);
   }
-  const ::flatbuffers::Vector<int64_t> *peer_stats() const {
-    return GetPointer<const ::flatbuffers::Vector<int64_t> *>(VT_PEER_STATS);
+  const ::flatbuffers::Vector<const hipdnn_sdk::data_objects::TensorID *> *peer_stats() const {
+    return GetPointer<const ::flatbuffers::Vector<const hipdnn_sdk::data_objects::TensorID *> *>(VT_PEER_STATS);
   }
-  ::flatbuffers::Vector<int64_t> *mutable_peer_stats() {
-    return GetPointer<::flatbuffers::Vector<int64_t> *>(VT_PEER_STATS);
+  ::flatbuffers::Vector<const hipdnn_sdk::data_objects::TensorID *> *mutable_peer_stats() {
+    return GetPointer<::flatbuffers::Vector<const hipdnn_sdk::data_objects::TensorID *> *>(VT_PEER_STATS);
   }
-  ::flatbuffers::Optional<int64_t> prev_running_mean() const {
-    return GetOptional<int64_t, int64_t>(VT_PREV_RUNNING_MEAN);
+  const hipdnn_sdk::data_objects::TensorID *prev_running_mean() const {
+    return GetStruct<const hipdnn_sdk::data_objects::TensorID *>(VT_PREV_RUNNING_MEAN);
   }
-  bool mutate_prev_running_mean(int64_t _prev_running_mean) {
-    return SetField<int64_t>(VT_PREV_RUNNING_MEAN, _prev_running_mean);
+  hipdnn_sdk::data_objects::TensorID *mutable_prev_running_mean() {
+    return GetStruct<hipdnn_sdk::data_objects::TensorID *>(VT_PREV_RUNNING_MEAN);
   }
-  ::flatbuffers::Optional<int64_t> prev_running_variance() const {
-    return GetOptional<int64_t, int64_t>(VT_PREV_RUNNING_VARIANCE);
+  const hipdnn_sdk::data_objects::TensorID *prev_running_variance() const {
+    return GetStruct<const hipdnn_sdk::data_objects::TensorID *>(VT_PREV_RUNNING_VARIANCE);
   }
-  bool mutate_prev_running_variance(int64_t _prev_running_variance) {
-    return SetField<int64_t>(VT_PREV_RUNNING_VARIANCE, _prev_running_variance);
+  hipdnn_sdk::data_objects::TensorID *mutable_prev_running_variance() {
+    return GetStruct<hipdnn_sdk::data_objects::TensorID *>(VT_PREV_RUNNING_VARIANCE);
   }
-  ::flatbuffers::Optional<int64_t> momentum() const {
-    return GetOptional<int64_t, int64_t>(VT_MOMENTUM);
+  const hipdnn_sdk::data_objects::TensorID *momentum() const {
+    return GetStruct<const hipdnn_sdk::data_objects::TensorID *>(VT_MOMENTUM);
   }
-  bool mutate_momentum(int64_t _momentum) {
-    return SetField<int64_t>(VT_MOMENTUM, _momentum);
+  hipdnn_sdk::data_objects::TensorID *mutable_momentum() {
+    return GetStruct<hipdnn_sdk::data_objects::TensorID *>(VT_MOMENTUM);
   }
-  int64_t y() const {
-    return GetField<int64_t>(VT_Y, 0);
+  const hipdnn_sdk::data_objects::TensorID *y() const {
+    return GetStruct<const hipdnn_sdk::data_objects::TensorID *>(VT_Y);
   }
-  bool mutate_y(int64_t _y = 0) {
-    return SetField<int64_t>(VT_Y, _y, 0);
+  hipdnn_sdk::data_objects::TensorID *mutable_y() {
+    return GetStruct<hipdnn_sdk::data_objects::TensorID *>(VT_Y);
   }
-  ::flatbuffers::Optional<int64_t> mean() const {
-    return GetOptional<int64_t, int64_t>(VT_MEAN);
+  const hipdnn_sdk::data_objects::TensorID *mean() const {
+    return GetStruct<const hipdnn_sdk::data_objects::TensorID *>(VT_MEAN);
   }
-  bool mutate_mean(int64_t _mean) {
-    return SetField<int64_t>(VT_MEAN, _mean);
+  hipdnn_sdk::data_objects::TensorID *mutable_mean() {
+    return GetStruct<hipdnn_sdk::data_objects::TensorID *>(VT_MEAN);
   }
-  ::flatbuffers::Optional<int64_t> inv_variance() const {
-    return GetOptional<int64_t, int64_t>(VT_INV_VARIANCE);
+  const hipdnn_sdk::data_objects::TensorID *inv_variance() const {
+    return GetStruct<const hipdnn_sdk::data_objects::TensorID *>(VT_INV_VARIANCE);
   }
-  bool mutate_inv_variance(int64_t _inv_variance) {
-    return SetField<int64_t>(VT_INV_VARIANCE, _inv_variance);
+  hipdnn_sdk::data_objects::TensorID *mutable_inv_variance() {
+    return GetStruct<hipdnn_sdk::data_objects::TensorID *>(VT_INV_VARIANCE);
   }
-  ::flatbuffers::Optional<int64_t> next_running_mean() const {
-    return GetOptional<int64_t, int64_t>(VT_NEXT_RUNNING_MEAN);
+  const hipdnn_sdk::data_objects::TensorID *next_running_mean() const {
+    return GetStruct<const hipdnn_sdk::data_objects::TensorID *>(VT_NEXT_RUNNING_MEAN);
   }
-  bool mutate_next_running_mean(int64_t _next_running_mean) {
-    return SetField<int64_t>(VT_NEXT_RUNNING_MEAN, _next_running_mean);
+  hipdnn_sdk::data_objects::TensorID *mutable_next_running_mean() {
+    return GetStruct<hipdnn_sdk::data_objects::TensorID *>(VT_NEXT_RUNNING_MEAN);
   }
-  ::flatbuffers::Optional<int64_t> next_running_variance() const {
-    return GetOptional<int64_t, int64_t>(VT_NEXT_RUNNING_VARIANCE);
+  const hipdnn_sdk::data_objects::TensorID *next_running_variance() const {
+    return GetStruct<const hipdnn_sdk::data_objects::TensorID *>(VT_NEXT_RUNNING_VARIANCE);
   }
-  bool mutate_next_running_variance(int64_t _next_running_variance) {
-    return SetField<int64_t>(VT_NEXT_RUNNING_VARIANCE, _next_running_variance);
+  hipdnn_sdk::data_objects::TensorID *mutable_next_running_variance() {
+    return GetStruct<hipdnn_sdk::data_objects::TensorID *>(VT_NEXT_RUNNING_VARIANCE);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<int64_t>(verifier, VT_X, 8) &&
-           VerifyField<int64_t>(verifier, VT_SCALE, 8) &&
-           VerifyField<int64_t>(verifier, VT_BIAS, 8) &&
-           VerifyField<int64_t>(verifier, VT_EPSILON, 8) &&
+           VerifyField<hipdnn_sdk::data_objects::TensorID>(verifier, VT_X, 8) &&
+           VerifyField<hipdnn_sdk::data_objects::TensorID>(verifier, VT_SCALE, 8) &&
+           VerifyField<hipdnn_sdk::data_objects::TensorID>(verifier, VT_BIAS, 8) &&
+           VerifyField<hipdnn_sdk::data_objects::TensorID>(verifier, VT_EPSILON, 8) &&
            VerifyOffset(verifier, VT_PEER_STATS) &&
            verifier.VerifyVector(peer_stats()) &&
-           VerifyField<int64_t>(verifier, VT_PREV_RUNNING_MEAN, 8) &&
-           VerifyField<int64_t>(verifier, VT_PREV_RUNNING_VARIANCE, 8) &&
-           VerifyField<int64_t>(verifier, VT_MOMENTUM, 8) &&
-           VerifyField<int64_t>(verifier, VT_Y, 8) &&
-           VerifyField<int64_t>(verifier, VT_MEAN, 8) &&
-           VerifyField<int64_t>(verifier, VT_INV_VARIANCE, 8) &&
-           VerifyField<int64_t>(verifier, VT_NEXT_RUNNING_MEAN, 8) &&
-           VerifyField<int64_t>(verifier, VT_NEXT_RUNNING_VARIANCE, 8) &&
+           VerifyField<hipdnn_sdk::data_objects::TensorID>(verifier, VT_PREV_RUNNING_MEAN, 8) &&
+           VerifyField<hipdnn_sdk::data_objects::TensorID>(verifier, VT_PREV_RUNNING_VARIANCE, 8) &&
+           VerifyField<hipdnn_sdk::data_objects::TensorID>(verifier, VT_MOMENTUM, 8) &&
+           VerifyField<hipdnn_sdk::data_objects::TensorID>(verifier, VT_Y, 8) &&
+           VerifyField<hipdnn_sdk::data_objects::TensorID>(verifier, VT_MEAN, 8) &&
+           VerifyField<hipdnn_sdk::data_objects::TensorID>(verifier, VT_INV_VARIANCE, 8) &&
+           VerifyField<hipdnn_sdk::data_objects::TensorID>(verifier, VT_NEXT_RUNNING_MEAN, 8) &&
+           VerifyField<hipdnn_sdk::data_objects::TensorID>(verifier, VT_NEXT_RUNNING_VARIANCE, 8) &&
            verifier.EndTable();
   }
   BatchnormAttributesT *UnPack(const ::flatbuffers::resolver_function_t *_resolver = nullptr) const;
@@ -163,44 +169,44 @@ struct BatchnormAttributesBuilder {
   typedef BatchnormAttributes Table;
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
-  void add_x(int64_t x) {
-    fbb_.AddElement<int64_t>(BatchnormAttributes::VT_X, x, 0);
+  void add_x(const hipdnn_sdk::data_objects::TensorID *x) {
+    fbb_.AddStruct(BatchnormAttributes::VT_X, x);
   }
-  void add_scale(int64_t scale) {
-    fbb_.AddElement<int64_t>(BatchnormAttributes::VT_SCALE, scale, 0);
+  void add_scale(const hipdnn_sdk::data_objects::TensorID *scale) {
+    fbb_.AddStruct(BatchnormAttributes::VT_SCALE, scale);
   }
-  void add_bias(int64_t bias) {
-    fbb_.AddElement<int64_t>(BatchnormAttributes::VT_BIAS, bias, 0);
+  void add_bias(const hipdnn_sdk::data_objects::TensorID *bias) {
+    fbb_.AddStruct(BatchnormAttributes::VT_BIAS, bias);
   }
-  void add_epsilon(int64_t epsilon) {
-    fbb_.AddElement<int64_t>(BatchnormAttributes::VT_EPSILON, epsilon, 0);
+  void add_epsilon(const hipdnn_sdk::data_objects::TensorID *epsilon) {
+    fbb_.AddStruct(BatchnormAttributes::VT_EPSILON, epsilon);
   }
-  void add_peer_stats(::flatbuffers::Offset<::flatbuffers::Vector<int64_t>> peer_stats) {
+  void add_peer_stats(::flatbuffers::Offset<::flatbuffers::Vector<const hipdnn_sdk::data_objects::TensorID *>> peer_stats) {
     fbb_.AddOffset(BatchnormAttributes::VT_PEER_STATS, peer_stats);
   }
-  void add_prev_running_mean(int64_t prev_running_mean) {
-    fbb_.AddElement<int64_t>(BatchnormAttributes::VT_PREV_RUNNING_MEAN, prev_running_mean);
+  void add_prev_running_mean(const hipdnn_sdk::data_objects::TensorID *prev_running_mean) {
+    fbb_.AddStruct(BatchnormAttributes::VT_PREV_RUNNING_MEAN, prev_running_mean);
   }
-  void add_prev_running_variance(int64_t prev_running_variance) {
-    fbb_.AddElement<int64_t>(BatchnormAttributes::VT_PREV_RUNNING_VARIANCE, prev_running_variance);
+  void add_prev_running_variance(const hipdnn_sdk::data_objects::TensorID *prev_running_variance) {
+    fbb_.AddStruct(BatchnormAttributes::VT_PREV_RUNNING_VARIANCE, prev_running_variance);
   }
-  void add_momentum(int64_t momentum) {
-    fbb_.AddElement<int64_t>(BatchnormAttributes::VT_MOMENTUM, momentum);
+  void add_momentum(const hipdnn_sdk::data_objects::TensorID *momentum) {
+    fbb_.AddStruct(BatchnormAttributes::VT_MOMENTUM, momentum);
   }
-  void add_y(int64_t y) {
-    fbb_.AddElement<int64_t>(BatchnormAttributes::VT_Y, y, 0);
+  void add_y(const hipdnn_sdk::data_objects::TensorID *y) {
+    fbb_.AddStruct(BatchnormAttributes::VT_Y, y);
   }
-  void add_mean(int64_t mean) {
-    fbb_.AddElement<int64_t>(BatchnormAttributes::VT_MEAN, mean);
+  void add_mean(const hipdnn_sdk::data_objects::TensorID *mean) {
+    fbb_.AddStruct(BatchnormAttributes::VT_MEAN, mean);
   }
-  void add_inv_variance(int64_t inv_variance) {
-    fbb_.AddElement<int64_t>(BatchnormAttributes::VT_INV_VARIANCE, inv_variance);
+  void add_inv_variance(const hipdnn_sdk::data_objects::TensorID *inv_variance) {
+    fbb_.AddStruct(BatchnormAttributes::VT_INV_VARIANCE, inv_variance);
   }
-  void add_next_running_mean(int64_t next_running_mean) {
-    fbb_.AddElement<int64_t>(BatchnormAttributes::VT_NEXT_RUNNING_MEAN, next_running_mean);
+  void add_next_running_mean(const hipdnn_sdk::data_objects::TensorID *next_running_mean) {
+    fbb_.AddStruct(BatchnormAttributes::VT_NEXT_RUNNING_MEAN, next_running_mean);
   }
-  void add_next_running_variance(int64_t next_running_variance) {
-    fbb_.AddElement<int64_t>(BatchnormAttributes::VT_NEXT_RUNNING_VARIANCE, next_running_variance);
+  void add_next_running_variance(const hipdnn_sdk::data_objects::TensorID *next_running_variance) {
+    fbb_.AddStruct(BatchnormAttributes::VT_NEXT_RUNNING_VARIANCE, next_running_variance);
   }
   explicit BatchnormAttributesBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -215,52 +221,52 @@ struct BatchnormAttributesBuilder {
 
 inline ::flatbuffers::Offset<BatchnormAttributes> CreateBatchnormAttributes(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    int64_t x = 0,
-    int64_t scale = 0,
-    int64_t bias = 0,
-    int64_t epsilon = 0,
-    ::flatbuffers::Offset<::flatbuffers::Vector<int64_t>> peer_stats = 0,
-    ::flatbuffers::Optional<int64_t> prev_running_mean = ::flatbuffers::nullopt,
-    ::flatbuffers::Optional<int64_t> prev_running_variance = ::flatbuffers::nullopt,
-    ::flatbuffers::Optional<int64_t> momentum = ::flatbuffers::nullopt,
-    int64_t y = 0,
-    ::flatbuffers::Optional<int64_t> mean = ::flatbuffers::nullopt,
-    ::flatbuffers::Optional<int64_t> inv_variance = ::flatbuffers::nullopt,
-    ::flatbuffers::Optional<int64_t> next_running_mean = ::flatbuffers::nullopt,
-    ::flatbuffers::Optional<int64_t> next_running_variance = ::flatbuffers::nullopt) {
+    const hipdnn_sdk::data_objects::TensorID *x = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *scale = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *bias = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *epsilon = nullptr,
+    ::flatbuffers::Offset<::flatbuffers::Vector<const hipdnn_sdk::data_objects::TensorID *>> peer_stats = 0,
+    const hipdnn_sdk::data_objects::TensorID *prev_running_mean = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *prev_running_variance = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *momentum = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *y = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *mean = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *inv_variance = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *next_running_mean = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *next_running_variance = nullptr) {
   BatchnormAttributesBuilder builder_(_fbb);
-  if(next_running_variance) { builder_.add_next_running_variance(*next_running_variance); }
-  if(next_running_mean) { builder_.add_next_running_mean(*next_running_mean); }
-  if(inv_variance) { builder_.add_inv_variance(*inv_variance); }
-  if(mean) { builder_.add_mean(*mean); }
+  builder_.add_next_running_variance(next_running_variance);
+  builder_.add_next_running_mean(next_running_mean);
+  builder_.add_inv_variance(inv_variance);
+  builder_.add_mean(mean);
   builder_.add_y(y);
-  if(momentum) { builder_.add_momentum(*momentum); }
-  if(prev_running_variance) { builder_.add_prev_running_variance(*prev_running_variance); }
-  if(prev_running_mean) { builder_.add_prev_running_mean(*prev_running_mean); }
+  builder_.add_momentum(momentum);
+  builder_.add_prev_running_variance(prev_running_variance);
+  builder_.add_prev_running_mean(prev_running_mean);
+  builder_.add_peer_stats(peer_stats);
   builder_.add_epsilon(epsilon);
   builder_.add_bias(bias);
   builder_.add_scale(scale);
   builder_.add_x(x);
-  builder_.add_peer_stats(peer_stats);
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<BatchnormAttributes> CreateBatchnormAttributesDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    int64_t x = 0,
-    int64_t scale = 0,
-    int64_t bias = 0,
-    int64_t epsilon = 0,
-    const std::vector<int64_t> *peer_stats = nullptr,
-    ::flatbuffers::Optional<int64_t> prev_running_mean = ::flatbuffers::nullopt,
-    ::flatbuffers::Optional<int64_t> prev_running_variance = ::flatbuffers::nullopt,
-    ::flatbuffers::Optional<int64_t> momentum = ::flatbuffers::nullopt,
-    int64_t y = 0,
-    ::flatbuffers::Optional<int64_t> mean = ::flatbuffers::nullopt,
-    ::flatbuffers::Optional<int64_t> inv_variance = ::flatbuffers::nullopt,
-    ::flatbuffers::Optional<int64_t> next_running_mean = ::flatbuffers::nullopt,
-    ::flatbuffers::Optional<int64_t> next_running_variance = ::flatbuffers::nullopt) {
-  auto peer_stats__ = peer_stats ? _fbb.CreateVector<int64_t>(*peer_stats) : 0;
+    const hipdnn_sdk::data_objects::TensorID *x = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *scale = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *bias = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *epsilon = nullptr,
+    const std::vector<hipdnn_sdk::data_objects::TensorID> *peer_stats = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *prev_running_mean = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *prev_running_variance = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *momentum = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *y = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *mean = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *inv_variance = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *next_running_mean = nullptr,
+    const hipdnn_sdk::data_objects::TensorID *next_running_variance = nullptr) {
+  auto peer_stats__ = peer_stats ? _fbb.CreateVectorOfStructs<hipdnn_sdk::data_objects::TensorID>(*peer_stats) : 0;
   return hipdnn_sdk::data_objects::CreateBatchnormAttributes(
       _fbb,
       x,
@@ -283,25 +289,58 @@ inline ::flatbuffers::Offset<BatchnormAttributes> CreateBatchnormAttributesDirec
 
 inline bool operator==(const BatchnormAttributesT &lhs, const BatchnormAttributesT &rhs) {
   return
-      (lhs.x == rhs.x) &&
-      (lhs.scale == rhs.scale) &&
-      (lhs.bias == rhs.bias) &&
-      (lhs.epsilon == rhs.epsilon) &&
+      ((lhs.x == rhs.x) || (lhs.x && rhs.x && *lhs.x == *rhs.x)) &&
+      ((lhs.scale == rhs.scale) || (lhs.scale && rhs.scale && *lhs.scale == *rhs.scale)) &&
+      ((lhs.bias == rhs.bias) || (lhs.bias && rhs.bias && *lhs.bias == *rhs.bias)) &&
+      ((lhs.epsilon == rhs.epsilon) || (lhs.epsilon && rhs.epsilon && *lhs.epsilon == *rhs.epsilon)) &&
       (lhs.peer_stats == rhs.peer_stats) &&
-      (lhs.prev_running_mean == rhs.prev_running_mean) &&
-      (lhs.prev_running_variance == rhs.prev_running_variance) &&
-      (lhs.momentum == rhs.momentum) &&
-      (lhs.y == rhs.y) &&
-      (lhs.mean == rhs.mean) &&
-      (lhs.inv_variance == rhs.inv_variance) &&
-      (lhs.next_running_mean == rhs.next_running_mean) &&
-      (lhs.next_running_variance == rhs.next_running_variance);
+      ((lhs.prev_running_mean == rhs.prev_running_mean) || (lhs.prev_running_mean && rhs.prev_running_mean && *lhs.prev_running_mean == *rhs.prev_running_mean)) &&
+      ((lhs.prev_running_variance == rhs.prev_running_variance) || (lhs.prev_running_variance && rhs.prev_running_variance && *lhs.prev_running_variance == *rhs.prev_running_variance)) &&
+      ((lhs.momentum == rhs.momentum) || (lhs.momentum && rhs.momentum && *lhs.momentum == *rhs.momentum)) &&
+      ((lhs.y == rhs.y) || (lhs.y && rhs.y && *lhs.y == *rhs.y)) &&
+      ((lhs.mean == rhs.mean) || (lhs.mean && rhs.mean && *lhs.mean == *rhs.mean)) &&
+      ((lhs.inv_variance == rhs.inv_variance) || (lhs.inv_variance && rhs.inv_variance && *lhs.inv_variance == *rhs.inv_variance)) &&
+      ((lhs.next_running_mean == rhs.next_running_mean) || (lhs.next_running_mean && rhs.next_running_mean && *lhs.next_running_mean == *rhs.next_running_mean)) &&
+      ((lhs.next_running_variance == rhs.next_running_variance) || (lhs.next_running_variance && rhs.next_running_variance && *lhs.next_running_variance == *rhs.next_running_variance));
 }
 
 inline bool operator!=(const BatchnormAttributesT &lhs, const BatchnormAttributesT &rhs) {
     return !(lhs == rhs);
 }
 
+
+inline BatchnormAttributesT::BatchnormAttributesT(const BatchnormAttributesT &o)
+      : x((o.x) ? new hipdnn_sdk::data_objects::TensorID(*o.x) : nullptr),
+        scale((o.scale) ? new hipdnn_sdk::data_objects::TensorID(*o.scale) : nullptr),
+        bias((o.bias) ? new hipdnn_sdk::data_objects::TensorID(*o.bias) : nullptr),
+        epsilon((o.epsilon) ? new hipdnn_sdk::data_objects::TensorID(*o.epsilon) : nullptr),
+        peer_stats(o.peer_stats),
+        prev_running_mean((o.prev_running_mean) ? new hipdnn_sdk::data_objects::TensorID(*o.prev_running_mean) : nullptr),
+        prev_running_variance((o.prev_running_variance) ? new hipdnn_sdk::data_objects::TensorID(*o.prev_running_variance) : nullptr),
+        momentum((o.momentum) ? new hipdnn_sdk::data_objects::TensorID(*o.momentum) : nullptr),
+        y((o.y) ? new hipdnn_sdk::data_objects::TensorID(*o.y) : nullptr),
+        mean((o.mean) ? new hipdnn_sdk::data_objects::TensorID(*o.mean) : nullptr),
+        inv_variance((o.inv_variance) ? new hipdnn_sdk::data_objects::TensorID(*o.inv_variance) : nullptr),
+        next_running_mean((o.next_running_mean) ? new hipdnn_sdk::data_objects::TensorID(*o.next_running_mean) : nullptr),
+        next_running_variance((o.next_running_variance) ? new hipdnn_sdk::data_objects::TensorID(*o.next_running_variance) : nullptr) {
+}
+
+inline BatchnormAttributesT &BatchnormAttributesT::operator=(BatchnormAttributesT o) FLATBUFFERS_NOEXCEPT {
+  std::swap(x, o.x);
+  std::swap(scale, o.scale);
+  std::swap(bias, o.bias);
+  std::swap(epsilon, o.epsilon);
+  std::swap(peer_stats, o.peer_stats);
+  std::swap(prev_running_mean, o.prev_running_mean);
+  std::swap(prev_running_variance, o.prev_running_variance);
+  std::swap(momentum, o.momentum);
+  std::swap(y, o.y);
+  std::swap(mean, o.mean);
+  std::swap(inv_variance, o.inv_variance);
+  std::swap(next_running_mean, o.next_running_mean);
+  std::swap(next_running_variance, o.next_running_variance);
+  return *this;
+}
 
 inline BatchnormAttributesT *BatchnormAttributes::UnPack(const ::flatbuffers::resolver_function_t *_resolver) const {
   auto _o = std::unique_ptr<BatchnormAttributesT>(new BatchnormAttributesT());
@@ -312,19 +351,19 @@ inline BatchnormAttributesT *BatchnormAttributes::UnPack(const ::flatbuffers::re
 inline void BatchnormAttributes::UnPackTo(BatchnormAttributesT *_o, const ::flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = x(); _o->x = _e; }
-  { auto _e = scale(); _o->scale = _e; }
-  { auto _e = bias(); _o->bias = _e; }
-  { auto _e = epsilon(); _o->epsilon = _e; }
-  { auto _e = peer_stats(); if (_e) { _o->peer_stats.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->peer_stats[_i] = _e->Get(_i); } } else { _o->peer_stats.resize(0); } }
-  { auto _e = prev_running_mean(); _o->prev_running_mean = _e; }
-  { auto _e = prev_running_variance(); _o->prev_running_variance = _e; }
-  { auto _e = momentum(); _o->momentum = _e; }
-  { auto _e = y(); _o->y = _e; }
-  { auto _e = mean(); _o->mean = _e; }
-  { auto _e = inv_variance(); _o->inv_variance = _e; }
-  { auto _e = next_running_mean(); _o->next_running_mean = _e; }
-  { auto _e = next_running_variance(); _o->next_running_variance = _e; }
+  { auto _e = x(); if (_e) _o->x = std::unique_ptr<hipdnn_sdk::data_objects::TensorID>(new hipdnn_sdk::data_objects::TensorID(*_e)); }
+  { auto _e = scale(); if (_e) _o->scale = std::unique_ptr<hipdnn_sdk::data_objects::TensorID>(new hipdnn_sdk::data_objects::TensorID(*_e)); }
+  { auto _e = bias(); if (_e) _o->bias = std::unique_ptr<hipdnn_sdk::data_objects::TensorID>(new hipdnn_sdk::data_objects::TensorID(*_e)); }
+  { auto _e = epsilon(); if (_e) _o->epsilon = std::unique_ptr<hipdnn_sdk::data_objects::TensorID>(new hipdnn_sdk::data_objects::TensorID(*_e)); }
+  { auto _e = peer_stats(); if (_e) { _o->peer_stats.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->peer_stats[_i] = *_e->Get(_i); } } else { _o->peer_stats.resize(0); } }
+  { auto _e = prev_running_mean(); if (_e) _o->prev_running_mean = std::unique_ptr<hipdnn_sdk::data_objects::TensorID>(new hipdnn_sdk::data_objects::TensorID(*_e)); }
+  { auto _e = prev_running_variance(); if (_e) _o->prev_running_variance = std::unique_ptr<hipdnn_sdk::data_objects::TensorID>(new hipdnn_sdk::data_objects::TensorID(*_e)); }
+  { auto _e = momentum(); if (_e) _o->momentum = std::unique_ptr<hipdnn_sdk::data_objects::TensorID>(new hipdnn_sdk::data_objects::TensorID(*_e)); }
+  { auto _e = y(); if (_e) _o->y = std::unique_ptr<hipdnn_sdk::data_objects::TensorID>(new hipdnn_sdk::data_objects::TensorID(*_e)); }
+  { auto _e = mean(); if (_e) _o->mean = std::unique_ptr<hipdnn_sdk::data_objects::TensorID>(new hipdnn_sdk::data_objects::TensorID(*_e)); }
+  { auto _e = inv_variance(); if (_e) _o->inv_variance = std::unique_ptr<hipdnn_sdk::data_objects::TensorID>(new hipdnn_sdk::data_objects::TensorID(*_e)); }
+  { auto _e = next_running_mean(); if (_e) _o->next_running_mean = std::unique_ptr<hipdnn_sdk::data_objects::TensorID>(new hipdnn_sdk::data_objects::TensorID(*_e)); }
+  { auto _e = next_running_variance(); if (_e) _o->next_running_variance = std::unique_ptr<hipdnn_sdk::data_objects::TensorID>(new hipdnn_sdk::data_objects::TensorID(*_e)); }
 }
 
 inline ::flatbuffers::Offset<BatchnormAttributes> BatchnormAttributes::Pack(::flatbuffers::FlatBufferBuilder &_fbb, const BatchnormAttributesT* _o, const ::flatbuffers::rehasher_function_t *_rehasher) {
@@ -335,19 +374,19 @@ inline ::flatbuffers::Offset<BatchnormAttributes> CreateBatchnormAttributes(::fl
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const BatchnormAttributesT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _x = _o->x;
-  auto _scale = _o->scale;
-  auto _bias = _o->bias;
-  auto _epsilon = _o->epsilon;
-  auto _peer_stats = _o->peer_stats.size() ? _fbb.CreateVector(_o->peer_stats) : 0;
-  auto _prev_running_mean = _o->prev_running_mean;
-  auto _prev_running_variance = _o->prev_running_variance;
-  auto _momentum = _o->momentum;
-  auto _y = _o->y;
-  auto _mean = _o->mean;
-  auto _inv_variance = _o->inv_variance;
-  auto _next_running_mean = _o->next_running_mean;
-  auto _next_running_variance = _o->next_running_variance;
+  auto _x = _o->x ? _o->x.get() : nullptr;
+  auto _scale = _o->scale ? _o->scale.get() : nullptr;
+  auto _bias = _o->bias ? _o->bias.get() : nullptr;
+  auto _epsilon = _o->epsilon ? _o->epsilon.get() : nullptr;
+  auto _peer_stats = _o->peer_stats.size() ? _fbb.CreateVectorOfStructs(_o->peer_stats) : 0;
+  auto _prev_running_mean = _o->prev_running_mean ? _o->prev_running_mean.get() : nullptr;
+  auto _prev_running_variance = _o->prev_running_variance ? _o->prev_running_variance.get() : nullptr;
+  auto _momentum = _o->momentum ? _o->momentum.get() : nullptr;
+  auto _y = _o->y ? _o->y.get() : nullptr;
+  auto _mean = _o->mean ? _o->mean.get() : nullptr;
+  auto _inv_variance = _o->inv_variance ? _o->inv_variance.get() : nullptr;
+  auto _next_running_mean = _o->next_running_mean ? _o->next_running_mean.get() : nullptr;
+  auto _next_running_variance = _o->next_running_variance ? _o->next_running_variance.get() : nullptr;
   return hipdnn_sdk::data_objects::CreateBatchnormAttributes(
       _fbb,
       _x,

--- a/sdk/include/hipdnn_sdk/data_objects/tensor_attributes_generated.h
+++ b/sdk/include/hipdnn_sdk/data_objects/tensor_attributes_generated.h
@@ -18,6 +18,8 @@ static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
 namespace hipdnn_sdk {
 namespace data_objects {
 
+struct TensorID;
+
 struct Float32Value;
 
 struct Float16Value;
@@ -32,6 +34,8 @@ struct TensorAttributes;
 struct TensorAttributesBuilder;
 struct TensorAttributesT;
 
+bool operator==(const TensorID &lhs, const TensorID &rhs);
+bool operator!=(const TensorID &lhs, const TensorID &rhs);
 bool operator==(const Float32Value &lhs, const Float32Value &rhs);
 bool operator!=(const Float32Value &lhs, const Float32Value &rhs);
 bool operator==(const Float16Value &lhs, const Float16Value &rhs);
@@ -247,6 +251,36 @@ inline bool operator!=(const TensorValueUnion &lhs, const TensorValueUnion &rhs)
 bool VerifyTensorValue(::flatbuffers::Verifier &verifier, const void *obj, TensorValue type);
 bool VerifyTensorValueVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<uint8_t> *types);
 
+FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) TensorID FLATBUFFERS_FINAL_CLASS {
+ private:
+  int64_t value_;
+
+ public:
+  TensorID()
+      : value_(0) {
+  }
+  TensorID(int64_t _value)
+      : value_(::flatbuffers::EndianScalar(_value)) {
+  }
+  int64_t value() const {
+    return ::flatbuffers::EndianScalar(value_);
+  }
+  void mutate_value(int64_t _value) {
+    ::flatbuffers::WriteScalar(&value_, _value);
+  }
+};
+FLATBUFFERS_STRUCT_END(TensorID, 8);
+
+inline bool operator==(const TensorID &lhs, const TensorID &rhs) {
+  return
+      (lhs.value() == rhs.value());
+}
+
+inline bool operator!=(const TensorID &lhs, const TensorID &rhs) {
+    return !(lhs == rhs);
+}
+
+
 FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Float32Value FLATBUFFERS_FINAL_CLASS {
  private:
   float value_;
@@ -399,20 +433,24 @@ inline bool operator!=(const Float64Value &lhs, const Float64Value &rhs) {
 
 struct TensorAttributesT : public ::flatbuffers::NativeTable {
   typedef TensorAttributes TableType;
-  int64_t uid = 0;
+  std::unique_ptr<hipdnn_sdk::data_objects::TensorID> id{};
   std::string name{};
   hipdnn_sdk::data_objects::DataType data_type = hipdnn_sdk::data_objects::DataType_UNSET;
   std::vector<int64_t> strides{};
   std::vector<int64_t> dims{};
   bool virtual_ = false;
   hipdnn_sdk::data_objects::TensorValueUnion value{};
+  TensorAttributesT() = default;
+  TensorAttributesT(const TensorAttributesT &o);
+  TensorAttributesT(TensorAttributesT&&) FLATBUFFERS_NOEXCEPT = default;
+  TensorAttributesT &operator=(TensorAttributesT o) FLATBUFFERS_NOEXCEPT;
 };
 
 struct TensorAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef TensorAttributesT NativeTableType;
   typedef TensorAttributesBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_UID = 4,
+    VT_ID = 4,
     VT_NAME = 6,
     VT_DATA_TYPE = 8,
     VT_STRIDES = 10,
@@ -421,11 +459,11 @@ struct TensorAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_VALUE_TYPE = 16,
     VT_VALUE = 18
   };
-  int64_t uid() const {
-    return GetField<int64_t>(VT_UID, 0);
+  const hipdnn_sdk::data_objects::TensorID *id() const {
+    return GetStruct<const hipdnn_sdk::data_objects::TensorID *>(VT_ID);
   }
-  bool mutate_uid(int64_t _uid = 0) {
-    return SetField<int64_t>(VT_UID, _uid, 0);
+  hipdnn_sdk::data_objects::TensorID *mutable_id() {
+    return GetStruct<hipdnn_sdk::data_objects::TensorID *>(VT_ID);
   }
   const ::flatbuffers::String *name() const {
     return GetPointer<const ::flatbuffers::String *>(VT_NAME);
@@ -484,7 +522,7 @@ struct TensorAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<int64_t>(verifier, VT_UID, 8) &&
+           VerifyField<hipdnn_sdk::data_objects::TensorID>(verifier, VT_ID, 8) &&
            VerifyOffset(verifier, VT_NAME) &&
            verifier.VerifyString(name()) &&
            VerifyField<int8_t>(verifier, VT_DATA_TYPE, 1) &&
@@ -527,8 +565,8 @@ struct TensorAttributesBuilder {
   typedef TensorAttributes Table;
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
-  void add_uid(int64_t uid) {
-    fbb_.AddElement<int64_t>(TensorAttributes::VT_UID, uid, 0);
+  void add_id(const hipdnn_sdk::data_objects::TensorID *id) {
+    fbb_.AddStruct(TensorAttributes::VT_ID, id);
   }
   void add_name(::flatbuffers::Offset<::flatbuffers::String> name) {
     fbb_.AddOffset(TensorAttributes::VT_NAME, name);
@@ -564,7 +602,7 @@ struct TensorAttributesBuilder {
 
 inline ::flatbuffers::Offset<TensorAttributes> CreateTensorAttributes(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    int64_t uid = 0,
+    const hipdnn_sdk::data_objects::TensorID *id = nullptr,
     ::flatbuffers::Offset<::flatbuffers::String> name = 0,
     hipdnn_sdk::data_objects::DataType data_type = hipdnn_sdk::data_objects::DataType_UNSET,
     ::flatbuffers::Offset<::flatbuffers::Vector<int64_t>> strides = 0,
@@ -573,11 +611,11 @@ inline ::flatbuffers::Offset<TensorAttributes> CreateTensorAttributes(
     hipdnn_sdk::data_objects::TensorValue value_type = hipdnn_sdk::data_objects::TensorValue_NONE,
     ::flatbuffers::Offset<void> value = 0) {
   TensorAttributesBuilder builder_(_fbb);
-  builder_.add_uid(uid);
   builder_.add_value(value);
   builder_.add_dims(dims);
   builder_.add_strides(strides);
   builder_.add_name(name);
+  builder_.add_id(id);
   builder_.add_value_type(value_type);
   builder_.add_virtual_(virtual_);
   builder_.add_data_type(data_type);
@@ -586,7 +624,7 @@ inline ::flatbuffers::Offset<TensorAttributes> CreateTensorAttributes(
 
 inline ::flatbuffers::Offset<TensorAttributes> CreateTensorAttributesDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    int64_t uid = 0,
+    const hipdnn_sdk::data_objects::TensorID *id = nullptr,
     const char *name = nullptr,
     hipdnn_sdk::data_objects::DataType data_type = hipdnn_sdk::data_objects::DataType_UNSET,
     const std::vector<int64_t> *strides = nullptr,
@@ -599,7 +637,7 @@ inline ::flatbuffers::Offset<TensorAttributes> CreateTensorAttributesDirect(
   auto dims__ = dims ? _fbb.CreateVector<int64_t>(*dims) : 0;
   return hipdnn_sdk::data_objects::CreateTensorAttributes(
       _fbb,
-      uid,
+      id,
       name__,
       data_type,
       strides__,
@@ -614,7 +652,7 @@ inline ::flatbuffers::Offset<TensorAttributes> CreateTensorAttributesDirect(
 
 inline bool operator==(const TensorAttributesT &lhs, const TensorAttributesT &rhs) {
   return
-      (lhs.uid == rhs.uid) &&
+      ((lhs.id == rhs.id) || (lhs.id && rhs.id && *lhs.id == *rhs.id)) &&
       (lhs.name == rhs.name) &&
       (lhs.data_type == rhs.data_type) &&
       (lhs.strides == rhs.strides) &&
@@ -628,6 +666,27 @@ inline bool operator!=(const TensorAttributesT &lhs, const TensorAttributesT &rh
 }
 
 
+inline TensorAttributesT::TensorAttributesT(const TensorAttributesT &o)
+      : id((o.id) ? new hipdnn_sdk::data_objects::TensorID(*o.id) : nullptr),
+        name(o.name),
+        data_type(o.data_type),
+        strides(o.strides),
+        dims(o.dims),
+        virtual_(o.virtual_),
+        value(o.value) {
+}
+
+inline TensorAttributesT &TensorAttributesT::operator=(TensorAttributesT o) FLATBUFFERS_NOEXCEPT {
+  std::swap(id, o.id);
+  std::swap(name, o.name);
+  std::swap(data_type, o.data_type);
+  std::swap(strides, o.strides);
+  std::swap(dims, o.dims);
+  std::swap(virtual_, o.virtual_);
+  std::swap(value, o.value);
+  return *this;
+}
+
 inline TensorAttributesT *TensorAttributes::UnPack(const ::flatbuffers::resolver_function_t *_resolver) const {
   auto _o = std::unique_ptr<TensorAttributesT>(new TensorAttributesT());
   UnPackTo(_o.get(), _resolver);
@@ -637,7 +696,7 @@ inline TensorAttributesT *TensorAttributes::UnPack(const ::flatbuffers::resolver
 inline void TensorAttributes::UnPackTo(TensorAttributesT *_o, const ::flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = uid(); _o->uid = _e; }
+  { auto _e = id(); if (_e) _o->id = std::unique_ptr<hipdnn_sdk::data_objects::TensorID>(new hipdnn_sdk::data_objects::TensorID(*_e)); }
   { auto _e = name(); if (_e) _o->name = _e->str(); }
   { auto _e = data_type(); _o->data_type = _e; }
   { auto _e = strides(); if (_e) { _o->strides.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->strides[_i] = _e->Get(_i); } } else { _o->strides.resize(0); } }
@@ -655,7 +714,7 @@ inline ::flatbuffers::Offset<TensorAttributes> CreateTensorAttributes(::flatbuff
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const TensorAttributesT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _uid = _o->uid;
+  auto _id = _o->id ? _o->id.get() : nullptr;
   auto _name = _o->name.empty() ? 0 : _fbb.CreateString(_o->name);
   auto _data_type = _o->data_type;
   auto _strides = _o->strides.size() ? _fbb.CreateVector(_o->strides) : 0;
@@ -665,7 +724,7 @@ inline ::flatbuffers::Offset<TensorAttributes> CreateTensorAttributes(::flatbuff
   auto _value = _o->value.Pack(_fbb);
   return hipdnn_sdk::data_objects::CreateTensorAttributes(
       _fbb,
-      _uid,
+      _id,
       _name,
       _data_type,
       _strides,

--- a/sdk/include/hipdnn_sdk/plugin/flatbuffer_utilities/graph_wrapper.hpp
+++ b/sdk/include/hipdnn_sdk/plugin/flatbuffer_utilities/graph_wrapper.hpp
@@ -100,7 +100,7 @@ public:
 
         for(const auto tensor : *_shallow_graph->tensors())
         {
-            _tensor_map[tensor->uid()] = tensor;
+            _tensor_map[tensor->id()->value()] = tensor;
         }
 
         return _tensor_map;

--- a/sdk/include/hipdnn_sdk/test_utilities/flatbuffer_graph_test_utils.hpp
+++ b/sdk/include/hipdnn_sdk/test_utilities/flatbuffer_graph_test_utils.hpp
@@ -13,6 +13,11 @@ namespace flatbuffer_test_utils
 
 using namespace hipdnn_sdk::data_objects;
 
+
+inline std::unique_ptr<hipdnn_sdk::data_objects::TensorID> make_tensor_id(int64_t value){ 
+        return std::make_unique<hipdnn_sdk::data_objects::TensorID>(value);
+}
+
 inline flatbuffers::FlatBufferBuilder create_empty_valid_graph()
 {
     std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::TensorAttributes>>
@@ -40,24 +45,24 @@ inline flatbuffers::FlatBufferBuilder
         tensor_attributes;
 
     tensor_attributes.push_back(hipdnn_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
+        builder, make_tensor_id(1).get(), "x", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
 
     tensor_attributes.push_back(hipdnn_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
+        builder, make_tensor_id(2).get(), "y", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
 
     tensor_attributes.push_back(hipdnn_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 3, "scale", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
+        builder, make_tensor_id(3).get(), "scale", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
 
     tensor_attributes.push_back(hipdnn_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 4, "bias", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
+        builder, make_tensor_id(4).get(), "bias", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
 
     if(has_optional_attributes)
     {
         tensor_attributes.push_back(hipdnn_sdk::data_objects::CreateTensorAttributesDirect(
-            builder, 5, "est_mean", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
+            builder, make_tensor_id(5).get(), "est_mean", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
 
         tensor_attributes.push_back(hipdnn_sdk::data_objects::CreateTensorAttributesDirect(
-            builder, 6, "est_variance", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
+            builder, make_tensor_id(6).get(), "est_variance", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
     }
 
     auto bnorm_attributes = hipdnn_sdk::data_objects::CreateBatchnormInferenceAttributes(

--- a/sdk/schemas/batchnorm_attributes.fbs
+++ b/sdk/schemas/batchnorm_attributes.fbs
@@ -1,20 +1,22 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
+include "tensor_attributes.fbs";
+
 namespace hipdnn_sdk.data_objects;
 
 table BatchnormAttributes {
-    x: long;
-    scale: long;
-    bias: long;
-    epsilon: long;
-    peer_stats: [long];
-    prev_running_mean: long = null;
-    prev_running_variance: long = null;
-    momentum: long = null;
-    y: long;
-    mean: long = null;
-    inv_variance: long = null;
-    next_running_mean: long = null;
-    next_running_variance: long = null;
+    x: TensorID;
+    scale: TensorID;
+    bias: TensorID;
+    epsilon: TensorID;
+    peer_stats: [TensorID];
+    prev_running_mean: TensorID;
+    prev_running_variance: TensorID;
+    momentum: TensorID;
+    y: TensorID;
+    mean: TensorID;
+    inv_variance: TensorID;
+    next_running_mean: TensorID;
+    next_running_variance: TensorID;
 }

--- a/sdk/schemas/tensor_attributes.fbs
+++ b/sdk/schemas/tensor_attributes.fbs
@@ -5,6 +5,10 @@ include "data_types.fbs";
 
 namespace hipdnn_sdk.data_objects;
 
+struct TensorID{
+    value: long;
+}
+
 struct Float32Value {
   value: float;
 }
@@ -34,7 +38,7 @@ union TensorValue {
 }
 
 table TensorAttributes {
-    uid: long;
+    id: TensorID;
     name: string;
     data_type: DataType;
     strides: [long];

--- a/sdk/tests/plugin/flatbuffer_utilities/test_graph_wrapper.cpp
+++ b/sdk/tests/plugin/flatbuffer_utilities/test_graph_wrapper.cpp
@@ -95,6 +95,7 @@ TEST(Graph_wrapperTest, GetTensorMapEmptyGraph)
 
 TEST(Graph_wrapperTest, GetTensorMapReturnsCorrectTensors)
 {
+    using flatbuffer_test_utils::make_tensor_id;
     flatbuffers::FlatBufferBuilder builder;
     std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::Node>> nodes;
 
@@ -103,9 +104,9 @@ TEST(Graph_wrapperTest, GetTensorMapReturnsCorrectTensors)
     std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::TensorAttributes>>
         tensor_attributes;
     tensor_attributes.push_back(hipdnn_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
+        builder, make_tensor_id(1).get(), "x", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
     tensor_attributes.push_back(hipdnn_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
+        builder, make_tensor_id(2).get(), "y", hipdnn_sdk::data_objects::DataType_FLOAT, &strides, &dims));
 
     auto graph = hipdnn_sdk::data_objects::CreateGraphDirect(builder,
                                                              "test",
@@ -124,6 +125,6 @@ TEST(Graph_wrapperTest, GetTensorMapReturnsCorrectTensors)
     EXPECT_EQ(tensor_map.size(), 2);
     EXPECT_NE(tensor_map.find(1), tensor_map.end());
     EXPECT_NE(tensor_map.find(2), tensor_map.end());
-    EXPECT_EQ(tensor_map.at(1)->uid(), 1);
-    EXPECT_EQ(tensor_map.at(2)->uid(), 2);
+    EXPECT_EQ(tensor_map.at(1)->id()->value(), 1);
+    EXPECT_EQ(tensor_map.at(2)->id()->value(), 2);
 }

--- a/tests/backend/test_util.cpp
+++ b/tests/backend/test_util.cpp
@@ -284,7 +284,7 @@ void extract_tensor_info_from_graph(
     // Extract all tensor information from the deserialized graph
     for(const auto& tensor : deserialized_graph->tensors)
     {
-        int64_t uid = tensor->uid;
+        int64_t uid = tensor->id->value();
         std::string name = tensor->name;
 
         uid_to_name_map[uid] = name;


### PR DESCRIPTION
## Proposed changes

Updates the schema to use a strongly typed TensorID class as a wrapper around "long" instead of just using longs. The goal of this is to make it clear which values are supposed to be tensorIDs and which are supposed to be 64 bit integers, as well as provide extra type safety

This change has fairly widespread changes, there are a couple that may not be ideal. I'm doing a self-review to highlight some I noticed. I want to get some opinions before I continue down this path

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [ ] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [ ] I have ran the tests, and they are all passing locally
- [ ] I have ran the tests with ASAN, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] I have ran `make format` & `make check_format` to ensure the changes have been formatted
