### PR TITLE
Disable cognitive complexity check for project

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,7 +20,8 @@ Checks: >
   -readability-qualified-auto,
   -readability-uppercase-literal-suffix,
   -readability-avoid-unconditional-preprocessor-if,
-  -readability-use-anyofallof
+  -readability-use-anyofallof,
+  -readability-function-cognitive-complexity
 
 WarningsAsErrors: "*"
 HeaderFileExtensions: ['h','hpp']

--- a/backend/src/plugin/plugin_core.hpp
+++ b/backend/src/plugin/plugin_core.hpp
@@ -104,8 +104,7 @@ protected:
     }
 
     // TODO: figure out how to ignore cognitive complexity warnings induced by logging macros
-    // NOLINTBEGIN(readability-function-cognitive-complexity)
-    std::set<std::filesystem::path> resolve_default_paths() const
+        std::set<std::filesystem::path> resolve_default_paths() const
     {
         std::filesystem::path base_dir;
         try
@@ -137,13 +136,11 @@ protected:
 
         return resolved_paths;
     }
-    // NOLINTEND(readability-function-cognitive-complexity)
-
+    
 public:
     virtual ~Plugin_manager_base() = default;
 
-    // NOLINTBEGIN(readability-function-cognitive-complexity)
-    void load_plugins(const std::set<std::filesystem::path>& custom_paths,
+        void load_plugins(const std::set<std::filesystem::path>& custom_paths,
                       hipdnnPluginLoadingMode_ext_t mode)
     {
         std::set<std::filesystem::path> paths_to_load;
@@ -196,8 +193,7 @@ public:
             load_plugin_from_file(path);
         }
     }
-    // NOLINTEND(readability-function-cognitive-complexity)
-
+    
     const std::vector<Plugin>& get_plugins() const
     {
         return _plugins;

--- a/backend/tests/descriptors/test_engine_heuristic_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_heuristic_descriptor.cpp
@@ -27,7 +27,6 @@ using namespace ::testing;
 
 using ::testing::Return;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 class Engine_heuristic_descriptor_test : public ::testing::Test
 {
 public:
@@ -545,4 +544,3 @@ TEST_F(Engine_heuristic_descriptor_test, GetGraphReturnsPointerIfFinalized)
     ASSERT_EQ(static_cast<const Backend_descriptor_interface*>(graph_ptr.get()),
               static_cast<const Backend_descriptor_interface*>(get_mock_graph().get()));
 }
-// NOLINTEND(readability-function-cognitive-complexity)

--- a/backend/tests/descriptors/test_variant_pack.cpp
+++ b/backend/tests/descriptors/test_variant_pack.cpp
@@ -145,7 +145,6 @@ TEST_F(Initialize_variant_pack_descriptor_tests, InvalidGetAttributeNotFinalized
                                HIPDNN_STATUS_NOT_INITIALIZED);
 }
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 class Finalized_variant_pack_descriptor_tests : public ::testing::Test
 {
 protected:
@@ -262,6 +261,5 @@ TEST_F(Finalized_variant_pack_descriptor_tests, InvalidGetAttributes)
                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-// NOLINTEND(readability-function-cognitive-complexity)
 
 } // namespace hipdnn_backend

--- a/backend/tests/test_engine_plugin.cpp
+++ b/backend/tests/test_engine_plugin.cpp
@@ -25,7 +25,6 @@ public:
     {
     }
 };
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 TEST(GPU_EnginePluginTest, LoadPluginsAndExecuteOpGraph)
 {
     SKIP_IF_NO_DEVICES();
@@ -151,4 +150,3 @@ TEST(GPU_EnginePluginTest, LoadPluginsAndExecuteOpGraph)
         }
     }
 }
-// NOLINTEND(readability-function-cognitive-complexity)

--- a/plugins/miopen_legacy_plugin/integration_tests/batchnorm_fwd_inference_integration_test.cpp
+++ b/plugins/miopen_legacy_plugin/integration_tests/batchnorm_fwd_inference_integration_test.cpp
@@ -76,7 +76,6 @@ struct Batchnorm_2d_tensor_bundle
     Tensor mean_tensor;
     Tensor variance_tensor;
 };
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 class Batchnorm_forward_inference_integration_test
     : public ::testing::TestWithParam<Bn_2d_test_case>
 {
@@ -340,4 +339,3 @@ INSTANTIATE_TEST_SUITE_P(RunHalfFwdbatchnormGraph,
                          Batchnorm_forward_inference_integration_test_half,
                          testing::ValuesIn(get_bn_fwd_inference_test_cases()));
 
-// NOLINTEND(readability-function-cognitive-complexity)

--- a/sdk/include/hipdnn_sdk/test_utilities/test_utilities.hpp
+++ b/sdk/include/hipdnn_sdk/test_utilities/test_utilities.hpp
@@ -4,16 +4,13 @@
 #pragma once
 
 #ifdef ADDRESS_SANITIZER
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 #define SKIP_IF_NO_DEVICES()                              \
     do                                                    \
     {                                                     \
         GTEST_SKIP() << "Disable device tests with ASAN"; \
     } while(0)
-// NOLINTEND(readability-function-cognitive-complexity)
 
 #else
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 #define SKIP_IF_NO_DEVICES()                                        \
     do                                                              \
     {                                                               \
@@ -24,5 +21,4 @@
             GTEST_SKIP() << "No devices available. Skipping test."; \
         }                                                           \
     } while(0)
-// NOLINTEND(readability-function-cognitive-complexity)
 #endif

--- a/tests/backend/test_engine_heuristic_api.cpp
+++ b/tests/backend/test_engine_heuristic_api.cpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 // TODO - Once PluginManager is implemented, we will need to add a testing plugin for this API.
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 namespace
 {
 constexpr hipdnnBackendHeurMode_t FALLBACK_MODE = HIPDNN_HEUR_MODE_FALLBACK;
@@ -439,4 +438,3 @@ TEST_F(Engine_heuristic_api_tests, GetEngineConfigsRequestMoreThanAvailable)
         EXPECT_EQ(hipdnnBackendDestroyDescriptor(config), HIPDNN_STATUS_SUCCESS);
     }
 }
-// NOLINTEND(readability-function-cognitive-complexity)


### PR DESCRIPTION
## Proposed changes

Disable cognitive complexity check project wide since it flags too easily on any macro usage.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [X] I have added automated tests relevant to the introduced functionality
- [X] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [X] I have ran the tests, and they are all passing locally
- [X] I have ran the tests with ASAN, and they are all passing locally
- [X] I have added relevant documentation for the changes
- [X] I have removed the stale documentation which is no longer relevant after this pull request
- [X] I have ran `make format` & `make check_format` to ensure the changes have been formatted
