### PR TITLE
Engine plugin resource manager: execution plan descriptor integration

### DIFF
--- a/backend/src/descriptors/engine_config_descriptor.hpp
+++ b/backend/src/descriptors/engine_config_descriptor.hpp
@@ -35,8 +35,6 @@ private:
                                 int64_t* element_count,
                                 void* array_of_elements) const;
 
-    hipdnnPluginConstData_t get_serialized_engine_config() const;
-
 public:
     Engine_config_descriptor();
     static constexpr int64_t INVALID_WORKSPACE_SIZE = -1;
@@ -57,7 +55,9 @@ public:
     static hipdnnBackendDescriptorType_t get_static_type();
 
     // Throws an exception if the descriptor is not finalized before calling these.
-    std::shared_ptr<const Engine_descriptor> get_engine() const;
+    virtual std::shared_ptr<const Engine_descriptor> get_engine() const;
+
+    virtual hipdnnPluginConstData_t get_serialized_engine_config() const;
 };
 
 } // namespace hipdnn_backend

--- a/backend/src/descriptors/execution_plan_descriptor.cpp
+++ b/backend/src/descriptors/execution_plan_descriptor.cpp
@@ -1,9 +1,11 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
-#include "execution_plan_descriptor.hpp"
 #include "engine_config_descriptor.hpp"
+#include "engine_descriptor.hpp"
 #include "error.hpp"
+#include "execution_plan_descriptor.hpp"
+#include "handle/handle.hpp"
 #include "hipdnn_backend_descriptor_type.h"
 #include "hipdnn_exception.hpp"
 
@@ -23,6 +25,13 @@ void Execution_plan_descriptor::finalize()
     THROW_IF_NULL(_engine_config,
                   HIPDNN_STATUS_BAD_PARAM,
                   "Execution_plan_descriptor::finalize() failed: Engine was not set.");
+
+    auto plugin_resource_manager = _handle->get_plugin_resource_manager();
+    auto engine_config_plugin_data = _engine_config->get_serialized_engine_config();
+    auto engine = _engine_config->get_engine();
+
+    _execution_context = plugin::Engine_plugin_resource_manager::create_execution_context(
+        plugin_resource_manager, engine->get_engine_id(), &engine_config_plugin_data, engine->get_graph().get());
 
     hipdnnBackendDescriptorImpl<Execution_plan_descriptor>::finalize();
 }
@@ -204,6 +213,15 @@ std::shared_ptr<const Engine_config_descriptor> Execution_plan_descriptor::get_e
                    "Execution_plan_descriptor::get_engine_config() failed: Not finalized.");
 
     return _engine_config;
+}
+
+hipdnnEnginePluginExecutionContext_t Execution_plan_descriptor::get_execution_context() const
+{
+    THROW_IF_FALSE(is_finalized(),
+                   HIPDNN_STATUS_INTERNAL_ERROR,
+                   "Execution_plan_descriptor::get_execution_context() failed: Not finalized.");
+
+    return _execution_context->get();
 }
 
 hipdnnBackendDescriptorType_t Execution_plan_descriptor::get_static_type()

--- a/backend/src/descriptors/execution_plan_descriptor.cpp
+++ b/backend/src/descriptors/execution_plan_descriptor.cpp
@@ -1,10 +1,10 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
+#include "execution_plan_descriptor.hpp"
 #include "engine_config_descriptor.hpp"
 #include "engine_descriptor.hpp"
 #include "error.hpp"
-#include "execution_plan_descriptor.hpp"
 #include "handle/handle.hpp"
 #include "hipdnn_backend_descriptor_type.h"
 #include "hipdnn_exception.hpp"
@@ -31,7 +31,10 @@ void Execution_plan_descriptor::finalize()
     auto engine = _engine_config->get_engine();
 
     _execution_context = plugin::Engine_plugin_resource_manager::create_execution_context(
-        plugin_resource_manager, engine->get_engine_id(), &engine_config_plugin_data, engine->get_graph().get());
+        plugin_resource_manager,
+        engine->get_engine_id(),
+        &engine_config_plugin_data,
+        engine->get_graph().get());
 
     hipdnnBackendDescriptorImpl<Execution_plan_descriptor>::finalize();
 }

--- a/backend/src/descriptors/execution_plan_descriptor.hpp
+++ b/backend/src/descriptors/execution_plan_descriptor.hpp
@@ -4,16 +4,24 @@
 #pragma once
 
 #include "backend_descriptor.hpp"
+#include <hipdnn_sdk/plugin/plugin_api_data_types.h>
 
 namespace hipdnn_backend
 {
 
 class Engine_config_descriptor;
+
+namespace plugin
+{
+class Engine_execution_context_wrapper;
+}
+
 class Execution_plan_descriptor : public hipdnnBackendDescriptorImpl<Execution_plan_descriptor>
 {
 private:
     hipdnnHandle_t _handle = nullptr;
     std::shared_ptr<const Engine_config_descriptor> _engine_config;
+    std::shared_ptr<const plugin::Engine_execution_context_wrapper> _execution_context;
 
     void get_workspace_size(hipdnnBackendAttributeType_t attribute_type,
                             int64_t requested_element_count,
@@ -49,6 +57,7 @@ public:
 
     // Throws an exception if the descriptor is not finalized.
     std::shared_ptr<const Engine_config_descriptor> get_engine_config() const;
+    hipdnnEnginePluginExecutionContext_t get_execution_context() const;
 
     static hipdnnBackendDescriptorType_t get_static_type();
 };

--- a/backend/tests/descriptors/mocks/mock_descriptor.hpp
+++ b/backend/tests/descriptors/mocks/mock_descriptor.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "descriptors/backend_descriptor.hpp"
+#include "descriptors/engine_config_descriptor.hpp"
 #include "descriptors/engine_descriptor.hpp"
 #include "descriptors/graph_descriptor.hpp"
 
@@ -83,6 +84,36 @@ public:
     static hipdnnBackendDescriptorType_t get_static_type()
     {
         return HIPDNN_BACKEND_ENGINE_DESCRIPTOR;
+    }
+};
+
+class Mock_engine_config_descriptor : public Engine_config_descriptor
+{
+public:
+    MOCK_METHOD(void, finalize, (), (override));
+    MOCK_METHOD(bool, is_finalized, (), (const, override));
+    MOCK_METHOD(void,
+                set_attribute,
+                (hipdnnBackendAttributeName_t attribute_name,
+                 hipdnnBackendAttributeType_t attribute_type,
+                 int64_t element_count,
+                 const void* array_of_element),
+                (override));
+    MOCK_METHOD(void,
+                get_attribute,
+                (hipdnnBackendAttributeName_t attribute_name,
+                 hipdnnBackendAttributeType_t attribute_type,
+                 int64_t requested_element_count,
+                 int64_t* element_count,
+                 void* array_of_elements),
+                (const, override));
+
+    MOCK_METHOD(std::shared_ptr<const Engine_descriptor>, get_engine, (), (const, override));
+    MOCK_METHOD(hipdnnPluginConstData_t, get_serialized_engine_config, (), (const, override));
+
+    static hipdnnBackendDescriptorType_t get_static_type()
+    {
+        return HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR;
     }
 };
 

--- a/backend/tests/descriptors/test_engine_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_descriptor.cpp
@@ -60,22 +60,21 @@ public:
                                                                &_mock_graph_wrapper));
     }
 
-    void set_global_index() const
+    void set_global_index(int64_t engine_id) const
     {
-        int64_t gidx = 0;
         ASSERT_NO_THROW(get_engine_descriptor()->set_attribute(
-            HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &gidx));
+            HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &engine_id));
     }
 
     void make_engine_finalized() const
     {
         set_graph();
-        set_global_index();
+        set_global_index(ENGINE_ID);
         EXPECT_CALL(*get_mock_graph(), get_handle()).WillOnce(Return(_mock_handle.get()));
         EXPECT_CALL(*_mock_handle, get_plugin_resource_manager())
             .WillOnce(Return(_mock_engine_plugin_resource_manager));
         EXPECT_CALL(*_mock_engine_plugin_resource_manager, get_applicable_engine_ids(_))
-            .WillOnce(Return(std::vector<int64_t>{0}));
+            .WillOnce(Return(std::vector<int64_t>{ENGINE_ID}));
         EXPECT_CALL(*_mock_engine_plugin_resource_manager, get_engine_details(_, _, _))
             .WillOnce(Invoke([this](int64_t, const Graph_descriptor*, hipdnnPluginConstData_t* d) {
                 *d = this->_serialized_engine_details;
@@ -97,23 +96,22 @@ protected:
         _mock_engine_plugin_resource_manager
             = std::make_shared<Mock_engine_plugin_resource_manager>();
 
-        serialize_engine_details();
+        serialize_engine_details(ENGINE_ID);
     }
 
 private:
-    void serialize_engine_details()
+    void serialize_engine_details(int64_t engine_id)
     {
-        int64_t gidx = 0;
-
         flatbuffers::FlatBufferBuilder builder;
         hipdnn_sdk::data_objects::EngineDetailsBuilder engine_details_builder(builder);
-        engine_details_builder.add_engine_id(gidx);
+        engine_details_builder.add_engine_id(engine_id);
         builder.Finish(engine_details_builder.Finish());
         _engine_details_buffer = builder.Release();
         _serialized_engine_details
             = {.ptr = _engine_details_buffer.data(), .size = _engine_details_buffer.size()};
     }
 
+    static constexpr int64_t ENGINE_ID = 0;
     flatbuffers::DetachedBuffer _engine_details_buffer;
     hipdnnPluginConstData_t _serialized_engine_details;
 };

--- a/backend/tests/descriptors/test_execution_plan_descriptor.cpp
+++ b/backend/tests/descriptors/test_execution_plan_descriptor.cpp
@@ -91,9 +91,7 @@ public:
         EXPECT_CALL(*get_mock_engine_config(), is_finalized()).WillOnce(Return(true));
         EXPECT_CALL(*get_mock_engine_config(), get_engine()).WillOnce(Return(get_mock_engine()));
         EXPECT_CALL(*get_mock_engine_config(), get_serialized_engine_config())
-            .WillOnce(Invoke([]() {
-                return hipdnnPluginConstData_t{nullptr, 0};
-            }));
+            .WillOnce(Invoke([]() { return hipdnnPluginConstData_t{nullptr, 0}; }));
 
         get_execution_plan_descriptor()->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,

--- a/backend/tests/descriptors/test_execution_plan_descriptor.cpp
+++ b/backend/tests/descriptors/test_execution_plan_descriptor.cpp
@@ -7,6 +7,8 @@
 #include "hipdnn_backend.h"
 #include "hipdnn_exception.hpp"
 #include "mocks/mock_descriptor.hpp"
+#include "mocks/mock_engine_plugin_resource_manager.hpp"
+#include "mocks/mock_handle.hpp"
 #include "test_descriptor_utils.hpp"
 #include "test_macros.hpp"
 
@@ -16,88 +18,114 @@
 #include <memory>
 
 using namespace hipdnn_backend;
+using namespace plugin;
 using namespace test_descriptor_utils;
+using namespace ::testing;
 
-using ::testing::_;
 using ::testing::Return;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 class Execution_plan_descriptor_test : public ::testing::Test
 {
 public:
     std::unique_ptr<hipdnnBackendDescriptor> _plan_wrapper = nullptr;
-    hipdnnHandle_t _handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
+    std::unique_ptr<hipdnnBackendDescriptor> _mock_graph_wrapper = nullptr;
+    std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_wrapper = nullptr;
     std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_config_wrapper = nullptr;
     std::unique_ptr<hipdnnBackendDescriptor> _mock_engine_config_bad_type_wrapper = nullptr;
     std::unique_ptr<hipdnnBackendDescriptor> _mock_wrong_type_wrapper = nullptr;
+    std::unique_ptr<Mock_handle> _mock_handle = nullptr;
+    std::shared_ptr<Mock_engine_plugin_resource_manager> _mock_engine_plugin_resource_manager
+        = nullptr;
 
     std::shared_ptr<Execution_plan_descriptor> get_execution_plan_descriptor() const
     {
         return _plan_wrapper->as_descriptor<Execution_plan_descriptor>();
     }
 
-    std::shared_ptr<Mock_descriptor<Engine_config_descriptor>> get_mock_engine_config() const
+    std::shared_ptr<Mock_graph_descriptor> get_mock_graph() const
     {
-        return _mock_engine_config_wrapper
-            ->as_descriptor<Mock_descriptor<Engine_config_descriptor>>();
+        return Mock_descriptor_utility::as_descriptor_unsafe<Mock_graph_descriptor>(
+            _mock_graph_wrapper.get());
     }
 
-    std::shared_ptr<Mock_descriptor<Engine_config_descriptor>>
-        get_mock_engine_config_bad_type() const
+    std::shared_ptr<Mock_engine_descriptor> get_mock_engine() const
     {
-        return _mock_engine_config_bad_type_wrapper
-            ->as_descriptor<Mock_descriptor<Engine_config_descriptor>>();
+        return Mock_descriptor_utility::as_descriptor_unsafe<Mock_engine_descriptor>(_mock_engine_wrapper.get());
     }
 
-    std::shared_ptr<Mock_descriptor<Execution_plan_descriptor>> get_mock_wrong_type() const
+    std::shared_ptr<Mock_engine_config_descriptor> get_mock_engine_config() const
     {
-        return _mock_wrong_type_wrapper
-            ->as_descriptor<Mock_descriptor<Execution_plan_descriptor>>();
+        return Mock_descriptor_utility::as_descriptor_unsafe<Mock_engine_config_descriptor>(_mock_engine_config_wrapper.get());
     }
 
-    void SetUp() override
+    std::shared_ptr<Mock_engine_config_descriptor> get_mock_engine_config_bad_type() const
     {
-        _plan_wrapper = create_descriptor<Execution_plan_descriptor>();
-        _mock_engine_config_wrapper
-            = create_descriptor<Mock_descriptor<Engine_config_descriptor>>();
-        _mock_engine_config_bad_type_wrapper
-            = create_descriptor<Mock_descriptor<Engine_config_descriptor>>();
-        _mock_wrong_type_wrapper = create_descriptor<Mock_descriptor<Execution_plan_descriptor>>();
+        return Mock_descriptor_utility::as_descriptor_unsafe<Mock_engine_config_descriptor>(_mock_engine_config_bad_type_wrapper.get());
     }
 
-    void TearDown() override
+    static hipdnnEnginePluginExecutionContext_t get_execution_context()
     {
-        _plan_wrapper.reset();
-        _mock_engine_config_wrapper.reset();
-        _mock_engine_config_bad_type_wrapper.reset();
-        _mock_wrong_type_wrapper.reset();
-    }
-
-    void make_execution_plan_finalized()
-    {
-        ASSERT_NO_THROW(set_handle());
-        ASSERT_NO_THROW(set_engine_config());
-
-        auto plan = get_execution_plan_descriptor();
-        ASSERT_NO_THROW(plan->finalize());
+        return reinterpret_cast<hipdnnEnginePluginExecutionContext_t>(0xFFFFFFFF);
     }
 
     void set_handle()
     {
-        auto plan = get_execution_plan_descriptor();
-        plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle);
+        EXPECT_CALL(*_mock_engine_plugin_resource_manager, create_execution_context(_, _, _)).WillOnce(Return(get_execution_context()));
+        EXPECT_CALL(*_mock_engine_plugin_resource_manager, destroy_execution_context(_, _));
+
+        EXPECT_CALL(*_mock_handle, get_plugin_resource_manager())
+            .WillOnce(Return(_mock_engine_plugin_resource_manager));
+        get_execution_plan_descriptor()->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_mock_handle);
     }
 
     void set_engine_config()
     {
-        auto plan = get_execution_plan_descriptor();
-        auto mock_engine_config = get_mock_engine_config();
-        EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(true));
-        plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                            HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                            1,
-                            &_mock_engine_config_wrapper);
+        EXPECT_CALL(*get_mock_engine(), get_engine_id()).WillOnce(Return(ENGINE_ID));
+        EXPECT_CALL(*get_mock_engine(), get_graph()).WillOnce(Return(get_mock_graph()));
+
+        EXPECT_CALL(*get_mock_engine_config(), is_finalized()).WillOnce(Return(true));
+        EXPECT_CALL(*get_mock_engine_config(), get_engine()).WillOnce(Return(get_mock_engine()));
+        EXPECT_CALL(*get_mock_engine_config(), get_serialized_engine_config())
+            .WillOnce(Invoke([]() {
+                return hipdnnPluginConstData_t{nullptr, 0};
+            }));
+
+        get_execution_plan_descriptor()->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                       1,
+                                                       &_mock_engine_config_wrapper);
     }
+
+    void make_execution_plan_finalized()
+    {
+        set_handle();
+        set_engine_config();
+        ASSERT_NO_THROW(get_execution_plan_descriptor()->finalize());
+    }
+
+protected:
+    void SetUp() override
+    {
+        _plan_wrapper = create_descriptor<Execution_plan_descriptor>();
+        _mock_graph_wrapper = test_descriptor_utils::create_descriptor<Mock_graph_descriptor>();
+        _mock_engine_wrapper
+            = create_descriptor<Mock_engine_descriptor>();
+        _mock_engine_config_wrapper
+            = create_descriptor<Mock_engine_config_descriptor>();
+        _mock_engine_config_bad_type_wrapper
+            = create_descriptor<Mock_engine_config_descriptor>();
+        _mock_wrong_type_wrapper = create_descriptor<Mock_engine_descriptor>();
+        _mock_handle = std::make_unique<Mock_handle>();
+        _mock_engine_plugin_resource_manager
+            = std::make_shared<Mock_engine_plugin_resource_manager>();
+    }
+
+    void TearDown() override
+    {
+    }
+
+private:
+    static constexpr int64_t ENGINE_ID = 0;
 };
 
 TEST_F(Execution_plan_descriptor_test, CreateExecutionPlanDescriptor)
@@ -326,4 +354,12 @@ TEST_F(Execution_plan_descriptor_test, GetEngineConfigReturnsPointerIfFinalized)
     ASSERT_EQ(static_cast<const Backend_descriptor_interface*>(engine_config_ptr.get()),
               static_cast<const Backend_descriptor_interface*>(get_mock_engine_config().get()));
 }
-// NOLINTEND(readability-function-cognitive-complexity)
+
+TEST_F(Execution_plan_descriptor_test, ExecutionPlanDescriptorGetExecutionContext)
+{
+    auto plan = get_execution_plan_descriptor();
+    make_execution_plan_finalized();
+    auto context = plan->get_execution_context();
+    ASSERT_NE(context, nullptr);
+    ASSERT_EQ(context, get_execution_context());
+}

--- a/backend/tests/descriptors/test_execution_plan_descriptor.cpp
+++ b/backend/tests/descriptors/test_execution_plan_descriptor.cpp
@@ -50,17 +50,20 @@ public:
 
     std::shared_ptr<Mock_engine_descriptor> get_mock_engine() const
     {
-        return Mock_descriptor_utility::as_descriptor_unsafe<Mock_engine_descriptor>(_mock_engine_wrapper.get());
+        return Mock_descriptor_utility::as_descriptor_unsafe<Mock_engine_descriptor>(
+            _mock_engine_wrapper.get());
     }
 
     std::shared_ptr<Mock_engine_config_descriptor> get_mock_engine_config() const
     {
-        return Mock_descriptor_utility::as_descriptor_unsafe<Mock_engine_config_descriptor>(_mock_engine_config_wrapper.get());
+        return Mock_descriptor_utility::as_descriptor_unsafe<Mock_engine_config_descriptor>(
+            _mock_engine_config_wrapper.get());
     }
 
     std::shared_ptr<Mock_engine_config_descriptor> get_mock_engine_config_bad_type() const
     {
-        return Mock_descriptor_utility::as_descriptor_unsafe<Mock_engine_config_descriptor>(_mock_engine_config_bad_type_wrapper.get());
+        return Mock_descriptor_utility::as_descriptor_unsafe<Mock_engine_config_descriptor>(
+            _mock_engine_config_bad_type_wrapper.get());
     }
 
     static hipdnnEnginePluginExecutionContext_t get_execution_context()
@@ -70,12 +73,14 @@ public:
 
     void set_handle()
     {
-        EXPECT_CALL(*_mock_engine_plugin_resource_manager, create_execution_context(_, _, _)).WillOnce(Return(get_execution_context()));
+        EXPECT_CALL(*_mock_engine_plugin_resource_manager, create_execution_context(_, _, _))
+            .WillOnce(Return(get_execution_context()));
         EXPECT_CALL(*_mock_engine_plugin_resource_manager, destroy_execution_context(_, _));
 
         EXPECT_CALL(*_mock_handle, get_plugin_resource_manager())
             .WillOnce(Return(_mock_engine_plugin_resource_manager));
-        get_execution_plan_descriptor()->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_mock_handle);
+        get_execution_plan_descriptor()->set_attribute(
+            HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_mock_handle);
     }
 
     void set_engine_config()
@@ -108,21 +113,16 @@ protected:
     {
         _plan_wrapper = create_descriptor<Execution_plan_descriptor>();
         _mock_graph_wrapper = test_descriptor_utils::create_descriptor<Mock_graph_descriptor>();
-        _mock_engine_wrapper
-            = create_descriptor<Mock_engine_descriptor>();
-        _mock_engine_config_wrapper
-            = create_descriptor<Mock_engine_config_descriptor>();
-        _mock_engine_config_bad_type_wrapper
-            = create_descriptor<Mock_engine_config_descriptor>();
+        _mock_engine_wrapper = create_descriptor<Mock_engine_descriptor>();
+        _mock_engine_config_wrapper = create_descriptor<Mock_engine_config_descriptor>();
+        _mock_engine_config_bad_type_wrapper = create_descriptor<Mock_engine_config_descriptor>();
         _mock_wrong_type_wrapper = create_descriptor<Mock_engine_descriptor>();
         _mock_handle = std::make_unique<Mock_handle>();
         _mock_engine_plugin_resource_manager
             = std::make_shared<Mock_engine_plugin_resource_manager>();
     }
 
-    void TearDown() override
-    {
-    }
+    void TearDown() override {}
 
 private:
     static constexpr int64_t ENGINE_ID = 0;


### PR DESCRIPTION
## Proposed changes

Add execution plan descriptor integration logic, update tests to support it.

Note: It breaks public API tests since we are missing testing plugins to provide equivalent results as before.