### PR TITLE
Turn off test logging by default

### DIFF
--- a/plugins/miopen_legacy_plugin/integration_tests/batchnorm_fwd_inference_integration_test.cpp
+++ b/plugins/miopen_legacy_plugin/integration_tests/batchnorm_fwd_inference_integration_test.cpp
@@ -83,12 +83,12 @@ class Batchnorm_forward_inference_integration_test
 protected:
     void SetUp() override
     {
-        setenv("HIPDNN_LOG_LEVEL", "info", 1);
+        // Uncomment if you want debug logging info.
+        // setenv("HIPDNN_LOG_LEVEL", "info", 1);
+
         // Initialize HIP
         ASSERT_EQ(hipInit(0), hipSuccess);
         ASSERT_EQ(hipGetDevice(&_device_id), hipSuccess);
-        //todo: bring back stream support once MigratableMemory supports it
-        //ASSERT_EQ(hipStreamCreate(&_stream), hipSuccess);
 
         //Note: The plugin paths has to be set before we create the hipdnn handle.
         const std::array<const char*, 1> paths = {PLUGIN_DIR};
@@ -98,6 +98,9 @@ protected:
 
         // Create handle
         ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
+        
+        //todo: bring back stream support once MigratableMemory supports it
+        //ASSERT_EQ(hipStreamCreate(&_stream), hipSuccess);
         //ASSERT_EQ(hipdnnSetStream(_handle, _stream), HIPDNN_STATUS_SUCCESS);
     }
 


### PR DESCRIPTION
## Proposed changes

Disable logging by default, and move around stream logic to prevent future issues when we implement multi-stream usage.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added automated tests relevant to the introduced functionality
- [x] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [x] I have ran the tests, and they are all passing locally
- [x] I have ran the tests with ASAN, and they are all passing locally
- [x] I have added relevant documentation for the changes
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] I have ran `make format` & `make check_format` to ensure the changes have been formatted
