### PR TITLE
Handle gmock uninteresting call warnings

### DIFF
--- a/backend/tests/descriptors/test_engine_config_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_config_descriptor.cpp
@@ -69,7 +69,7 @@ public:
 
     void make_engine_config_finalized() const
     {
-        set_engine();
+        // TODO: With the call to finalize and get_mock_engine this makes it likely that we're interweaving EXPECTs and function calls
         EXPECT_CALL(*get_mock_engine(), is_finalized()).WillRepeatedly(Return(true));
         EXPECT_CALL(*get_mock_engine(), get_engine_id()).WillRepeatedly(Return(1));
         EXPECT_CALL(*get_mock_engine(), get_graph())
@@ -80,6 +80,8 @@ public:
             .WillOnce(Return(_mock_engine_plugin_resource_manager));
         EXPECT_CALL(*_mock_engine_plugin_resource_manager, get_workspace_size(_, _, _))
             .WillOnce(Return(1024));
+
+        set_engine();
         ASSERT_NO_THROW(get_engine_config_descriptor()->finalize());
     }
 
@@ -111,6 +113,18 @@ TEST_F(Engine_config_descriptor_test, CreateEngineConfigDescriptor)
 TEST_F(Engine_config_descriptor_test, SetEngineConfigDescriptorEngine)
 {
     auto engine_config = get_engine_config_descriptor();
+
+    EXPECT_CALL(*get_mock_engine_bad_type(), is_finalized()).Times(1);
+    EXPECT_CALL(*get_mock_engine(), get_engine_id()).Times(AnyNumber());
+    EXPECT_CALL(*get_mock_engine(), is_finalized()).WillOnce(Return(false)).WillOnce(Return(true));
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        engine_config->set_attribute(
+            HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &_mock_engine_wrapper),
+        HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+
+    ASSERT_NO_THROW(engine_config->set_attribute(
+        HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &_mock_engine_wrapper));
 
     ASSERT_THROW_HIPDNN_STATUS(
         engine_config->set_attribute(
@@ -144,16 +158,6 @@ TEST_F(Engine_config_descriptor_test, SetEngineConfigDescriptorEngine)
                                                             1,
                                                             &_mock_wrong_type_wrapper),
                                HIPDNN_STATUS_BAD_PARAM);
-
-    EXPECT_CALL(*get_mock_engine(), is_finalized()).WillOnce(Return(false));
-    ASSERT_THROW_HIPDNN_STATUS(
-        engine_config->set_attribute(
-            HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &_mock_engine_wrapper),
-        HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
-
-    EXPECT_CALL(*get_mock_engine(), is_finalized()).WillOnce(Return(true));
-    ASSERT_NO_THROW(engine_config->set_attribute(
-        HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &_mock_engine_wrapper));
 }
 
 TEST_F(Engine_config_descriptor_test, SetAttrOnFinalizedEngineConfigDescriptor)

--- a/backend/tests/descriptors/test_engine_config_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_config_descriptor.cpp
@@ -69,7 +69,10 @@ public:
 
     void make_engine_config_finalized() const
     {
-        // TODO: With the call to finalize and get_mock_engine this makes it likely that we're interweaving EXPECTs and function calls
+        // TODO: These expectations being hidden in here are dangerous.
+        // It's easy to forget they exist, and if any of these functions are called prior to this
+        // call it is undefined behavior. Similarly, any expectations on functions called within
+        // "finalize" or "setup" made after calling this function are UB
         EXPECT_CALL(*get_mock_engine(), is_finalized()).WillRepeatedly(Return(true));
         EXPECT_CALL(*get_mock_engine(), get_engine_id()).WillRepeatedly(Return(1));
         EXPECT_CALL(*get_mock_engine(), get_graph())

--- a/backend/tests/descriptors/test_engine_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_descriptor.cpp
@@ -132,6 +132,7 @@ TEST_F(Engine_descriptor_test, CreateEngineDescriptor)
 TEST_F(Engine_descriptor_test, SetEngineDescriptorGraph)
 {
     auto engine = get_engine_descriptor();
+    EXPECT_CALL(*get_mock_graph_bad_type(), is_finalized()).Times(1);
 
     ASSERT_THROW_HIPDNN_STATUS(
         engine->set_attribute(

--- a/backend/tests/descriptors/test_engine_heuristic_descriptor.cpp
+++ b/backend/tests/descriptors/test_engine_heuristic_descriptor.cpp
@@ -136,6 +136,22 @@ TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorGraph)
 {
     auto heur = get_engine_heuristic_descriptor();
 
+    EXPECT_CALL(*get_mock_graph_bad_type(), is_finalized()).Times(1);
+    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(false)).WillOnce(Return(true));
+
+    // is_finalized->false
+    ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   1,
+                                                   &_mock_graph_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+
+    // is_finalized()->true
+    ASSERT_NO_THROW(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &_mock_graph_wrapper));
+
     ASSERT_THROW_HIPDNN_STATUS(
         heur->set_attribute(
             HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH, HIPDNN_TYPE_INT64, 1, &_mock_graph_wrapper),
@@ -169,19 +185,6 @@ TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorGraph)
                                                    1,
                                                    &_mock_wrong_type_wrapper),
                                HIPDNN_STATUS_BAD_PARAM);
-
-    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(false));
-    ASSERT_THROW_HIPDNN_STATUS(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   1,
-                                                   &_mock_graph_wrapper),
-                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
-
-    EXPECT_CALL(*get_mock_graph(), is_finalized()).WillOnce(Return(true));
-    ASSERT_NO_THROW(heur->set_attribute(HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
-                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                        1,
-                                        &_mock_graph_wrapper));
 }
 
 TEST_F(Engine_heuristic_descriptor_test, SetEngineHeuristicDescriptorHeurMode)
@@ -236,6 +239,9 @@ TEST_F(Engine_heuristic_descriptor_test, SetAttrOnFinalizedEngineHeuristicDescri
 TEST_F(Engine_heuristic_descriptor_test, FinalizeEngineHeuristicDescriptor)
 {
     auto heur = get_engine_heuristic_descriptor();
+    EXPECT_CALL(*_mock_engine_plugin_resource_manager, get_applicable_engine_ids)
+        .Times(AnyNumber()); //Uninteresting call
+
     ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
 
     set_graph();
@@ -250,6 +256,9 @@ TEST_F(Engine_heuristic_descriptor_test, FinalizeEngineHeuristicDescriptor)
 TEST_F(Engine_heuristic_descriptor_test, FinalizeEngineHeuristicDescriptorReverseOrder)
 {
     auto heur = get_engine_heuristic_descriptor();
+    EXPECT_CALL(*_mock_engine_plugin_resource_manager, get_applicable_engine_ids)
+        .Times(AnyNumber()); //Uninteresting call
+
     ASSERT_THROW_HIPDNN_STATUS(heur->finalize(), HIPDNN_STATUS_BAD_PARAM);
 
     set_heuristic_mode();

--- a/backend/tests/descriptors/test_execution_plan_descriptor.cpp
+++ b/backend/tests/descriptors/test_execution_plan_descriptor.cpp
@@ -182,6 +182,22 @@ TEST_F(Execution_plan_descriptor_test, SetExecutionPlanDescriptorEngineConfig)
     auto plan = get_execution_plan_descriptor();
     auto mock_engine_config = get_mock_engine_config();
 
+    EXPECT_CALL(*get_mock_engine_config_bad_type(), is_finalized()).Times(1);
+    EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(false)).WillOnce(Return(true));
+
+    // is_finalized()->false
+    ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                   1,
+                                                   &_mock_engine_config_wrapper),
+                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+
+    // is_finalized()->true
+    plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                        1,
+                        &_mock_engine_config_wrapper);
+
     ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                                    HIPDNN_TYPE_HANDLE,
                                                    1,
@@ -217,19 +233,6 @@ TEST_F(Execution_plan_descriptor_test, SetExecutionPlanDescriptorEngineConfig)
                                                    1,
                                                    &_mock_wrong_type_wrapper),
                                HIPDNN_STATUS_BAD_PARAM);
-
-    EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(false));
-    ASSERT_THROW_HIPDNN_STATUS(plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                   1,
-                                                   &_mock_engine_config_wrapper),
-                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
-
-    EXPECT_CALL(*mock_engine_config, is_finalized()).WillOnce(Return(true));
-    plan->set_attribute(HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                        1,
-                        &_mock_engine_config_wrapper);
 }
 
 TEST_F(Execution_plan_descriptor_test, FinalizeExecutionPlanDescriptor)

--- a/frontend/tests/test_graph.cpp
+++ b/frontend/tests/test_graph.cpp
@@ -264,6 +264,7 @@ static void validate_tensor(const Tensor_attributes& tensor,
 // NOLINTBEGIN
 TEST_F(Graph_test_fixture, BuildAndSerializeBatchnormInferenceGraph)
 {
+    ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
 
     graph.set_name("SerializedGraphTest")
@@ -340,6 +341,7 @@ TEST_F(Graph_test_fixture, BuildAndSerializeBatchnormInferenceGraph)
 
 TEST_F(Graph_test_fixture, BuildAndSerializeBatchnormGraph)
 {
+    ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
 
     graph.set_name("SerializedBatchnormGraph")
@@ -443,6 +445,7 @@ TEST_F(Graph_test_fixture, BuildAndSerializeBatchnormGraph)
 
 TEST_F(Graph_test_fixture, BuildAndSerializeBatchnormAndPointwiseGraph)
 {
+    ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
 
     graph.set_name("SerializedBatchnormAndPointwiseGraph")
@@ -563,6 +566,7 @@ TEST_F(Graph_test_fixture, BuildAndSerializeBatchnormAndPointwiseGraph)
 
 TEST_F(Graph_test_fixture, BuildAndSerializePointwiseGraph)
 {
+    ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
 
     graph.set_name("SerializedGraphTest")
@@ -621,6 +625,7 @@ TEST_F(Graph_test_fixture, BuildAndSerializePointwiseGraph)
 
 TEST_F(Graph_test_fixture, BuildAndSerializePointwiseAndBatchnormInferenceGraph)
 {
+    ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
 
     graph.set_name("SerializedGraphTest")
@@ -714,6 +719,7 @@ TEST_F(Graph_test_fixture, BuildAndSerializePointwiseAndBatchnormInferenceGraph)
 
 TEST_F(Graph_test_fixture, BuildAndSerializeBatchnormBackwardGraph)
 {
+    ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
 
     graph.set_name("SerializedGraphTest")
@@ -798,6 +804,7 @@ TEST_F(Graph_test_fixture, BuildAndSerializeBatchnormBackwardGraph)
 
 TEST_F(Graph_test_fixture, BuildAndSerializePointwiseAndBatchnormBackwardGraph)
 {
+    ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
 
     graph.set_name("SerializedGraphTest")
@@ -948,6 +955,7 @@ TEST_F(Graph_test_fixture, TensorLikeGraphAttributes)
 
 TEST_F(Graph_test_fixture, WillCorrectlyBuildOperationGraphDescriptor)
 {
+    ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
     auto tensor_attributes = create_basic_batchnorm_graph(graph);
 
@@ -987,6 +995,7 @@ TEST_F(Graph_test_fixture, CreatingExecutionPlansFailsWithNoGraph)
 
 TEST_F(Graph_test_fixture, CanSuccessfullyCreateExecutionPlans)
 {
+    ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
     const std::vector<HeurMode_t> heurModes = {HeurMode_t::FALLBACK};
     std::vector<hipdnnBackendHeurMode_t> backend_modes;
@@ -1125,6 +1134,7 @@ TEST_F(Graph_test_fixture, CanSuccessfullyCreateExecutionPlans)
 
 TEST_F(Graph_test_fixture, CheckSupportFailsIfNoExecutionPlanCreated)
 {
+    ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
     auto tensor_attributes = create_basic_batchnorm_graph(graph);
 
@@ -1137,6 +1147,7 @@ TEST_F(Graph_test_fixture, CheckSupportFailsIfNoExecutionPlanCreated)
 
 TEST_F(Graph_test_fixture, CheckSupportSucceedsWhenExecutionPlanCreated)
 {
+    ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
     const std::vector<HeurMode_t> heur_modes = {HeurMode_t::FALLBACK};
     auto tensor_attributes = create_basic_batchnorm_graph(graph);
@@ -1168,6 +1179,7 @@ TEST_F(Graph_test_fixture, CheckSupportSucceedsWhenExecutionPlanCreated)
 
 TEST_F(Graph_test_fixture, EngineConfigAndExecutionPlanAreFinalizedAfterBuildPlans)
 {
+    ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
     const std::vector<HeurMode_t> heur_modes = {HeurMode_t::FALLBACK};
     auto tensor_attributes = create_basic_batchnorm_graph(graph);
@@ -1248,6 +1260,7 @@ TEST_F(Graph_test_fixture, EngineConfigAndExecutionPlanAreFinalizedAfterBuildPla
 
 TEST_F(Graph_test_fixture, WorkspaceSizeIsRetrievedFromExecutionPlan)
 {
+    ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
     const std::vector<HeurMode_t> heur_modes = {HeurMode_t::FALLBACK};
     auto tensor_attributes = create_basic_batchnorm_graph(graph);
@@ -1308,6 +1321,7 @@ TEST_F(Graph_test_fixture, WorkspaceSizeIsRetrievedFromExecutionPlan)
 
 TEST_F(Graph_test_fixture, ExecutePacksVariantPackAndPassesTheCorrectArguments)
 {
+    ::testing::FLAGS_gmock_verbose = "error";
     using ::testing::_;
     using ::testing::Invoke;
     using ::testing::NotNull;

--- a/frontend/tests/test_scoped_hipdnn_backend_descriptor.cpp
+++ b/frontend/tests/test_scoped_hipdnn_backend_descriptor.cpp
@@ -43,6 +43,9 @@ TEST_F(Hipdnn_backend_descriptor_test_fixture, ConstructWithRawDescriptorIsValid
 {
     auto fake_desc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x1234);
     auto desc = Scoped_hipdnn_backend_descriptor(fake_desc);
+
+    EXPECT_CALL(*_mock_backend, hipdnnBackendDestroyDescriptor(fake_desc))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
     EXPECT_TRUE(desc.valid());
     EXPECT_EQ(desc.get(), fake_desc);
 }
@@ -56,6 +59,8 @@ TEST_F(Hipdnn_backend_descriptor_test_fixture, ConstructWithTypeSuccess)
             *out = fake_desc;
             return HIPDNN_STATUS_SUCCESS;
         });
+    EXPECT_CALL(*_mock_backend, hipdnnBackendDestroyDescriptor(fake_desc))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
     auto desc = Scoped_hipdnn_backend_descriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR);
     EXPECT_TRUE(desc.valid());
@@ -69,6 +74,7 @@ TEST_F(Hipdnn_backend_descriptor_test_fixture, ConstructWithTypeFailure)
         .WillOnce([](hipdnnBackendDescriptorType_t, hipdnnBackendDescriptor_t*) {
             return HIPDNN_STATUS_BAD_PARAM;
         });
+    EXPECT_CALL(*_mock_backend, hipdnnGetLastErrorString).Times(AnyNumber()); // Uninteresting call
 
     auto desc = Scoped_hipdnn_backend_descriptor(HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR);
     EXPECT_FALSE(desc.valid());
@@ -84,6 +90,8 @@ TEST_F(Hipdnn_backend_descriptor_test_fixture, ConstructWithSerializedGraphSucce
             *out = fake_desc;
             return HIPDNN_STATUS_SUCCESS;
         });
+    EXPECT_CALL(*_mock_backend, hipdnnBackendDestroyDescriptor(fake_desc))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
     auto desc = Scoped_hipdnn_backend_descriptor(fake_graph.data(), fake_graph.size());
     EXPECT_TRUE(desc.valid());
@@ -97,6 +105,7 @@ TEST_F(Hipdnn_backend_descriptor_test_fixture, ConstructWithSerializedGraphFailu
         .WillOnce([](hipdnnBackendDescriptor_t*, const uint8_t*, size_t) {
             return HIPDNN_STATUS_BAD_PARAM;
         });
+    EXPECT_CALL(*_mock_backend, hipdnnGetLastErrorString).Times(AnyNumber()); // Uninteresting call
 
     auto desc = Scoped_hipdnn_backend_descriptor(fake_graph.data(), fake_graph.size());
     EXPECT_FALSE(desc.valid());
@@ -132,6 +141,7 @@ TEST_F(Hipdnn_backend_descriptor_test_fixture, DestructorHandlesDestroyFailure)
         });
     EXPECT_CALL(*_mock_backend, hipdnnBackendDestroyDescriptor(fake_desc))
         .WillOnce(Return(HIPDNN_STATUS_BAD_PARAM));
+    EXPECT_CALL(*_mock_backend, hipdnnGetLastErrorString).Times(AnyNumber()); // Uninteresting call
 
     {
         auto desc = Scoped_hipdnn_backend_descriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR);

--- a/plugins/miopen_legacy_plugin/tests/test_engine_manager.cpp
+++ b/plugins/miopen_legacy_plugin/tests/test_engine_manager.cpp
@@ -170,6 +170,7 @@ TEST(Engine_managerTest, InitializeExecutionContextCallsEngine)
     Mock_graph mock_graph;
     Mock_engine_config mock_engine_config;
     ON_CALL(mock_engine_config, engine_id()).WillByDefault(Return(7));
+    EXPECT_CALL(mock_engine_config, engine_id()).Times(testing::AnyNumber()); // Uninteresting call
     Mock_hipdnn_engine_plugin_execution_context exec_ctx;
 
     manager.initialize_execution_context(dummy_handle, mock_graph, mock_engine_config, exec_ctx);
@@ -183,6 +184,7 @@ TEST(Engine_managerTest, InitializeExecutionContextThrowsOnInvalidEngineId)
     Mock_graph mock_graph;
     Mock_engine_config mock_engine_config;
 
+    EXPECT_CALL(mock_engine_config, engine_id()).Times(testing::AnyNumber()); // Uninteresting call
     EXPECT_THROW(manager.initialize_execution_context(
                      dummy_handle, mock_graph, mock_engine_config, exec_ctx),
                  hipdnn_plugin::Hipdnn_plugin_exception);


### PR DESCRIPTION
## Proposed changes

Gmock warns for uninteresting calls when a mocked function is called when expectations aren't noted for it. For this PR I looked at all of the calls outside of the test_graph.cpp file. There were a small number, and fit into two categories:
* Destructors being called - For which I think we want to either state whether we expect them, or when we don't expect them
* Logging functions - which I think are generally uninteresting

The vast majority of these warnings are in the graph_test.cpp file. Those have been turned off selectively by setting`FLAGS_gmock_verbose="error"`

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x] I have added automated tests relevant to the introduced functionality
- [x] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [x] I have ran the tests, and they are all passing locally
- [ ] I have ran the tests with ASAN, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [x] I have ran `make format` & `make check_format` to ensure the changes have been formatted
