### PR TITLE
Forcing include order for the validators when using half_utils.hpp or bfloat16_utils.hpp

### DIFF
--- a/plugins/miopen_legacy_plugin/tests/test_miopen_batchnorm_operations.cpp
+++ b/plugins/miopen_legacy_plugin/tests/test_miopen_batchnorm_operations.cpp
@@ -4,15 +4,14 @@
 #include <gtest/gtest.h>
 #include <numeric>
 
-#include <hipdnn_sdk/utilities/half_utils.hpp>
-#include <hipdnn_sdk/utilities/hip_bfloat16_utils.hpp>
-
 #include <hipdnn_sdk/plugin/engine_plugin_api.h>
 #include <hipdnn_sdk/plugin/plugin_api_data_types.h>
 #include <hipdnn_sdk/test_utilities/cpu_fp_reference_implementation.hpp>
 #include <hipdnn_sdk/test_utilities/cpu_fp_reference_validation.hpp>
 #include <hipdnn_sdk/test_utilities/flatbuffer_graph_test_utils.hpp>
 #include <hipdnn_sdk/test_utilities/test_utilities.hpp>
+#include <hipdnn_sdk/utilities/half_utils.hpp>
+#include <hipdnn_sdk/utilities/hip_bfloat16_utils.hpp>
 #include <hipdnn_sdk/utilities/tensor.hpp>
 
 #include "hipdnn_engine_plugin_execution_context.hpp"

--- a/sdk/include/hipdnn_sdk/test_utilities/cpu_fp_reference_implementation.hpp
+++ b/sdk/include/hipdnn_sdk/test_utilities/cpu_fp_reference_implementation.hpp
@@ -7,6 +7,12 @@
 #include <numeric>
 #include <vector>
 
+#if defined(__HIP_PLATFORM_AMD__)
+// Need these for the half and bfloat16 types
+#include <hipdnn_sdk/utilities/half_utils.hpp>
+#include <hipdnn_sdk/utilities/hip_bfloat16_utils.hpp>
+#endif
+
 namespace hipdnn_sdk
 {
 namespace reference_test_utilities

--- a/sdk/include/hipdnn_sdk/test_utilities/cpu_fp_reference_validation.hpp
+++ b/sdk/include/hipdnn_sdk/test_utilities/cpu_fp_reference_validation.hpp
@@ -3,8 +3,11 @@
 
 #pragma once
 
+#if defined(__HIP_PLATFORM_AMD__)
+// Need these for the half and bfloat16 types
 #include <hipdnn_sdk/utilities/half_utils.hpp>
 #include <hipdnn_sdk/utilities/hip_bfloat16_utils.hpp>
+#endif
 
 #include <hipdnn_sdk/logging/logger.hpp>
 #include <hipdnn_sdk/test_utilities/reference_validation_interface.hpp>

--- a/sdk/tests/test_utilities/test_cpu_fp_reference_validation.cpp
+++ b/sdk/tests/test_utilities/test_cpu_fp_reference_validation.cpp
@@ -3,11 +3,10 @@
 
 #include <gtest/gtest.h>
 
-#include <hipdnn_sdk/utilities/half_utils.hpp>
-#include <hipdnn_sdk/utilities/hip_bfloat16_utils.hpp>
-
 #include <hipdnn_sdk/test_utilities/cpu_fp_reference_validation.hpp>
 #include <hipdnn_sdk/test_utilities/test_utilities.hpp>
+#include <hipdnn_sdk/utilities/half_utils.hpp>
+#include <hipdnn_sdk/utilities/hip_bfloat16_utils.hpp>
 
 using namespace hipdnn_sdk::reference_test_utilities;
 using namespace hipdnn_sdk::utilities;


### PR DESCRIPTION
## Proposed changes
- If using the validators in the context of an AMD HIP application, it will ensure that the validators include the half and bfloat16 types so that the custom versions of abs() and max() can be used, rather than falling back to the float versions because the headers weren't included in the correct order, thereby causing implicit cast warnings.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added automated tests relevant to the introduced functionality
- [x] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [x] I have ran the tests, and they are all passing locally
- [x] I have ran the tests with ASAN, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [x] I have ran `make format` & `make check_format` to ensure the changes have been formatted
