### PR TITLE
Add SKIP_IF_NO_DEVICES to MIOpen legacy plugin integration tests

### DIFF
--- a/plugins/miopen_legacy_plugin/integration_tests/batchnorm_fwd_inference_integration_test.cpp
+++ b/plugins/miopen_legacy_plugin/integration_tests/batchnorm_fwd_inference_integration_test.cpp
@@ -10,9 +10,9 @@
 
 #include <hipdnn_frontend/attributes/tensor_attributes.hpp>
 #include <hipdnn_frontend/graph.hpp>
-#include <hipdnn_sdk/test_utilities/test_utilities.hpp>
 #include <hipdnn_sdk/test_utilities/cpu_fp_reference_implementation.hpp>
 #include <hipdnn_sdk/test_utilities/cpu_fp_reference_validation.hpp>
+#include <hipdnn_sdk/test_utilities/test_utilities.hpp>
 #include <hipdnn_sdk/utilities/migratable_memory.hpp>
 #include <hipdnn_sdk/utilities/tensor.hpp>
 
@@ -85,7 +85,7 @@ protected:
     void SetUp() override
     {
         SKIP_IF_NO_DEVICES();
-        
+
         // Uncomment if you want debug logging info.
         // setenv("HIPDNN_LOG_LEVEL", "info", 1);
 

--- a/plugins/miopen_legacy_plugin/integration_tests/batchnorm_fwd_inference_integration_test.cpp
+++ b/plugins/miopen_legacy_plugin/integration_tests/batchnorm_fwd_inference_integration_test.cpp
@@ -10,6 +10,7 @@
 
 #include <hipdnn_frontend/attributes/tensor_attributes.hpp>
 #include <hipdnn_frontend/graph.hpp>
+#include <hipdnn_sdk/test_utilities/test_utilities.hpp>
 #include <hipdnn_sdk/test_utilities/cpu_fp_reference_implementation.hpp>
 #include <hipdnn_sdk/test_utilities/cpu_fp_reference_validation.hpp>
 #include <hipdnn_sdk/utilities/migratable_memory.hpp>
@@ -83,6 +84,8 @@ class Batchnorm_forward_inference_integration_test
 protected:
     void SetUp() override
     {
+        SKIP_IF_NO_DEVICES();
+        
         // Uncomment if you want debug logging info.
         // setenv("HIPDNN_LOG_LEVEL", "info", 1);
 


### PR DESCRIPTION
## Proposed changes

Added SKIP_IF_NO_DEVICE() to the integration tests, which will eliminate some fake memory leaks from ASAN builds.

## Checklist

- [x] I have added automated tests relevant to the introduced functionality
- [x] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [x] I have ran the tests, and they are all passing locally
- [x] I have ran the tests with ASAN, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [x] I have ran `make format` & `make check_format` to ensure the changes have been formatted
