### PR TITLE
Clang-tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,6 +37,7 @@ CheckOptions:
   - { key: readability-identifier-naming.StructCase,              value: Leading_upper_snake_case }
   - { key: readability-identifier-naming.FunctionCase,            value: lower_case }
   - { key: readability-identifier-naming.VariableCase,            value: lower_case }
+  - { key: readability-identifier-naming.ParameterCase,           value: lower_case }
   - { key: readability-identifier-naming.PrivateMemberCase,       value: lower_case }
   - { key: readability-identifier-naming.PrivateMemberPrefix,     value: _ }
 #  - { key: readability-identifier-naming.EnumCase,                value: Leading_upper_snake_case  }

--- a/frontend/include/hipdnn_frontend/attributes/attributes.hpp
+++ b/frontend/include/hipdnn_frontend/attributes/attributes.hpp
@@ -31,9 +31,9 @@ private:
 public:
     std::string name;
 
-    DerivedT& set_name(const std::string& name_)
+    DerivedT& set_name(const std::string& name_value)
     {
-        name = name_;
+        name = name_value;
         return self();
     }
 

--- a/frontend/include/hipdnn_frontend/backend/backend_wrapper.hpp
+++ b/frontend/include/hipdnn_frontend/backend/backend_wrapper.hpp
@@ -21,14 +21,14 @@ public:
         return hipdnnDestroy(handle);
     }
 
-    hipdnnStatus_t set_stream(hipdnnHandle_t handle, hipStream_t streamId) override
+    hipdnnStatus_t set_stream(hipdnnHandle_t handle, hipStream_t stream_id) override
     {
-        return hipdnnSetStream(handle, streamId);
+        return hipdnnSetStream(handle, stream_id);
     }
 
-    hipdnnStatus_t get_stream(hipdnnHandle_t handle, hipStream_t* streamId) override
+    hipdnnStatus_t get_stream(hipdnnHandle_t handle, hipStream_t* stream_id) override
     {
-        return hipdnnGetStream(handle, streamId);
+        return hipdnnGetStream(handle, stream_id);
     }
 
     hipdnnStatus_t backend_create_descriptor(hipdnnBackendDescriptorType_t descriptor_type,

--- a/frontend/include/hipdnn_frontend/backend/hipdnn_backend_interface.hpp
+++ b/frontend/include/hipdnn_frontend/backend/hipdnn_backend_interface.hpp
@@ -18,8 +18,8 @@ public:
 
     virtual hipdnnStatus_t create(hipdnnHandle_t* handle) = 0;
     virtual hipdnnStatus_t destroy(hipdnnHandle_t handle) = 0;
-    virtual hipdnnStatus_t set_stream(hipdnnHandle_t handle, hipStream_t streamId) = 0;
-    virtual hipdnnStatus_t get_stream(hipdnnHandle_t handle, hipStream_t* streamId) = 0;
+    virtual hipdnnStatus_t set_stream(hipdnnHandle_t handle, hipStream_t stream_id) = 0;
+    virtual hipdnnStatus_t get_stream(hipdnnHandle_t handle, hipStream_t* stream_id) = 0;
     virtual hipdnnStatus_t backend_create_descriptor(hipdnnBackendDescriptorType_t descriptor_type,
                                                      hipdnnBackendDescriptor_t* descriptor)
         = 0;

--- a/frontend/include/hipdnn_frontend/node/batchnorm_backward_node.hpp
+++ b/frontend/include/hipdnn_frontend/node/batchnorm_backward_node.hpp
@@ -100,20 +100,20 @@ public:
             dx->set_stride(x->get_stride());
         }
 
-        auto infer_c_tensor = [&](std::shared_ptr<Tensor_attributes>& tensorToInfer) {
-            if(tensorToInfer->get_dim().empty())
+        auto infer_c_tensor = [&](std::shared_ptr<Tensor_attributes>& tensor_to_infer) {
+            if(tensor_to_infer->get_dim().empty())
             {
                 std::vector<int64_t> tensor_dims(x->get_dim().size(), 1);
                 tensor_dims[1] = x->get_dim()[1];
-                tensorToInfer->set_dim(tensor_dims);
+                tensor_to_infer->set_dim(tensor_dims);
             }
 
-            if(tensorToInfer->get_stride().empty())
+            if(tensor_to_infer->get_stride().empty())
             {
                 auto stride_order
-                    = hipdnn_sdk::utilities::stride_order_nhwc(tensorToInfer->get_dim().size());
-                tensorToInfer->set_stride(hipdnn_sdk::utilities::generate_strides(
-                    tensorToInfer->get_dim(), stride_order));
+                    = hipdnn_sdk::utilities::stride_order_nhwc(tensor_to_infer->get_dim().size());
+                tensor_to_infer->set_stride(hipdnn_sdk::utilities::generate_strides(
+                    tensor_to_infer->get_dim(), stride_order));
             }
         };
 

--- a/frontend/include/hipdnn_frontend/node/batchnorm_node.hpp
+++ b/frontend/include/hipdnn_frontend/node/batchnorm_node.hpp
@@ -81,20 +81,20 @@ public:
             y->set_stride(x->get_stride());
         }
 
-        auto infer_c_tensor = [&](std::shared_ptr<Tensor_attributes>& tensorToInfer) {
-            if(tensorToInfer->get_dim().empty())
+        auto infer_c_tensor = [&](std::shared_ptr<Tensor_attributes>& tensor_to_infer) {
+            if(tensor_to_infer->get_dim().empty())
             {
                 std::vector<int64_t> tensor_dims(x->get_dim().size(), 1);
                 tensor_dims[1] = x->get_dim()[1];
-                tensorToInfer->set_dim(tensor_dims);
+                tensor_to_infer->set_dim(tensor_dims);
             }
 
-            if(tensorToInfer->get_stride().empty())
+            if(tensor_to_infer->get_stride().empty())
             {
                 auto stride_order
-                    = hipdnn_sdk::utilities::stride_order_nhwc(tensorToInfer->get_dim().size());
-                tensorToInfer->set_stride(hipdnn_sdk::utilities::generate_strides(
-                    tensorToInfer->get_dim(), stride_order));
+                    = hipdnn_sdk::utilities::stride_order_nhwc(tensor_to_infer->get_dim().size());
+                tensor_to_infer->set_stride(hipdnn_sdk::utilities::generate_strides(
+                    tensor_to_infer->get_dim(), stride_order));
             }
         };
 

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -62,6 +62,8 @@ target_include_directories(hipdnn_sdk INTERFACE
     $<INSTALL_INTERFACE:${HIP_DNN_SDK_INSTALL_INCLUDE_DIR}>
 )
 
+clang_tidy_check(hipdnn_sdk)
+
 install( 
     TARGETS hipdnn_sdk FlatBuffers spdlog_header_only
     EXPORT hipdnn_sdk_targets

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -62,8 +62,6 @@ target_include_directories(hipdnn_sdk INTERFACE
     $<INSTALL_INTERFACE:${HIP_DNN_SDK_INSTALL_INCLUDE_DIR}>
 )
 
-clang_tidy_check(hipdnn_sdk)
-
 install( 
     TARGETS hipdnn_sdk FlatBuffers spdlog_header_only
     EXPORT hipdnn_sdk_targets

--- a/sdk/include/hipdnn_sdk/test_utilities/cpu_fp_reference_implementation.hpp
+++ b/sdk/include/hipdnn_sdk/test_utilities/cpu_fp_reference_implementation.hpp
@@ -32,8 +32,8 @@ public:
     void batchnorm_fwd_inference(const Tensor& input,
                                  const Tensor& scale,
                                  const Tensor& bias,
-                                 const Tensor& estimatedMean,
-                                 const Tensor& estimatedVariance,
+                                 const Tensor& estimated_mean,
+                                 const Tensor& estimated_variance,
                                  Tensor& output,
                                  double epsilon) override
     {
@@ -49,9 +49,9 @@ public:
         int64_t width = input.dims().at(3);
 
         std::for_each(channels.begin(), channels.end(), [&](int64_t cidx) {
-            auto mean = estimatedMean.get_host_value<Mean_variance_data_type>(0, cidx, 0, 0);
+            auto mean = estimated_mean.get_host_value<Mean_variance_data_type>(0, cidx, 0, 0);
             auto variance
-                = estimatedVariance.get_host_value<Mean_variance_data_type>(0, cidx, 0, 0);
+                = estimated_variance.get_host_value<Mean_variance_data_type>(0, cidx, 0, 0);
             Mean_variance_data_type invert_var
                 = static_cast<Mean_variance_data_type>(1.0f)
                   / sqrt_internal(variance + static_cast<Mean_variance_data_type>(epsilon));

--- a/sdk/include/hipdnn_sdk/test_utilities/reference_implementation_interface.hpp
+++ b/sdk/include/hipdnn_sdk/test_utilities/reference_implementation_interface.hpp
@@ -25,8 +25,8 @@ public:
     virtual void batchnorm_fwd_inference(const Tensor& input,
                                          const Tensor& scale,
                                          const Tensor& bias,
-                                         const Tensor& estimatedMean,
-                                         const Tensor& estimatedVariance,
+                                         const Tensor& estimated_mean,
+                                         const Tensor& estimated_variance,
                                          Tensor& output,
                                          double epsilon)
         = 0;

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -48,4 +48,5 @@ target_link_libraries(hipdnn_sdk_tests
     ${CMAKE_DL_LIBS}
 )
 
+clang_tidy_check(hipdnn_sdk_tests)
 add_target_to_check_targets(hipdnn_sdk_tests ${CMAKE_CURRENT_BINARY_DIR})

--- a/sdk/tests/utilities/test_callback_logger.cpp
+++ b/sdk/tests/utilities/test_callback_logger.cpp
@@ -17,10 +17,10 @@ static std::mutex g_log_mutex;
 
 // Custom callback for testing. It doesn't fully simulate the real logging behavior,
 // but the backend tests use the true callback function. The test could use the backend callback, but then it has to link against the backend.
-void test_logging_callback(hipdnnSeverity_t, const char* msg)
+void test_logging_callback(hipdnnSeverity_t severity [[maybe_unused]], const char* msg)
 {
     std::lock_guard<std::mutex> lock(g_log_mutex);
-    if(msg)
+    if(msg != nullptr)
     {
         g_captured_logs.emplace_back(msg);
     }
@@ -49,7 +49,7 @@ protected:
         spdlog::shutdown();
     }
 
-    std::vector<std::string> get_captured_logs()
+    static std::vector<std::string> get_captured_logs()
     {
         spdlog::shutdown(); // block until async queue is fully processed
         return g_captured_logs;


### PR DESCRIPTION
## Proposed changes

Brian noticed in another PR that parameter naming-case wasn’t enforced. I investigated this, and found a missing clang-tidy rule and absent clang-tidy checks for an SDK target. This update adds the rule, enables checks, and fixes all resulting warnings.

I am unsure if this a comprehensive fix of any clang-tidy omissions, but it's better than nothing.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [x] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [x] I have ran the tests, and they are all passing locally
- [ ] I have ran the tests with ASAN, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [x] I have ran `make format` & `make check_format` to ensure the changes have been formatted
