### PR TITLE
Rename backend integration tests

### DIFF
--- a/tests/backend/test_backend_execute_api.cpp
+++ b/tests/backend/test_backend_execute_api.cpp
@@ -11,17 +11,17 @@
 
 #include <gtest/gtest.h>
 
-class Execution_backend_end_api_tests : public ::testing::Test
+class ExecutionBackendEndApiTests : public ::testing::Test
 {
 protected:
     static constexpr int64_t GIDX = hipdnn_tests::plugin_constants::engine_id<Good_plugin>();
     hipdnnBackendDescriptor_t _plan = nullptr;
     hipdnnHandle_t _handle = nullptr;
-    hipdnnBackendDescriptor_t _engine_config = nullptr;
+    hipdnnBackendDescriptor_t _engineConfig = nullptr;
     hipdnnBackendDescriptor_t _engine = nullptr;
-    hipdnnBackendDescriptor_t _graph_descriptor = nullptr;
+    hipdnnBackendDescriptor_t _graphDescriptor = nullptr;
 
-    hipdnnBackendDescriptor_t _variant_pack = nullptr;
+    hipdnnBackendDescriptor_t _variantPack = nullptr;
 
     void SetUp() override
     {
@@ -36,15 +36,15 @@ protected:
 
     void TearDown() override
     {
-        destroy_test_handle();
-        destroy_test_descriptor(_plan);
-        destroy_test_descriptor(_engine_config);
-        destroy_test_descriptor(_engine);
-        destroy_test_descriptor(_graph_descriptor);
-        destroy_test_descriptor(_variant_pack);
+        destroyTestHandle();
+        destroyTestDescriptor(_plan);
+        destroyTestDescriptor(_engineConfig);
+        destroyTestDescriptor(_engine);
+        destroyTestDescriptor(_graphDescriptor);
+        destroyTestDescriptor(_variantPack);
     }
 
-    static void destroy_test_descriptor(hipdnnBackendDescriptor_t descriptor)
+    static void destroyTestDescriptor(hipdnnBackendDescriptor_t descriptor)
     {
         if(descriptor != nullptr)
         {
@@ -54,7 +54,7 @@ protected:
     }
 
 private:
-    void destroy_test_handle()
+    void destroyTestHandle()
     {
         if(_handle != nullptr)
         {
@@ -64,140 +64,140 @@ private:
     }
 };
 
-TEST_F(Execution_backend_end_api_tests, TestBackendExecuteWithNullHandle)
+TEST_F(ExecutionBackendEndApiTests, TestBackendExecuteWithNullHandle)
 {
-    auto batchnorm_builder = test_util::create_and_populate_batchnorm_node();
-    auto serialized_graph = batchnorm_builder.Release();
+    auto batchnormBuilder = test_util::createAndPopulateBatchnormNode();
+    auto serializedGraph = batchnormBuilder.Release();
 
-    test_util::create_and_initialize_backend_descriptor(
-        &_graph_descriptor, serialized_graph, _handle);
-    test_util::create_test_engine(&_engine, &_graph_descriptor, _handle, GIDX, true);
-    test_util::create_test_engine_config(
-        &_engine_config, &_engine, &_graph_descriptor, _handle, GIDX, true);
+    test_util::createAndInitializeBackendDescriptor(
+        &_graphDescriptor, serializedGraph, _handle);
+    test_util::createTestEngine(&_engine, &_graphDescriptor, _handle, GIDX, true);
+    test_util::createTestEngineConfig(
+        &_engineConfig, &_engine, &_graphDescriptor, _handle, GIDX, true);
 
     EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &_plan),
               HIPDNN_STATUS_SUCCESS);
 
-    test_util::populate_test_execution_plan(
-        &_plan, &_engine_config, &_engine, &_graph_descriptor, _handle, GIDX, true);
+    test_util::populateTestExecutionPlan(
+        &_plan, &_engineConfig, &_engine, &_graphDescriptor, _handle, GIDX, true);
 
-    ASSERT_EQ(hipdnnBackendExecute(nullptr, _plan, _variant_pack),
+    ASSERT_EQ(hipdnnBackendExecute(nullptr, _plan, _variantPack),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST_F(Execution_backend_end_api_tests, TestBackendExecuteWithNullDescriptors)
+TEST_F(ExecutionBackendEndApiTests, TestBackendExecuteWithNullDescriptors)
 {
-    auto batchnorm_builder = test_util::create_and_populate_batchnorm_node();
-    auto serialized_graph = batchnorm_builder.Release();
+    auto batchnormBuilder = test_util::createAndPopulateBatchnormNode();
+    auto serializedGraph = batchnormBuilder.Release();
 
-    test_util::create_and_initialize_backend_descriptor(
-        &_graph_descriptor, serialized_graph, _handle);
-    test_util::create_test_engine(&_engine, &_graph_descriptor, _handle, GIDX, true);
-    test_util::create_test_engine_config(
-        &_engine_config, &_engine, &_graph_descriptor, _handle, GIDX, true);
+    test_util::createAndInitializeBackendDescriptor(
+        &_graphDescriptor, serializedGraph, _handle);
+    test_util::createTestEngine(&_engine, &_graphDescriptor, _handle, GIDX, true);
+    test_util::createTestEngineConfig(
+        &_engineConfig, &_engine, &_graphDescriptor, _handle, GIDX, true);
 
     EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &_plan),
               HIPDNN_STATUS_SUCCESS);
 
-    test_util::populate_test_execution_plan(
-        &_plan, &_engine_config, &_engine, &_graph_descriptor, _handle, GIDX, true);
+    test_util::populateTestExecutionPlan(
+        &_plan, &_engineConfig, &_engine, &_graphDescriptor, _handle, GIDX, true);
 
-    ASSERT_EQ(hipdnnBackendExecute(_handle, nullptr, _variant_pack),
+    ASSERT_EQ(hipdnnBackendExecute(_handle, nullptr, _variantPack),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
     ASSERT_EQ(hipdnnBackendExecute(_handle, _plan, nullptr), HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST_F(Execution_backend_end_api_tests, TestBackendExecuteWithUnfinalizedPlan)
+TEST_F(ExecutionBackendEndApiTests, TestBackendExecuteWithUnfinalizedPlan)
 {
-    hipdnnBackendDescriptor_t unfinalized_plan = nullptr;
+    hipdnnBackendDescriptor_t unfinalizedPlan = nullptr;
     ASSERT_EQ(
-        hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &unfinalized_plan),
+        hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &unfinalizedPlan),
         HIPDNN_STATUS_SUCCESS);
 
-    auto batchnorm_builder = test_util::create_and_populate_batchnorm_node();
-    auto serialized_graph = batchnorm_builder.Release();
+    auto batchnormBuilder = test_util::createAndPopulateBatchnormNode();
+    auto serializedGraph = batchnormBuilder.Release();
 
-    test_util::create_and_initialize_backend_descriptor(
-        &_graph_descriptor, serialized_graph, _handle);
+    test_util::createAndInitializeBackendDescriptor(
+        &_graphDescriptor, serializedGraph, _handle);
 
-    ASSERT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR, &_variant_pack),
+    ASSERT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR, &_variantPack),
               HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(hipdnnBackendExecute(_handle, unfinalized_plan, _variant_pack),
+    ASSERT_EQ(hipdnnBackendExecute(_handle, unfinalizedPlan, _variantPack),
               HIPDNN_STATUS_BAD_PARAM);
 
-    destroy_test_descriptor(unfinalized_plan);
+    destroyTestDescriptor(unfinalizedPlan);
 }
 
-TEST_F(Execution_backend_end_api_tests, TestBackendExecuteWithWrongDescriptorTypes)
+TEST_F(ExecutionBackendEndApiTests, TestBackendExecuteWithWrongDescriptorTypes)
 {
-    auto batchnorm_builder = test_util::create_and_populate_batchnorm_node();
-    auto serialized_graph = batchnorm_builder.Release();
+    auto batchnormBuilder = test_util::createAndPopulateBatchnormNode();
+    auto serializedGraph = batchnormBuilder.Release();
 
-    test_util::create_and_initialize_backend_descriptor(
-        &_graph_descriptor, serialized_graph, _handle);
-    test_util::create_test_engine(&_engine, &_graph_descriptor, _handle, GIDX, true);
+    test_util::createAndInitializeBackendDescriptor(
+        &_graphDescriptor, serializedGraph, _handle);
+    test_util::createTestEngine(&_engine, &_graphDescriptor, _handle, GIDX, true);
 
-    ASSERT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR, &_variant_pack),
+    ASSERT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR, &_variantPack),
               HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(hipdnnBackendExecute(_handle, _engine, _variant_pack), HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_EQ(hipdnnBackendExecute(_handle, _engine, _variantPack), HIPDNN_STATUS_BAD_PARAM);
 
     EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &_plan),
               HIPDNN_STATUS_SUCCESS);
 
-    test_util::populate_test_execution_plan(
-        &_plan, &_engine_config, &_engine, &_graph_descriptor, _handle, GIDX, true);
-    ASSERT_EQ(hipdnnBackendExecute(_handle, _plan, _graph_descriptor), HIPDNN_STATUS_BAD_PARAM);
+    test_util::populateTestExecutionPlan(
+        &_plan, &_engineConfig, &_engine, &_graphDescriptor, _handle, GIDX, true);
+    ASSERT_EQ(hipdnnBackendExecute(_handle, _plan, _graphDescriptor), HIPDNN_STATUS_BAD_PARAM);
 }
 
-TEST_F(Execution_backend_end_api_tests, TestBackendExecute)
+TEST_F(ExecutionBackendEndApiTests, TestBackendExecute)
 {
-    auto batchnorm_builder = test_util::create_and_populate_batchnorm_node();
-    auto serialized_graph = batchnorm_builder.Release();
+    auto batchnormBuilder = test_util::createAndPopulateBatchnormNode();
+    auto serializedGraph = batchnormBuilder.Release();
 
-    std::unordered_map<int64_t, std::string> uid_to_name_map;
-    std::unordered_map<std::string, int64_t> name_to_uid_map;
-    std::unordered_map<int64_t, std::vector<int64_t>> uid_to_dims_map;
+    std::unordered_map<int64_t, std::string> uidToNameMap;
+    std::unordered_map<std::string, int64_t> nameToUidMap;
+    std::unordered_map<int64_t, std::vector<int64_t>> uidToDimsMap;
 
-    test_util::extract_tensor_info_from_graph(
-        serialized_graph, uid_to_name_map, name_to_uid_map, uid_to_dims_map);
+    test_util::extractTensorInfoFromGraph(
+        serializedGraph, uidToNameMap, nameToUidMap, uidToDimsMap);
 
-    test_util::create_and_initialize_backend_descriptor(
-        &_graph_descriptor, serialized_graph, _handle);
-    test_util::create_test_engine(&_engine, &_graph_descriptor, _handle, GIDX, true);
-    test_util::create_test_engine_config(
-        &_engine_config, &_engine, &_graph_descriptor, _handle, GIDX, true);
+    test_util::createAndInitializeBackendDescriptor(
+        &_graphDescriptor, serializedGraph, _handle);
+    test_util::createTestEngine(&_engine, &_graphDescriptor, _handle, GIDX, true);
+    test_util::createTestEngineConfig(
+        &_engineConfig, &_engine, &_graphDescriptor, _handle, GIDX, true);
 
     EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &_plan),
               HIPDNN_STATUS_SUCCESS);
 
-    test_util::populate_test_execution_plan(
-        &_plan, &_engine_config, &_engine, &_graph_descriptor, _handle, GIDX, true);
+    test_util::populateTestExecutionPlan(
+        &_plan, &_engineConfig, &_engine, &_graphDescriptor, _handle, GIDX, true);
 
-    std::unordered_map<int64_t, void*> data_ptr_mappings;
+    std::unordered_map<int64_t, void*> dataPtrMappings;
 
-    for(const auto& [uid, dims] : uid_to_dims_map)
+    for(const auto& [uid, dims] : uidToDimsMap)
     {
-        void* tensor_data
-            = test_util::allocate_tensor_memory(dims.data(), dims.size(), HIPDNN_TYPE_FLOAT, true);
+        void* tensorData
+            = test_util::allocateTensorMemory(dims.data(), dims.size(), HIPDNN_TYPE_FLOAT, true);
 
-        ASSERT_NE(tensor_data, nullptr)
-            << "Failed to allocate memory for tensor " << uid_to_name_map[uid];
+        ASSERT_NE(tensorData, nullptr)
+            << "Failed to allocate memory for tensor " << uidToNameMap[uid];
 
-        data_ptr_mappings[uid] = tensor_data;
+        dataPtrMappings[uid] = tensorData;
     }
 
-    ASSERT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR, &_variant_pack),
+    ASSERT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR, &_variantPack),
               HIPDNN_STATUS_SUCCESS);
 
-    test_util::populate_variant_pack_with_mappings(_variant_pack, data_ptr_mappings, nullptr);
+    test_util::populateVariantPackWithMappings(_variantPack, dataPtrMappings, nullptr);
 
-    ASSERT_EQ(hipdnnBackendExecute(_handle, _plan, _variant_pack), HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendExecute(_handle, _plan, _variantPack), HIPDNN_STATUS_SUCCESS);
 
-    for(const auto& [uid, data_ptr] : data_ptr_mappings)
+    for(const auto& [uid, dataPtr] : dataPtrMappings)
     {
-        test_util::free_tensor_memory(data_ptr);
+        test_util::freeTensorMemory(dataPtr);
     }
 }

--- a/tests/backend/test_backend_execute_api.cpp
+++ b/tests/backend/test_backend_execute_api.cpp
@@ -69,8 +69,7 @@ TEST_F(ExecutionBackendEndApiTests, TestBackendExecuteWithNullHandle)
     auto batchnormBuilder = test_util::createAndPopulateBatchnormNode();
     auto serializedGraph = batchnormBuilder.Release();
 
-    test_util::createAndInitializeBackendDescriptor(
-        &_graphDescriptor, serializedGraph, _handle);
+    test_util::createAndInitializeBackendDescriptor(&_graphDescriptor, serializedGraph, _handle);
     test_util::createTestEngine(&_engine, &_graphDescriptor, _handle, GIDX, true);
     test_util::createTestEngineConfig(
         &_engineConfig, &_engine, &_graphDescriptor, _handle, GIDX, true);
@@ -90,8 +89,7 @@ TEST_F(ExecutionBackendEndApiTests, TestBackendExecuteWithNullDescriptors)
     auto batchnormBuilder = test_util::createAndPopulateBatchnormNode();
     auto serializedGraph = batchnormBuilder.Release();
 
-    test_util::createAndInitializeBackendDescriptor(
-        &_graphDescriptor, serializedGraph, _handle);
+    test_util::createAndInitializeBackendDescriptor(&_graphDescriptor, serializedGraph, _handle);
     test_util::createTestEngine(&_engine, &_graphDescriptor, _handle, GIDX, true);
     test_util::createTestEngineConfig(
         &_engineConfig, &_engine, &_graphDescriptor, _handle, GIDX, true);
@@ -118,8 +116,7 @@ TEST_F(ExecutionBackendEndApiTests, TestBackendExecuteWithUnfinalizedPlan)
     auto batchnormBuilder = test_util::createAndPopulateBatchnormNode();
     auto serializedGraph = batchnormBuilder.Release();
 
-    test_util::createAndInitializeBackendDescriptor(
-        &_graphDescriptor, serializedGraph, _handle);
+    test_util::createAndInitializeBackendDescriptor(&_graphDescriptor, serializedGraph, _handle);
 
     ASSERT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR, &_variantPack),
               HIPDNN_STATUS_SUCCESS);
@@ -135,8 +132,7 @@ TEST_F(ExecutionBackendEndApiTests, TestBackendExecuteWithWrongDescriptorTypes)
     auto batchnormBuilder = test_util::createAndPopulateBatchnormNode();
     auto serializedGraph = batchnormBuilder.Release();
 
-    test_util::createAndInitializeBackendDescriptor(
-        &_graphDescriptor, serializedGraph, _handle);
+    test_util::createAndInitializeBackendDescriptor(&_graphDescriptor, serializedGraph, _handle);
     test_util::createTestEngine(&_engine, &_graphDescriptor, _handle, GIDX, true);
 
     ASSERT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR, &_variantPack),
@@ -164,8 +160,7 @@ TEST_F(ExecutionBackendEndApiTests, TestBackendExecute)
     test_util::extractTensorInfoFromGraph(
         serializedGraph, uidToNameMap, nameToUidMap, uidToDimsMap);
 
-    test_util::createAndInitializeBackendDescriptor(
-        &_graphDescriptor, serializedGraph, _handle);
+    test_util::createAndInitializeBackendDescriptor(&_graphDescriptor, serializedGraph, _handle);
     test_util::createTestEngine(&_engine, &_graphDescriptor, _handle, GIDX, true);
     test_util::createTestEngineConfig(
         &_engineConfig, &_engine, &_graphDescriptor, _handle, GIDX, true);

--- a/tests/backend/test_backend_public_functions.cpp
+++ b/tests/backend/test_backend_public_functions.cpp
@@ -115,8 +115,7 @@ TEST(HipDNNBackendTest, SetAttribute)
 TEST(HipDNNBackendTest, WillSetBackendGraphCorrectly)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::TensorAttributes>>
-        tensorAttributes;
+    std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::TensorAttributes>> tensorAttributes;
     std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::Node>> nodes;
     auto graph
         = hipdnn_sdk::data_objects::CreateGraphDirect(builder,

--- a/tests/backend/test_backend_public_functions.cpp
+++ b/tests/backend/test_backend_public_functions.cpp
@@ -62,10 +62,10 @@ TEST(HipDNNBackendTest, CreateHandleFailsIfHandlePtrIsNull)
 TEST(HipDNNBackendTest, Execute)
 {
     hipdnnHandle_t handle = nullptr;
-    hipdnnBackendDescriptor_t execution_plan = nullptr;
-    hipdnnBackendDescriptor_t variant_pack = nullptr;
+    hipdnnBackendDescriptor_t executionPlan = nullptr;
+    hipdnnBackendDescriptor_t variantPack = nullptr;
 
-    hipdnnStatus_t status = hipdnnBackendExecute(handle, execution_plan, variant_pack);
+    hipdnnStatus_t status = hipdnnBackendExecute(handle, executionPlan, variantPack);
 
     EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
@@ -82,18 +82,18 @@ TEST(HipDNNBackendTest, Finalize)
 TEST(HipDNNBackendTest, GetAttribute)
 {
     hipdnnBackendDescriptor_t descriptor = nullptr;
-    hipdnnBackendAttributeName_t attribute_name = HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH;
-    hipdnnBackendAttributeType_t attribute_type = HIPDNN_TYPE_NUMERICAL_NOTE;
-    int64_t requested_element_count = 0;
-    int64_t element_count = 0;
-    void* array_of_elements = nullptr;
+    hipdnnBackendAttributeName_t attributeName = HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH;
+    hipdnnBackendAttributeType_t attributeType = HIPDNN_TYPE_NUMERICAL_NOTE;
+    int64_t requestedElementCount = 0;
+    int64_t elementCount = 0;
+    void* arrayOfElements = nullptr;
 
     hipdnnStatus_t status = hipdnnBackendGetAttribute(descriptor,
-                                                      attribute_name,
-                                                      attribute_type,
-                                                      requested_element_count,
-                                                      &element_count,
-                                                      array_of_elements);
+                                                      attributeName,
+                                                      attributeType,
+                                                      requestedElementCount,
+                                                      &elementCount,
+                                                      arrayOfElements);
 
     EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
@@ -101,13 +101,13 @@ TEST(HipDNNBackendTest, GetAttribute)
 TEST(HipDNNBackendTest, SetAttribute)
 {
     hipdnnBackendDescriptor_t descriptor = nullptr;
-    hipdnnBackendAttributeName_t attribute_name = HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH;
-    hipdnnBackendAttributeType_t attribute_type = HIPDNN_TYPE_NUMERICAL_NOTE;
-    int64_t element_count = 0;
-    void* array_of_elements = nullptr;
+    hipdnnBackendAttributeName_t attributeName = HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH;
+    hipdnnBackendAttributeType_t attributeType = HIPDNN_TYPE_NUMERICAL_NOTE;
+    int64_t elementCount = 0;
+    void* arrayOfElements = nullptr;
 
     hipdnnStatus_t status = hipdnnBackendSetAttribute(
-        descriptor, attribute_name, attribute_type, element_count, array_of_elements);
+        descriptor, attributeName, attributeType, elementCount, arrayOfElements);
 
     EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
@@ -116,7 +116,7 @@ TEST(HipDNNBackendTest, WillSetBackendGraphCorrectly)
 {
     flatbuffers::FlatBufferBuilder builder;
     std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::TensorAttributes>>
-        tensor_attributes;
+        tensorAttributes;
     std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::Node>> nodes;
     auto graph
         = hipdnn_sdk::data_objects::CreateGraphDirect(builder,
@@ -124,15 +124,15 @@ TEST(HipDNNBackendTest, WillSetBackendGraphCorrectly)
                                                       hipdnn_sdk::data_objects::DataType_FLOAT,
                                                       hipdnn_sdk::data_objects::DataType_FLOAT,
                                                       hipdnn_sdk::data_objects::DataType_FLOAT,
-                                                      &tensor_attributes,
+                                                      &tensorAttributes,
                                                       &nodes);
     builder.Finish(graph);
-    flatbuffers::DetachedBuffer serialized_graph = builder.Release();
+    flatbuffers::DetachedBuffer serializedGraph = builder.Release();
 
     hipdnnBackendDescriptor_t descriptor = nullptr;
 
     auto status = hipdnnBackendCreateAndDeserializeGraph_ext(
-        &descriptor, serialized_graph.data(), serialized_graph.size());
+        &descriptor, serializedGraph.data(), serializedGraph.size());
 
     EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
 
@@ -175,11 +175,11 @@ TEST(HipDNNBackendTest, WillFailToCreateGraphIfGraphIsNull)
     EXPECT_EQ(descriptor, nullptr);
 }
 
-TEST(HipDNNBackendTest, SetPluginPathsExt_Success)
+TEST(HipDNNBackendTest, SetPluginPathsExtSuccess)
 {
     using namespace hipdnn_tests::plugin_constants;
-    std::string plugin_dir_str = PLUGIN_DIR.string();
-    std::array<const char*, 3> paths = {plugin_dir_str.c_str(), "./", "../directory/"};
+    std::string pluginDirStr = PLUGIN_DIR.string();
+    std::array<const char*, 3> paths = {pluginDirStr.c_str(), "./", "../directory/"};
 
     hipdnnStatus_t status = hipdnnSetEnginePluginPaths_ext(
         paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE);
@@ -187,7 +187,7 @@ TEST(HipDNNBackendTest, SetPluginPathsExt_Success)
     EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
 }
 
-TEST(HipDNNBackendTest, SetPluginPathsExt_InvalidAndValidNullPointerCorrectness)
+TEST(HipDNNBackendTest, SetPluginPathsExtInvalidAndValidNullPointerCorrectness)
 {
     hipdnnStatus_t status
         = hipdnnSetEnginePluginPaths_ext(1, nullptr, HIPDNN_PLUGIN_LOADING_ABSOLUTE);
@@ -201,13 +201,13 @@ TEST(HipDNNBackendTest, SetPluginPathsExt_InvalidAndValidNullPointerCorrectness)
     ASSERT_EQ(status, HIPDNN_STATUS_SUCCESS);
     ASSERT_NE(handle, nullptr);
 
-    auto loaded_plugins = test_util::get_loaded_plugins(handle);
-    EXPECT_EQ(loaded_plugins.size(), 0);
+    auto loadedPlugins = test_util::getLoadedPlugins(handle);
+    EXPECT_EQ(loadedPlugins.size(), 0);
 
     EXPECT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
 }
 
-TEST(HipDNNBackendTest, SetPluginPathsExt_FailsOnNullStringInList)
+TEST(HipDNNBackendTest, SetPluginPathsExtFailsOnNullStringInList)
 {
     std::array<const char*, 2> paths = {"./valid/path.so", nullptr};
 
@@ -217,7 +217,7 @@ TEST(HipDNNBackendTest, SetPluginPathsExt_FailsOnNullStringInList)
     EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST(HipDNNBackendTest, PluginPathsExt_FailsWithIneligibleHandle)
+TEST(HipDNNBackendTest, PluginPathsExtFailsWithIneligibleHandle)
 {
     hipdnnHandle_t handle = nullptr;
     hipdnnStatus_t status = hipdnnCreate(&handle);
@@ -232,13 +232,13 @@ TEST(HipDNNBackendTest, PluginPathsExt_FailsWithIneligibleHandle)
 
     EXPECT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
 
-    size_t num_plugins = 0;
-    size_t max_path_length = 0;
-    status = hipdnnGetLoadedEnginePluginPaths_ext(nullptr, &num_plugins, nullptr, &max_path_length);
+    size_t numPlugins = 0;
+    size_t maxPathLength = 0;
+    status = hipdnnGetLoadedEnginePluginPaths_ext(nullptr, &numPlugins, nullptr, &maxPathLength);
     EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST(HipDNNBackendTest, GetLoadedPluginPaths_LoadsDefault)
+TEST(HipDNNBackendTest, GetLoadedPluginPathsLoadsDefault)
 {
     hipdnnStatus_t status
         = hipdnnSetEnginePluginPaths_ext(0, nullptr, HIPDNN_PLUGIN_LOADING_ADDITIVE);
@@ -249,19 +249,19 @@ TEST(HipDNNBackendTest, GetLoadedPluginPaths_LoadsDefault)
     ASSERT_EQ(status, HIPDNN_STATUS_SUCCESS);
     ASSERT_NE(handle, nullptr);
 
-    auto loaded_plugins = test_util::get_loaded_plugins(handle);
+    auto loadedPlugins = test_util::getLoadedPlugins(handle);
 
-    fs::path expected_plugin_path = fs::path("../../backend/src/hipdnn_plugins/engines")
-                                    / getLibraryName("test_good_default_plugin");
+    fs::path expectedPluginPath = fs::path("../../backend/src/hipdnn_plugins/engines")
+                                  / getLibraryName("test_good_default_plugin");
 
-    EXPECT_TRUE(test_util::is_plugin_loaded(loaded_plugins, expected_plugin_path.string()));
+    EXPECT_TRUE(test_util::isPluginLoaded(loadedPlugins, expectedPluginPath.string()));
     EXPECT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
 }
 
-TEST(HipDNNBackendTest, GetLoadedPluginPaths_AdditiveLoadsBothDefaultAndCustom)
+TEST(HipDNNBackendTest, GetLoadedPluginPathsAdditiveLoadsBothDefaultAndCustom)
 {
-    std::string plugin_dir_str = PLUGIN_DIR.string();
-    const std::array<const char*, 1> paths = {plugin_dir_str.c_str()};
+    std::string pluginDirStr = PLUGIN_DIR.string();
+    const std::array<const char*, 1> paths = {pluginDirStr.c_str()};
     hipdnnStatus_t status = hipdnnSetEnginePluginPaths_ext(
         paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ADDITIVE);
     EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
@@ -271,23 +271,23 @@ TEST(HipDNNBackendTest, GetLoadedPluginPaths_AdditiveLoadsBothDefaultAndCustom)
     ASSERT_EQ(status, HIPDNN_STATUS_SUCCESS);
     ASSERT_NE(handle, nullptr);
 
-    auto loaded_plugins = test_util::get_loaded_plugins(handle);
-    EXPECT_GE(loaded_plugins.size(), 2);
+    auto loadedPlugins = test_util::getLoadedPlugins(handle);
+    EXPECT_GE(loadedPlugins.size(), 2);
 
-    auto default_plugin_path = fs::path("../../backend/src/hipdnn_plugins/engines")
-                               / getLibraryName("test_good_default_plugin");
-    auto test_plugin_path = PLUGIN_DIR / getLibraryName(test_good_plugin_name);
+    auto defaultPluginPath = fs::path("../../backend/src/hipdnn_plugins/engines")
+                             / getLibraryName("test_good_default_plugin");
+    auto testPluginPath = PLUGIN_DIR / getLibraryName(test_good_plugin_name);
 
-    EXPECT_TRUE(test_util::is_plugin_loaded(loaded_plugins, default_plugin_path.string()));
-    EXPECT_TRUE(test_util::is_plugin_loaded(loaded_plugins, test_plugin_path.string()));
+    EXPECT_TRUE(test_util::isPluginLoaded(loadedPlugins, defaultPluginPath.string()));
+    EXPECT_TRUE(test_util::isPluginLoaded(loadedPlugins, testPluginPath.string()));
 
     EXPECT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
 }
 
-TEST(HipDNNBackendTest, GetLoadedPluginPaths_AbsoluteLoadsOnlyCustom)
+TEST(HipDNNBackendTest, GetLoadedPluginPathsAbsoluteLoadsOnlyCustom)
 {
-    auto& plugin_file_path = test_good_plugin_path();
-    const std::array<const char*, 1> paths = {plugin_file_path.c_str()};
+    auto& pluginFilePath = test_good_plugin_path();
+    const std::array<const char*, 1> paths = {pluginFilePath.c_str()};
     hipdnnStatus_t status = hipdnnSetEnginePluginPaths_ext(
         paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE);
     EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
@@ -297,14 +297,14 @@ TEST(HipDNNBackendTest, GetLoadedPluginPaths_AbsoluteLoadsOnlyCustom)
     ASSERT_EQ(status, HIPDNN_STATUS_SUCCESS);
     ASSERT_NE(handle, nullptr);
 
-    auto loaded_plugins = test_util::get_loaded_plugins(handle);
-    EXPECT_EQ(loaded_plugins.size(), 1);
+    auto loadedPlugins = test_util::getLoadedPlugins(handle);
+    EXPECT_EQ(loadedPlugins.size(), 1);
 
-    auto default_plugin_path = fs::path("backend/src/hipdnn_plugins/engines")
-                               / getLibraryName("test_good_default_plugin");
+    auto defaultPluginPath = fs::path("backend/src/hipdnn_plugins/engines")
+                             / getLibraryName("test_good_default_plugin");
 
-    EXPECT_FALSE(test_util::is_plugin_loaded(loaded_plugins, default_plugin_path.string()));
-    EXPECT_TRUE(test_util::is_plugin_loaded(loaded_plugins, plugin_file_path));
+    EXPECT_FALSE(test_util::isPluginLoaded(loadedPlugins, defaultPluginPath.string()));
+    EXPECT_TRUE(test_util::isPluginLoaded(loadedPlugins, pluginFilePath));
 
     EXPECT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
 }

--- a/tests/backend/test_engine_api.cpp
+++ b/tests/backend/test_engine_api.cpp
@@ -8,7 +8,7 @@
 
 #include <gtest/gtest.h>
 
-class Engine_api_tests : public ::testing::Test
+class EngineApiTests : public ::testing::Test
 {
 protected:
     hipdnnBackendDescriptor_t _engine;
@@ -44,7 +44,7 @@ protected:
     }
 };
 
-TEST_F(Engine_api_tests, SetEngineGraph)
+TEST_F(EngineApiTests, SetEngineGraph)
 {
     EXPECT_EQ(hipdnnBackendSetAttribute(_engine,
                                         HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
@@ -53,7 +53,7 @@ TEST_F(Engine_api_tests, SetEngineGraph)
                                         &_graph),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    test_util::create_test_graph(&_graph, _handle);
+    test_util::createTestGraph(&_graph, _handle);
     ASSERT_EQ(hipdnnBackendFinalize(_graph), HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(hipdnnBackendSetAttribute(_engine,
                                         HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
@@ -63,7 +63,7 @@ TEST_F(Engine_api_tests, SetEngineGraph)
               HIPDNN_STATUS_SUCCESS);
 }
 
-TEST_F(Engine_api_tests, SetEngineGlobalIndex)
+TEST_F(EngineApiTests, SetEngineGlobalIndex)
 {
     int64_t gidx = hipdnn_tests::plugin_constants::engine_id<Good_plugin>();
 
@@ -76,38 +76,38 @@ TEST_F(Engine_api_tests, SetEngineGlobalIndex)
               HIPDNN_STATUS_SUCCESS);
 }
 
-TEST_F(Engine_api_tests, SetEngineAttrNotSupported)
+TEST_F(EngineApiTests, SetEngineAttrNotSupported)
 {
     EXPECT_EQ(hipdnnBackendSetAttribute(
                   _engine, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, nullptr),
               HIPDNN_STATUS_NOT_SUPPORTED);
 }
 
-TEST_F(Engine_api_tests, SetEngineAttrAlreadyFinalized)
+TEST_F(EngineApiTests, SetEngineAttrAlreadyFinalized)
 {
     int64_t gidx = hipdnn_tests::plugin_constants::engine_id<Good_plugin>();
 
-    test_util::populate_test_engine(_engine, &_graph, _handle, gidx, true);
+    test_util::populateTestEngine(_engine, &_graph, _handle, gidx, true);
     EXPECT_EQ(hipdnnBackendSetAttribute(
                   _engine, HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &gidx),
               HIPDNN_STATUS_NOT_INITIALIZED);
 }
 
-TEST_F(Engine_api_tests, FinalizeEngine)
+TEST_F(EngineApiTests, FinalizeEngine)
 {
     int64_t gidx = hipdnn_tests::plugin_constants::engine_id<Good_plugin>();
 
     EXPECT_EQ(hipdnnBackendFinalize(_engine), HIPDNN_STATUS_BAD_PARAM);
-    test_util::populate_test_engine(_engine, &_graph, _handle, gidx);
+    test_util::populateTestEngine(_engine, &_graph, _handle, gidx);
     EXPECT_EQ(hipdnnBackendFinalize(_engine), HIPDNN_STATUS_SUCCESS);
 }
 
-TEST_F(Engine_api_tests, GetEngineGraph)
+TEST_F(EngineApiTests, GetEngineGraph)
 {
     hipdnnBackendDescriptor_t graph = nullptr;
     int64_t gidx = hipdnn_tests::plugin_constants::engine_id<Good_plugin>();
 
-    test_util::populate_test_engine(_engine, &_graph, _handle, gidx, true);
+    test_util::populateTestEngine(_engine, &_graph, _handle, gidx, true);
     EXPECT_EQ(hipdnnBackendGetAttribute(_engine,
                                         HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
@@ -120,15 +120,15 @@ TEST_F(Engine_api_tests, GetEngineGraph)
     hipdnnBackendDestroyDescriptor(graph);
 }
 
-TEST_F(Engine_api_tests, GetEngineGlobalIndex)
+TEST_F(EngineApiTests, GetEngineGlobalIndex)
 {
     int64_t gidx = hipdnn_tests::plugin_constants::engine_id<Good_plugin>();
-    int64_t gidx_out;
+    int64_t gidxOut;
 
-    test_util::populate_test_engine(_engine, &_graph, _handle, gidx, true);
+    test_util::populateTestEngine(_engine, &_graph, _handle, gidx, true);
     EXPECT_EQ(
         hipdnnBackendGetAttribute(
-            _engine, HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, &gidx_out),
+            _engine, HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, &gidxOut),
         HIPDNN_STATUS_SUCCESS);
-    EXPECT_EQ(gidx_out, gidx);
+    EXPECT_EQ(gidxOut, gidx);
 }

--- a/tests/backend/test_engine_config_api.cpp
+++ b/tests/backend/test_engine_config_api.cpp
@@ -10,7 +10,7 @@
 class Engine_config_api_tests : public ::testing::Test
 {
 protected:
-    hipdnnBackendDescriptor_t _engine_config;
+    hipdnnBackendDescriptor_t _engineConfig;
     hipdnnBackendDescriptor_t _engine = nullptr;
     hipdnnBackendDescriptor_t _graph = nullptr;
     hipdnnHandle_t _handle = nullptr;
@@ -25,14 +25,14 @@ protected:
 
         ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
         EXPECT_EQ(
-            hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engine_config),
+            hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engineConfig),
             HIPDNN_STATUS_SUCCESS);
-        ASSERT_NE(_engine_config, nullptr);
+        ASSERT_NE(_engineConfig, nullptr);
     }
 
     void TearDown() override
     {
-        EXPECT_EQ(hipdnnBackendDestroyDescriptor(_engine_config), HIPDNN_STATUS_SUCCESS);
+        EXPECT_EQ(hipdnnBackendDestroyDescriptor(_engineConfig), HIPDNN_STATUS_SUCCESS);
         if(_engine != nullptr)
         {
             EXPECT_EQ(hipdnnBackendDestroyDescriptor(_engine), HIPDNN_STATUS_SUCCESS);
@@ -53,7 +53,7 @@ TEST_F(Engine_config_api_tests, SetEngineConfigEngine)
 {
     int64_t gidx = hipdnn_tests::plugin_constants::engine_id<Good_plugin>();
 
-    EXPECT_EQ(hipdnnBackendSetAttribute(_engine_config,
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
                                         HIPDNN_ATTR_ENGINECFG_ENGINE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
@@ -61,7 +61,7 @@ TEST_F(Engine_config_api_tests, SetEngineConfigEngine)
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
     test_util::createTestEngine(&_engine, &_graph, _handle, gidx, true);
-    EXPECT_EQ(hipdnnBackendSetAttribute(_engine_config,
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
                                         HIPDNN_ATTR_ENGINECFG_ENGINE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
@@ -73,9 +73,9 @@ TEST_F(Engine_config_api_tests, FinalizeEngineConfig)
 {
     int64_t gidx = hipdnn_tests::plugin_constants::engine_id<Good_plugin>();
 
-    EXPECT_EQ(hipdnnBackendFinalize(_engine_config), HIPDNN_STATUS_BAD_PARAM);
-    test_util::populateTestEngineConfig(&_engine_config, &_engine, &_graph, _handle, gidx);
-    EXPECT_EQ(hipdnnBackendFinalize(_engine_config), HIPDNN_STATUS_SUCCESS);
+    EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_BAD_PARAM);
+    test_util::populateTestEngineConfig(&_engineConfig, &_engine, &_graph, _handle, gidx);
+    EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
 }
 
 TEST_F(Engine_config_api_tests, GetMaxWorkspaceSizeFromEngineConfig)
@@ -83,8 +83,8 @@ TEST_F(Engine_config_api_tests, GetMaxWorkspaceSizeFromEngineConfig)
     int64_t gidx = hipdnn_tests::plugin_constants::engine_id<Good_plugin>();
     int64_t max_workspace_size = 0;
 
-    test_util::populateTestEngineConfig(&_engine_config, &_engine, &_graph, _handle, gidx, true);
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_config,
+    test_util::populateTestEngineConfig(&_engineConfig, &_engine, &_graph, _handle, gidx, true);
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineConfig,
                                         HIPDNN_ATTR_ENGINECFG_WORKSPACE_SIZE,
                                         HIPDNN_TYPE_INT64,
                                         1,

--- a/tests/backend/test_engine_config_api.cpp
+++ b/tests/backend/test_engine_config_api.cpp
@@ -60,7 +60,7 @@ TEST_F(Engine_config_api_tests, SetEngineConfigEngine)
                                         &_engine),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    test_util::create_test_engine(&_engine, &_graph, _handle, gidx, true);
+    test_util::createTestEngine(&_engine, &_graph, _handle, gidx, true);
     EXPECT_EQ(hipdnnBackendSetAttribute(_engine_config,
                                         HIPDNN_ATTR_ENGINECFG_ENGINE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
@@ -74,7 +74,7 @@ TEST_F(Engine_config_api_tests, FinalizeEngineConfig)
     int64_t gidx = hipdnn_tests::plugin_constants::engine_id<Good_plugin>();
 
     EXPECT_EQ(hipdnnBackendFinalize(_engine_config), HIPDNN_STATUS_BAD_PARAM);
-    test_util::populate_test_engine_config(&_engine_config, &_engine, &_graph, _handle, gidx);
+    test_util::populateTestEngineConfig(&_engine_config, &_engine, &_graph, _handle, gidx);
     EXPECT_EQ(hipdnnBackendFinalize(_engine_config), HIPDNN_STATUS_SUCCESS);
 }
 
@@ -83,7 +83,7 @@ TEST_F(Engine_config_api_tests, GetMaxWorkspaceSizeFromEngineConfig)
     int64_t gidx = hipdnn_tests::plugin_constants::engine_id<Good_plugin>();
     int64_t max_workspace_size = 0;
 
-    test_util::populate_test_engine_config(&_engine_config, &_engine, &_graph, _handle, gidx, true);
+    test_util::populateTestEngineConfig(&_engine_config, &_engine, &_graph, _handle, gidx, true);
     EXPECT_EQ(hipdnnBackendGetAttribute(_engine_config,
                                         HIPDNN_ATTR_ENGINECFG_WORKSPACE_SIZE,
                                         HIPDNN_TYPE_INT64,

--- a/tests/backend/test_engine_heuristic_api.cpp
+++ b/tests/backend/test_engine_heuristic_api.cpp
@@ -15,10 +15,10 @@ namespace
 constexpr hipdnnBackendHeurMode_t FALLBACK_MODE = HIPDNN_HEUR_MODE_FALLBACK;
 }
 
-class Engine_heuristic_api_tests : public ::testing::Test
+class EngineHeuristicApiTests : public ::testing::Test
 {
 protected:
-    hipdnnBackendDescriptor_t _engine_heuristic = nullptr;
+    hipdnnBackendDescriptor_t _engineHeuristic = nullptr;
     hipdnnBackendDescriptor_t _graph = nullptr;
     hipdnnHandle_t _handle = nullptr;
 
@@ -32,16 +32,16 @@ protected:
 
         ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
         EXPECT_EQ(
-            hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR, &_engine_heuristic),
+            hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR, &_engineHeuristic),
             HIPDNN_STATUS_SUCCESS);
-        ASSERT_NE(_engine_heuristic, nullptr);
+        ASSERT_NE(_engineHeuristic, nullptr);
     }
 
     void TearDown() override
     {
-        if(_engine_heuristic != nullptr)
+        if(_engineHeuristic != nullptr)
         {
-            EXPECT_EQ(hipdnnBackendDestroyDescriptor(_engine_heuristic), HIPDNN_STATUS_SUCCESS);
+            EXPECT_EQ(hipdnnBackendDestroyDescriptor(_engineHeuristic), HIPDNN_STATUS_SUCCESS);
         }
         if(_graph != nullptr)
         {
@@ -54,9 +54,9 @@ protected:
         }
     }
 
-    void set_heuristic_mode()
+    void setHeuristicMode()
     {
-        ASSERT_EQ(hipdnnBackendSetAttribute(_engine_heuristic,
+        ASSERT_EQ(hipdnnBackendSetAttribute(_engineHeuristic,
                                             HIPDNN_ATTR_ENGINEHEUR_MODE,
                                             HIPDNN_TYPE_HEUR_MODE,
                                             1,
@@ -64,11 +64,11 @@ protected:
                   HIPDNN_STATUS_SUCCESS);
     }
 
-    void set_operation_graph()
+    void setOperationGraph()
     {
-        test_util::create_test_graph(&_graph, _handle);
+        test_util::createTestGraph(&_graph, _handle);
         ASSERT_EQ(hipdnnBackendFinalize(_graph), HIPDNN_STATUS_SUCCESS);
-        ASSERT_EQ(hipdnnBackendSetAttribute(_engine_heuristic,
+        ASSERT_EQ(hipdnnBackendSetAttribute(_engineHeuristic,
                                             HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                             HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                             1,
@@ -76,31 +76,31 @@ protected:
                   HIPDNN_STATUS_SUCCESS);
     }
 
-    void populate_engine_heuristic(bool finalize = true)
+    void populateEngineHeuristic(bool finalize = true)
     {
-        set_operation_graph();
-        set_heuristic_mode();
+        setOperationGraph();
+        setHeuristicMode();
 
         if(finalize)
         {
-            ASSERT_EQ(hipdnnBackendFinalize(_engine_heuristic), HIPDNN_STATUS_SUCCESS);
+            ASSERT_EQ(hipdnnBackendFinalize(_engineHeuristic), HIPDNN_STATUS_SUCCESS);
         }
     }
 };
 
-TEST_F(Engine_heuristic_api_tests, SetEngineHeuristicOperationGraph)
+TEST_F(EngineHeuristicApiTests, SetEngineHeuristicOperationGraph)
 {
-    hipdnnBackendDescriptor_t null_graph = nullptr;
-    EXPECT_EQ(hipdnnBackendSetAttribute(_engine_heuristic,
+    hipdnnBackendDescriptor_t nullGraph = nullptr;
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &null_graph),
+                                        &nullGraph),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    test_util::create_test_graph(&_graph, _handle);
+    test_util::createTestGraph(&_graph, _handle);
     ASSERT_EQ(hipdnnBackendFinalize(_graph), HIPDNN_STATUS_SUCCESS);
-    EXPECT_EQ(hipdnnBackendSetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
@@ -108,36 +108,36 @@ TEST_F(Engine_heuristic_api_tests, SetEngineHeuristicOperationGraph)
               HIPDNN_STATUS_SUCCESS);
 }
 
-TEST_F(Engine_heuristic_api_tests, SetEngineHeuristicMode)
+TEST_F(EngineHeuristicApiTests, SetEngineHeuristicMode)
 {
     EXPECT_EQ(
         hipdnnBackendSetAttribute(
-            _engine_heuristic, HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr),
+            _engineHeuristic, HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr),
         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    EXPECT_EQ(hipdnnBackendSetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_MODE,
                                         HIPDNN_TYPE_HEUR_MODE,
                                         2,
                                         &FALLBACK_MODE),
               HIPDNN_STATUS_BAD_PARAM);
 
-    EXPECT_EQ(hipdnnBackendSetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_MODE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
                                         &FALLBACK_MODE),
               HIPDNN_STATUS_BAD_PARAM);
 
-    auto unsupported_mode = static_cast<hipdnnBackendHeurMode_t>(999);
-    EXPECT_EQ(hipdnnBackendSetAttribute(_engine_heuristic,
+    auto unsupportedMode = static_cast<hipdnnBackendHeurMode_t>(999);
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_MODE,
                                         HIPDNN_TYPE_HEUR_MODE,
                                         1,
-                                        &unsupported_mode),
+                                        &unsupportedMode),
               HIPDNN_STATUS_NOT_SUPPORTED);
 
-    EXPECT_EQ(hipdnnBackendSetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_MODE,
                                         HIPDNN_TYPE_HEUR_MODE,
                                         1,
@@ -145,32 +145,32 @@ TEST_F(Engine_heuristic_api_tests, SetEngineHeuristicMode)
               HIPDNN_STATUS_SUCCESS);
 }
 
-TEST_F(Engine_heuristic_api_tests, SetUnsupportedAttribute)
+TEST_F(EngineHeuristicApiTests, SetUnsupportedAttribute)
 {
     int32_t dummy = 0;
     EXPECT_EQ(hipdnnBackendSetAttribute(
-                  _engine_heuristic, HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_INT32, 1, &dummy),
+                  _engineHeuristic, HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_INT32, 1, &dummy),
               HIPDNN_STATUS_NOT_SUPPORTED);
 }
 
-TEST_F(Engine_heuristic_api_tests, FinalizeEngineHeuristic)
+TEST_F(EngineHeuristicApiTests, FinalizeEngineHeuristic)
 {
-    EXPECT_EQ(hipdnnBackendFinalize(_engine_heuristic), HIPDNN_STATUS_BAD_PARAM);
+    EXPECT_EQ(hipdnnBackendFinalize(_engineHeuristic), HIPDNN_STATUS_BAD_PARAM);
 
-    set_operation_graph();
-    EXPECT_EQ(hipdnnBackendFinalize(_engine_heuristic), HIPDNN_STATUS_BAD_PARAM);
+    setOperationGraph();
+    EXPECT_EQ(hipdnnBackendFinalize(_engineHeuristic), HIPDNN_STATUS_BAD_PARAM);
 
-    set_heuristic_mode();
-    EXPECT_EQ(hipdnnBackendFinalize(_engine_heuristic), HIPDNN_STATUS_SUCCESS);
+    setHeuristicMode();
+    EXPECT_EQ(hipdnnBackendFinalize(_engineHeuristic), HIPDNN_STATUS_SUCCESS);
 
-    EXPECT_EQ(hipdnnBackendFinalize(_engine_heuristic), HIPDNN_STATUS_BAD_PARAM);
+    EXPECT_EQ(hipdnnBackendFinalize(_engineHeuristic), HIPDNN_STATUS_BAD_PARAM);
 }
 
-TEST_F(Engine_heuristic_api_tests, SetAttributeOnFinalizedDescriptor)
+TEST_F(EngineHeuristicApiTests, SetAttributeOnFinalizedDescriptor)
 {
-    populate_engine_heuristic(true);
+    populateEngineHeuristic(true);
 
-    EXPECT_EQ(hipdnnBackendSetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_MODE,
                                         HIPDNN_TYPE_HEUR_MODE,
                                         1,
@@ -178,43 +178,43 @@ TEST_F(Engine_heuristic_api_tests, SetAttributeOnFinalizedDescriptor)
               HIPDNN_STATUS_NOT_INITIALIZED);
 }
 
-TEST_F(Engine_heuristic_api_tests, GetAttributeOnUnfinalizedDescriptor)
+TEST_F(EngineHeuristicApiTests, GetAttributeOnUnfinalizedDescriptor)
 {
-    hipdnnBackendDescriptor_t dummy_graph = nullptr;
+    hipdnnBackendDescriptor_t dummyGraph = nullptr;
 
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
                                         nullptr,
-                                        &dummy_graph),
+                                        &dummyGraph),
               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
 }
 
-TEST_F(Engine_heuristic_api_tests, GetOperationGraph)
+TEST_F(EngineHeuristicApiTests, GetOperationGraph)
 {
-    populate_engine_heuristic(true);
+    populateEngineHeuristic(true);
 
-    hipdnnBackendDescriptor_t retrieved_graph = nullptr;
-    hipdnnBackendDescriptor_t retrieved_graph2 = nullptr;
+    hipdnnBackendDescriptor_t retrievedGraph = nullptr;
+    hipdnnBackendDescriptor_t retrievedGraph2 = nullptr;
 
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                         HIPDNN_TYPE_INT64,
                                         1,
                                         nullptr,
-                                        &retrieved_graph),
+                                        &retrievedGraph),
               HIPDNN_STATUS_BAD_PARAM);
 
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         2,
                                         nullptr,
-                                        &retrieved_graph),
+                                        &retrievedGraph),
               HIPDNN_STATUS_BAD_PARAM);
 
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
@@ -222,39 +222,39 @@ TEST_F(Engine_heuristic_api_tests, GetOperationGraph)
                                         nullptr),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
                                         nullptr,
-                                        &retrieved_graph),
+                                        &retrievedGraph),
               HIPDNN_STATUS_SUCCESS);
-    EXPECT_NE(retrieved_graph, nullptr);
+    EXPECT_NE(retrievedGraph, nullptr);
 
-    hipdnnBackendDestroyDescriptor(retrieved_graph);
-    retrieved_graph = nullptr;
+    hipdnnBackendDestroyDescriptor(retrievedGraph);
+    retrievedGraph = nullptr;
 
     int64_t count = 0;
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
                                         &count,
-                                        &retrieved_graph2),
+                                        &retrievedGraph2),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(count, 1);
 
-    hipdnnBackendDestroyDescriptor(retrieved_graph2);
-    retrieved_graph2 = nullptr;
+    hipdnnBackendDestroyDescriptor(retrievedGraph2);
+    retrievedGraph2 = nullptr;
 }
 
-TEST_F(Engine_heuristic_api_tests, GetHeuristicMode)
+TEST_F(EngineHeuristicApiTests, GetHeuristicMode)
 {
-    populate_engine_heuristic(true);
+    populateEngineHeuristic(true);
 
     hipdnnBackendHeurMode_t mode = HIPDNN_HEUR_MODE_FALLBACK;
 
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_MODE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
@@ -262,7 +262,7 @@ TEST_F(Engine_heuristic_api_tests, GetHeuristicMode)
                                         &mode),
               HIPDNN_STATUS_BAD_PARAM);
 
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_MODE,
                                         HIPDNN_TYPE_HEUR_MODE,
                                         2,
@@ -270,7 +270,7 @@ TEST_F(Engine_heuristic_api_tests, GetHeuristicMode)
                                         &mode),
               HIPDNN_STATUS_BAD_PARAM);
 
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_MODE,
                                         HIPDNN_TYPE_HEUR_MODE,
                                         1,
@@ -278,7 +278,7 @@ TEST_F(Engine_heuristic_api_tests, GetHeuristicMode)
                                         nullptr),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_MODE,
                                         HIPDNN_TYPE_HEUR_MODE,
                                         1,
@@ -288,7 +288,7 @@ TEST_F(Engine_heuristic_api_tests, GetHeuristicMode)
     EXPECT_EQ(mode, HIPDNN_HEUR_MODE_FALLBACK);
 
     int64_t count = 0;
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_MODE,
                                         HIPDNN_TYPE_HEUR_MODE,
                                         1,
@@ -299,12 +299,12 @@ TEST_F(Engine_heuristic_api_tests, GetHeuristicMode)
     EXPECT_EQ(mode, HIPDNN_HEUR_MODE_FALLBACK);
 }
 
-TEST_F(Engine_heuristic_api_tests, GetUnsupportedAttribute)
+TEST_F(EngineHeuristicApiTests, GetUnsupportedAttribute)
 {
-    populate_engine_heuristic(true);
+    populateEngineHeuristic(true);
 
     hipdnnBackendHeurMode_t dummy;
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINE_KNOB_INFO,
                                         HIPDNN_TYPE_HEUR_MODE,
                                         1,
@@ -313,12 +313,12 @@ TEST_F(Engine_heuristic_api_tests, GetUnsupportedAttribute)
               HIPDNN_STATUS_NOT_SUPPORTED);
 }
 
-TEST_F(Engine_heuristic_api_tests, GetEngineConfigsCountOnly)
+TEST_F(EngineHeuristicApiTests, GetEngineConfigsCountOnly)
 {
-    populate_engine_heuristic(true);
+    populateEngineHeuristic(true);
 
     int64_t count = 0;
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_RESULTS,
                                         HIPDNN_TYPE_INT64,
                                         0,
@@ -326,7 +326,7 @@ TEST_F(Engine_heuristic_api_tests, GetEngineConfigsCountOnly)
                                         nullptr),
               HIPDNN_STATUS_BAD_PARAM);
 
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_RESULTS,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         0,
@@ -336,12 +336,12 @@ TEST_F(Engine_heuristic_api_tests, GetEngineConfigsCountOnly)
     EXPECT_EQ(count, 1);
 }
 
-TEST_F(Engine_heuristic_api_tests, GetEngineConfigs)
+TEST_F(EngineHeuristicApiTests, GetEngineConfigs)
 {
-    populate_engine_heuristic(true);
+    populateEngineHeuristic(true);
 
     std::vector<hipdnnBackendDescriptor_t> configs(3);
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_RESULTS,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         3,
@@ -350,7 +350,7 @@ TEST_F(Engine_heuristic_api_tests, GetEngineConfigs)
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
     int64_t count = 0;
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_RESULTS,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
@@ -358,7 +358,7 @@ TEST_F(Engine_heuristic_api_tests, GetEngineConfigs)
                                         nullptr),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_RESULTS,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         0,
@@ -374,7 +374,7 @@ TEST_F(Engine_heuristic_api_tests, GetEngineConfigs)
     }
 
     count = 0;
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_RESULTS,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         3, // Ask for 3, but only one engine avaliable.
@@ -395,12 +395,12 @@ TEST_F(Engine_heuristic_api_tests, GetEngineConfigs)
               HIPDNN_STATUS_SUCCESS);
     ASSERT_NE(engine, nullptr);
 
-    int64_t engine_id = 0;
+    int64_t engineId = 0;
     EXPECT_EQ(
         hipdnnBackendGetAttribute(
-            engine, HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, &engine_id),
+            engine, HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, nullptr, &engineId),
         HIPDNN_STATUS_SUCCESS);
-    EXPECT_EQ(engine_id, hipdnn_tests::plugin_constants::engine_id<Good_plugin>());
+    EXPECT_EQ(engineId, hipdnn_tests::plugin_constants::engine_id<Good_plugin>());
 
     // Expecting to only need to clean-up 1 engine config, since we only created & requested 1.
     for(auto config : configs)
@@ -414,9 +414,9 @@ TEST_F(Engine_heuristic_api_tests, GetEngineConfigs)
     EXPECT_EQ(hipdnnBackendDestroyDescriptor(engine), HIPDNN_STATUS_SUCCESS);
 }
 
-TEST_F(Engine_heuristic_api_tests, GetEngineConfigsRequestMoreThanAvailable)
+TEST_F(EngineHeuristicApiTests, GetEngineConfigsRequestMoreThanAvailable)
 {
-    populate_engine_heuristic(true);
+    populateEngineHeuristic(true);
 
     std::vector<hipdnnBackendDescriptor_t> configs(5);
     for(size_t i = 0; i < 5; ++i)
@@ -426,7 +426,7 @@ TEST_F(Engine_heuristic_api_tests, GetEngineConfigsRequestMoreThanAvailable)
     }
 
     int64_t count = 0;
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engine_heuristic,
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_RESULTS,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         5,

--- a/tests/backend/test_engine_heuristic_api.cpp
+++ b/tests/backend/test_engine_heuristic_api.cpp
@@ -110,10 +110,9 @@ TEST_F(EngineHeuristicApiTests, SetEngineHeuristicOperationGraph)
 
 TEST_F(EngineHeuristicApiTests, SetEngineHeuristicMode)
 {
-    EXPECT_EQ(
-        hipdnnBackendSetAttribute(
-            _engineHeuristic, HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    EXPECT_EQ(hipdnnBackendSetAttribute(
+                  _engineHeuristic, HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, nullptr),
+              HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
     EXPECT_EQ(hipdnnBackendSetAttribute(_engineHeuristic,
                                         HIPDNN_ATTR_ENGINEHEUR_MODE,
@@ -288,13 +287,10 @@ TEST_F(EngineHeuristicApiTests, GetHeuristicMode)
     EXPECT_EQ(mode, HIPDNN_HEUR_MODE_FALLBACK);
 
     int64_t count = 0;
-    EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
-                                        HIPDNN_ATTR_ENGINEHEUR_MODE,
-                                        HIPDNN_TYPE_HEUR_MODE,
-                                        1,
-                                        &count,
-                                        &mode),
-              HIPDNN_STATUS_SUCCESS);
+    EXPECT_EQ(
+        hipdnnBackendGetAttribute(
+            _engineHeuristic, HIPDNN_ATTR_ENGINEHEUR_MODE, HIPDNN_TYPE_HEUR_MODE, 1, &count, &mode),
+        HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(count, 1);
     EXPECT_EQ(mode, HIPDNN_HEUR_MODE_FALLBACK);
 }

--- a/tests/backend/test_execution_plan_api.cpp
+++ b/tests/backend/test_execution_plan_api.cpp
@@ -7,13 +7,13 @@
 
 #include <gtest/gtest.h>
 
-class Execution_plan_api_tests : public ::testing::Test
+class ExecutionPlanApiTests : public ::testing::Test
 {
 protected:
     static constexpr int64_t GIDX = hipdnn_tests::plugin_constants::engine_id<Good_plugin>();
     hipdnnBackendDescriptor_t _plan;
     hipdnnHandle_t _handle = nullptr;
-    hipdnnBackendDescriptor_t _engine_config = nullptr;
+    hipdnnBackendDescriptor_t _engineConfig = nullptr;
     hipdnnBackendDescriptor_t _engine = nullptr;
     hipdnnBackendDescriptor_t _graph = nullptr;
 
@@ -33,15 +33,15 @@ protected:
 
     void TearDown() override
     {
-        destroy_test_descriptor(_plan);
-        destroy_test_handle();
-        destroy_test_descriptor(_engine_config);
-        destroy_test_descriptor(_engine);
-        destroy_test_descriptor(_graph);
+        destroyTestDescriptor(_plan);
+        destroyTestHandle();
+        destroyTestDescriptor(_engineConfig);
+        destroyTestDescriptor(_engine);
+        destroyTestDescriptor(_graph);
     }
 
 private:
-    void destroy_test_handle()
+    void destroyTestHandle()
     {
         if(_handle != nullptr)
         {
@@ -50,7 +50,7 @@ private:
         }
     }
 
-    static void destroy_test_descriptor(hipdnnBackendDescriptor_t descriptor)
+    static void destroyTestDescriptor(hipdnnBackendDescriptor_t descriptor)
     {
         if(descriptor != nullptr)
         {
@@ -60,7 +60,7 @@ private:
     }
 };
 
-TEST_F(Execution_plan_api_tests, SetExecutionPlanHandle)
+TEST_F(ExecutionPlanApiTests, SetExecutionPlanHandle)
 {
     EXPECT_EQ(hipdnnBackendSetAttribute(
                   _plan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, nullptr),
@@ -71,7 +71,7 @@ TEST_F(Execution_plan_api_tests, SetExecutionPlanHandle)
               HIPDNN_STATUS_SUCCESS);
 }
 
-TEST_F(Execution_plan_api_tests, SetExecutionPlanEngineConfig)
+TEST_F(ExecutionPlanApiTests, SetExecutionPlanEngineConfig)
 {
     EXPECT_EQ(hipdnnBackendSetAttribute(_plan,
                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
@@ -80,24 +80,24 @@ TEST_F(Execution_plan_api_tests, SetExecutionPlanEngineConfig)
                                         nullptr),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    test_util::create_test_engine_config(&_engine_config, &_engine, &_graph, _handle, GIDX, true);
+    test_util::createTestEngineConfig(&_engineConfig, &_engine, &_graph, _handle, GIDX, true);
 
     EXPECT_EQ(hipdnnBackendSetAttribute(_plan,
                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engine_config),
+                                        &_engineConfig),
               HIPDNN_STATUS_SUCCESS);
 }
 
-TEST_F(Execution_plan_api_tests, SetExecutionPlanAttrNotSupported)
+TEST_F(ExecutionPlanApiTests, SetExecutionPlanAttrNotSupported)
 {
     EXPECT_EQ(hipdnnBackendSetAttribute(
                   _plan, HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, nullptr),
               HIPDNN_STATUS_NOT_SUPPORTED);
 }
 
-TEST_F(Execution_plan_api_tests, GetExecutionPlanWorkSpaceSize)
+TEST_F(ExecutionPlanApiTests, GetExecutionPlanWorkSpaceSize)
 {
     size_t size = 0;
     EXPECT_EQ(
@@ -105,8 +105,8 @@ TEST_F(Execution_plan_api_tests, GetExecutionPlanWorkSpaceSize)
             _plan, HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, nullptr, &size),
         HIPDNN_STATUS_NOT_INITIALIZED);
 
-    test_util::populate_test_execution_plan(
-        &_plan, &_engine_config, &_engine, &_graph, _handle, GIDX, true);
+    test_util::populateTestExecutionPlan(
+        &_plan, &_engineConfig, &_engine, &_graph, _handle, GIDX, true);
     EXPECT_EQ(
         hipdnnBackendGetAttribute(
             _plan, HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE, HIPDNN_TYPE_INT64, 1, nullptr, &size),
@@ -114,7 +114,7 @@ TEST_F(Execution_plan_api_tests, GetExecutionPlanWorkSpaceSize)
     EXPECT_EQ(size, 1024);
 }
 
-TEST_F(Execution_plan_api_tests, FinalizeExecutionPlan)
+TEST_F(ExecutionPlanApiTests, FinalizeExecutionPlan)
 {
     EXPECT_EQ(hipdnnBackendFinalize(_plan), HIPDNN_STATUS_BAD_PARAM);
 
@@ -123,7 +123,7 @@ TEST_F(Execution_plan_api_tests, FinalizeExecutionPlan)
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(hipdnnBackendFinalize(_plan), HIPDNN_STATUS_BAD_PARAM);
 
-    test_util::populate_test_execution_plan(
-        &_plan, &_engine_config, &_engine, &_graph, _handle, GIDX);
+    test_util::populateTestExecutionPlan(
+        &_plan, &_engineConfig, &_engine, &_graph, _handle, GIDX);
     EXPECT_EQ(hipdnnBackendFinalize(_plan), HIPDNN_STATUS_SUCCESS);
 }

--- a/tests/backend/test_execution_plan_api.cpp
+++ b/tests/backend/test_execution_plan_api.cpp
@@ -123,7 +123,6 @@ TEST_F(ExecutionPlanApiTests, FinalizeExecutionPlan)
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(hipdnnBackendFinalize(_plan), HIPDNN_STATUS_BAD_PARAM);
 
-    test_util::populateTestExecutionPlan(
-        &_plan, &_engineConfig, &_engine, &_graph, _handle, GIDX);
+    test_util::populateTestExecutionPlan(&_plan, &_engineConfig, &_engine, &_graph, _handle, GIDX);
     EXPECT_EQ(hipdnnBackendFinalize(_plan), HIPDNN_STATUS_SUCCESS);
 }

--- a/tests/backend/test_get_error_api.cpp
+++ b/tests/backend/test_get_error_api.cpp
@@ -13,7 +13,7 @@
 // NOLINTBEGIN(modernize-avoid-c-arrays)
 TEST(GetErrorStringTest, AllStatusCodes)
 {
-    std::vector<std::tuple<hipdnnStatus_t, std::string>> status_pairs
+    std::vector<std::tuple<hipdnnStatus_t, std::string>> statusPairs
         = {{HIPDNN_STATUS_SUCCESS, "HIPDNN_STATUS_SUCCESS"},
            {HIPDNN_STATUS_NOT_INITIALIZED, "HIPDNN_STATUS_NOT_INITIALIZED"},
            {HIPDNN_STATUS_BAD_PARAM, "HIPDNN_STATUS_BAD_PARAM"},
@@ -32,7 +32,7 @@ TEST(GetErrorStringTest, AllStatusCodes)
            {HIPDNN_STATUS_EXECUTION_FAILED, "HIPDNN_STATUS_EXECUTION_FAILED"},
            {static_cast<hipdnnStatus_t>(-999), "HIPDNN_STATUS_UNKNOWN"}};
 
-    for(const auto& [status, text] : status_pairs)
+    for(const auto& [status, text] : statusPairs)
     {
         const char* str = hipdnnGetErrorString(status);
         ASSERT_STREQ(str, text.c_str());
@@ -67,40 +67,40 @@ TEST(GetLastErrorStringTest, BufferTruncationAndNullTermination)
 
     ASSERT_EQ(buffer[sizeof(buffer) - 1], '\0');
     ASSERT_LT(strlen(buffer), sizeof(buffer));
-    std::string buffer_str(buffer);
-    ASSERT_NE(buffer_str, "");
+    std::string bufferStr(buffer);
+    ASSERT_NE(bufferStr, "");
 }
 
 TEST(GetLastErrorStringTest, PerThreadErrorIsolation)
 {
     // Set error in main thread
     hipdnnDestroy(nullptr);
-    char main_buf[HIPDNN_MAX_ERROR_STRING_SIZE];
-    hipdnnGetLastErrorString(main_buf, sizeof(main_buf));
+    char mainBuf[HIPDNN_MAX_ERROR_STRING_SIZE];
+    hipdnnGetLastErrorString(mainBuf, sizeof(mainBuf));
 
-    std::string thread_error;
-    std::thread t([&thread_error]() {
+    std::string threadError;
+    std::thread t([&threadError]() {
         char buf[HIPDNN_MAX_ERROR_STRING_SIZE];
         hipdnnGetLastErrorString(buf, sizeof(buf));
-        thread_error = buf;
+        threadError = buf;
     });
     t.join();
 
     // Main thread error should be unchanged
-    char main_buf2[HIPDNN_MAX_ERROR_STRING_SIZE];
-    hipdnnGetLastErrorString(main_buf2, sizeof(main_buf2));
-    ASSERT_STREQ(main_buf, main_buf2);
-    ASSERT_TRUE(thread_error.empty());
+    char mainBuf2[HIPDNN_MAX_ERROR_STRING_SIZE];
+    hipdnnGetLastErrorString(mainBuf2, sizeof(mainBuf2));
+    ASSERT_STREQ(mainBuf, mainBuf2);
+    ASSERT_TRUE(threadError.empty());
 }
 
 TEST(GetLastErrorStringTest, BufferLargerThanMax)
 {
     hipdnnDestroy(nullptr);
-    char main_buf[1028];
-    hipdnnGetLastErrorString(main_buf, sizeof(main_buf));
+    char mainBuf[1028];
+    hipdnnGetLastErrorString(mainBuf, sizeof(mainBuf));
 
-    char main_buf2[HIPDNN_MAX_ERROR_STRING_SIZE];
-    hipdnnGetLastErrorString(main_buf2, sizeof(main_buf2));
-    ASSERT_STREQ(main_buf, main_buf2);
+    char mainBuf2[HIPDNN_MAX_ERROR_STRING_SIZE];
+    hipdnnGetLastErrorString(mainBuf2, sizeof(mainBuf2));
+    ASSERT_STREQ(mainBuf, mainBuf2);
 }
 // NOLINTEND(modernize-avoid-c-arrays)

--- a/tests/backend/test_handle_api.cpp
+++ b/tests/backend/test_handle_api.cpp
@@ -5,72 +5,72 @@
 #include <gtest/gtest.h>
 #include <hipdnn_sdk/test_utilities/test_utilities.hpp>
 
-TEST(hipDNNHandleAPITests, CreateAndDestroy)
+TEST(HipDNNHandleAPITests, CreateAndDestroy)
 {
     hipdnnHandle_t handle = nullptr;
 
-    hipdnnStatus_t create_status = hipdnnCreate(&handle);
-    ASSERT_EQ(create_status, HIPDNN_STATUS_SUCCESS);
+    auto createStatus = hipdnnCreate(&handle);
+    ASSERT_EQ(createStatus, HIPDNN_STATUS_SUCCESS);
     ASSERT_NE(handle, nullptr);
 
-    auto destroy_status = hipdnnDestroy(handle);
-    ASSERT_EQ(destroy_status, HIPDNN_STATUS_SUCCESS);
+    auto destroyStatus = hipdnnDestroy(handle);
+    ASSERT_EQ(destroyStatus, HIPDNN_STATUS_SUCCESS);
 }
 
-TEST(hipDNNHandleAPITests, SetStreamNullptrHandle)
+TEST(HipDNNHandleAPITests, SetStreamNullptrHandle)
 {
-    hipStream_t test_stream = nullptr;
-    hipdnnStatus_t set_stream_status = hipdnnSetStream(nullptr, test_stream);
-    ASSERT_EQ(set_stream_status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    hipStream_t testStream = nullptr;
+    auto setStreamStatus = hipdnnSetStream(nullptr, testStream);
+    ASSERT_EQ(setStreamStatus, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST(hipDNNHandleAPITests, GetStreamNullptrHandle)
+TEST(HipDNNHandleAPITests, GetStreamNullptrHandle)
 {
-    hipStream_t retrieved_stream = nullptr;
-    hipdnnStatus_t get_stream_status = hipdnnGetStream(nullptr, &retrieved_stream);
-    ASSERT_EQ(get_stream_status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    hipStream_t retrievedStream = nullptr;
+    auto getStreamStatus = hipdnnGetStream(nullptr, &retrievedStream);
+    ASSERT_EQ(getStreamStatus, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST(hipDNNHandleAPITests, GetStreamNullptrStreamPointer)
+TEST(HipDNNHandleAPITests, GetStreamNullptrStreamPointer)
 {
     hipdnnHandle_t handle = nullptr;
 
-    hipdnnStatus_t create_status = hipdnnCreate(&handle);
-    ASSERT_EQ(create_status, HIPDNN_STATUS_SUCCESS);
+    auto createStatus = hipdnnCreate(&handle);
+    ASSERT_EQ(createStatus, HIPDNN_STATUS_SUCCESS);
     ASSERT_NE(handle, nullptr);
 
-    hipStream_t test_stream = nullptr;
-    hipdnnStatus_t get_stream_status = hipdnnGetStream(handle, &test_stream);
-    ASSERT_EQ(get_stream_status, HIPDNN_STATUS_SUCCESS);
-    ASSERT_EQ(test_stream, nullptr);
+    hipStream_t testStream = nullptr;
+    auto getStreamStatus = hipdnnGetStream(handle, &testStream);
+    ASSERT_EQ(getStreamStatus, HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(testStream, nullptr);
 
-    hipdnnStatus_t destroy_status = hipdnnDestroy(handle);
-    ASSERT_EQ(destroy_status, HIPDNN_STATUS_SUCCESS);
+    auto destroyStatus = hipdnnDestroy(handle);
+    ASSERT_EQ(destroyStatus, HIPDNN_STATUS_SUCCESS);
 }
 
-TEST(GPU_hipDNNHandleAPITests, GetStreamPointer)
+TEST(GPUHipDNNHandleAPITests, GetStreamPointer)
 {
     SKIP_IF_NO_DEVICES();
 
     hipdnnHandle_t handle = nullptr;
 
-    hipdnnStatus_t create_status = hipdnnCreate(&handle);
-    ASSERT_EQ(create_status, HIPDNN_STATUS_SUCCESS);
+    auto createStatus = hipdnnCreate(&handle);
+    ASSERT_EQ(createStatus, HIPDNN_STATUS_SUCCESS);
     ASSERT_NE(handle, nullptr);
 
     hipStream_t stream;
     ASSERT_EQ(hipStreamCreate(&stream), hipSuccess) << "Failed to create HIP stream.";
 
-    hipdnnStatus_t set_stream_status = hipdnnSetStream(handle, stream);
-    ASSERT_EQ(set_stream_status, HIPDNN_STATUS_SUCCESS);
+    auto setStreamStatus = hipdnnSetStream(handle, stream);
+    ASSERT_EQ(setStreamStatus, HIPDNN_STATUS_SUCCESS);
 
-    hipStream_t retrieved_stream = nullptr;
-    hipdnnStatus_t get_stream_status = hipdnnGetStream(handle, &retrieved_stream);
-    ASSERT_EQ(get_stream_status, HIPDNN_STATUS_SUCCESS);
-    ASSERT_EQ(retrieved_stream, stream);
+    hipStream_t retrievedStream = nullptr;
+    auto getStreamStatus = hipdnnGetStream(handle, &retrievedStream);
+    ASSERT_EQ(getStreamStatus, HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(retrievedStream, stream);
 
-    hipdnnStatus_t destroy_status = hipdnnDestroy(handle);
-    ASSERT_EQ(destroy_status, HIPDNN_STATUS_SUCCESS);
+    auto destroyStatus = hipdnnDestroy(handle);
+    ASSERT_EQ(destroyStatus, HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipStreamDestroy(stream), hipSuccess) << "Failed to destroy HIP stream.";
 }

--- a/tests/backend/test_plugin_loading.cpp
+++ b/tests/backend/test_plugin_loading.cpp
@@ -15,23 +15,23 @@
 
 #include <gtest/gtest.h>
 
-class Plugin_loading_tests : public ::testing::Test
+class PluginLoadingTests : public ::testing::Test
 {
 protected:
-    hipdnnBackendDescriptor_t _engine_config = nullptr;
+    hipdnnBackendDescriptor_t _engineConfig = nullptr;
     hipdnnBackendDescriptor_t _engine = nullptr;
     hipdnnBackendDescriptor_t _graph = nullptr;
-    hipdnnBackendDescriptor_t _heuristic_descriptor = nullptr;
+    hipdnnBackendDescriptor_t _heuristicDescriptor = nullptr;
     hipdnnHandle_t _handle = nullptr;
 
     void SetUp() override {}
 
     void TearDown() override
     {
-        if(_engine_config != nullptr)
+        if(_engineConfig != nullptr)
         {
-            EXPECT_EQ(hipdnnBackendDestroyDescriptor(_engine_config), HIPDNN_STATUS_SUCCESS);
-            _engine_config = nullptr;
+            EXPECT_EQ(hipdnnBackendDestroyDescriptor(_engineConfig), HIPDNN_STATUS_SUCCESS);
+            _engineConfig = nullptr;
         }
         if(_engine != nullptr)
         {
@@ -43,10 +43,10 @@ protected:
             EXPECT_EQ(hipdnnBackendDestroyDescriptor(_graph), HIPDNN_STATUS_SUCCESS);
             _graph = nullptr;
         }
-        if(_heuristic_descriptor != nullptr)
+        if(_heuristicDescriptor != nullptr)
         {
-            EXPECT_EQ(hipdnnBackendDestroyDescriptor(_heuristic_descriptor), HIPDNN_STATUS_SUCCESS);
-            _heuristic_descriptor = nullptr;
+            EXPECT_EQ(hipdnnBackendDestroyDescriptor(_heuristicDescriptor), HIPDNN_STATUS_SUCCESS);
+            _heuristicDescriptor = nullptr;
         }
         if(_handle != nullptr)
         {
@@ -56,68 +56,68 @@ protected:
     }
 };
 
-void create_heuristic_descriptor(hipdnnBackendDescriptor_t* heuristic_descriptor,
-                                 hipdnnBackendDescriptor_t* graph,
-                                 bool finalize = false)
+void createHeuristicDescriptor(hipdnnBackendDescriptor_t* heuristicDescriptor,
+                               hipdnnBackendDescriptor_t* graph,
+                               bool finalize = false)
 {
     EXPECT_EQ(
-        hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR, heuristic_descriptor),
+        hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR, heuristicDescriptor),
         HIPDNN_STATUS_SUCCESS);
 
-    EXPECT_EQ(hipdnnBackendSetAttribute(*heuristic_descriptor,
+    EXPECT_EQ(hipdnnBackendSetAttribute(*heuristicDescriptor,
                                         HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
                                         graph),
               HIPDNN_STATUS_SUCCESS);
 
-    hipdnnBackendHeurMode_t backend_modes = HIPDNN_HEUR_MODE_FALLBACK;
+    auto backendModes = HIPDNN_HEUR_MODE_FALLBACK;
 
-    EXPECT_EQ(hipdnnBackendSetAttribute(*heuristic_descriptor,
+    EXPECT_EQ(hipdnnBackendSetAttribute(*heuristicDescriptor,
                                         HIPDNN_ATTR_ENGINEHEUR_MODE,
                                         HIPDNN_TYPE_HEUR_MODE,
                                         1,
-                                        &backend_modes),
+                                        &backendModes),
               HIPDNN_STATUS_SUCCESS);
 
     if(finalize)
     {
-        EXPECT_EQ(hipdnnBackendFinalize(*heuristic_descriptor), HIPDNN_STATUS_SUCCESS);
+        EXPECT_EQ(hipdnnBackendFinalize(*heuristicDescriptor), HIPDNN_STATUS_SUCCESS);
     }
 }
 
-TEST_F(Plugin_loading_tests, EmptyPluginPath)
+TEST_F(PluginLoadingTests, EmptyPluginPath)
 {
-    TempDirectory plugin_dir("empty_plugins");
-    auto plugin_path = plugin_dir.path().string();
-    const std::array<const char*, 1> paths = {plugin_path.c_str()};
+    TempDirectory pluginDir("empty_plugins");
+    auto pluginPath = pluginDir.path().string();
+    const std::array<const char*, 1> paths = {pluginPath.c_str()};
     ASSERT_EQ(
         hipdnnSetEnginePluginPaths_ext(paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
         HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
-    EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engine_config),
+    EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engineConfig),
               HIPDNN_STATUS_SUCCESS);
-    ASSERT_NE(_engine_config, nullptr);
+    ASSERT_NE(_engineConfig, nullptr);
 
-    test_util::create_test_graph(&_graph, _handle);
+    test_util::createTestGraph(&_graph, _handle);
     hipdnnBackendFinalize(_graph);
 
-    create_heuristic_descriptor(&_heuristic_descriptor, &_graph, true);
+    createHeuristicDescriptor(&_heuristicDescriptor, &_graph, true);
 
-    int64_t available_engine_count = -1;
-    EXPECT_EQ(hipdnnBackendGetAttribute(_heuristic_descriptor,
+    auto availableEngineCount = int64_t{-1};
+    EXPECT_EQ(hipdnnBackendGetAttribute(_heuristicDescriptor,
                                         HIPDNN_ATTR_ENGINEHEUR_RESULTS,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         0,
-                                        &available_engine_count,
+                                        &availableEngineCount,
                                         nullptr),
               HIPDNN_STATUS_SUCCESS);
 
-    EXPECT_EQ(available_engine_count, 0);
+    EXPECT_EQ(availableEngineCount, 0);
 }
 
-TEST_F(Plugin_loading_tests, NoPluginsSupportGraph)
+TEST_F(PluginLoadingTests, NoPluginsSupportGraph)
 {
     const std::array<const char*, 1> paths
         = {hipdnn_tests::plugin_constants::test_no_applicable_engines_plugin_path().c_str()};
@@ -126,28 +126,28 @@ TEST_F(Plugin_loading_tests, NoPluginsSupportGraph)
         HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
-    EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engine_config),
+    EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engineConfig),
               HIPDNN_STATUS_SUCCESS);
-    ASSERT_NE(_engine_config, nullptr);
+    ASSERT_NE(_engineConfig, nullptr);
 
-    test_util::create_test_graph(&_graph, _handle);
+    test_util::createTestGraph(&_graph, _handle);
     hipdnnBackendFinalize(_graph);
 
-    create_heuristic_descriptor(&_heuristic_descriptor, &_graph, true);
+    createHeuristicDescriptor(&_heuristicDescriptor, &_graph, true);
 
-    int64_t available_engine_count = -1;
-    EXPECT_EQ(hipdnnBackendGetAttribute(_heuristic_descriptor,
+    auto availableEngineCount = int64_t{-1};
+    EXPECT_EQ(hipdnnBackendGetAttribute(_heuristicDescriptor,
                                         HIPDNN_ATTR_ENGINEHEUR_RESULTS,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         0,
-                                        &available_engine_count,
+                                        &availableEngineCount,
                                         nullptr),
               HIPDNN_STATUS_SUCCESS);
 
-    EXPECT_EQ(available_engine_count, 0);
+    EXPECT_EQ(availableEngineCount, 0);
 }
 
-TEST_F(Plugin_loading_tests, IncorrectEngineID)
+TEST_F(PluginLoadingTests, IncorrectEngineID)
 {
     const std::array<const char*, 1> paths
         = {hipdnn_tests::plugin_constants::test_no_applicable_engines_plugin_path().c_str()};
@@ -156,27 +156,27 @@ TEST_F(Plugin_loading_tests, IncorrectEngineID)
         HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
-    EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engine_config),
+    EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engineConfig),
               HIPDNN_STATUS_SUCCESS);
-    ASSERT_NE(_engine_config, nullptr);
+    ASSERT_NE(_engineConfig, nullptr);
 
-    test_util::create_test_graph(&_graph, _handle);
+    test_util::createTestGraph(&_graph, _handle);
     hipdnnBackendFinalize(_graph);
 
-    test_util::create_test_engine(&_engine, &_graph, _handle, -193489);
+    test_util::createTestEngine(&_engine, &_graph, _handle, -193489);
 
     ASSERT_EQ(hipdnnBackendFinalize(_engine), HIPDNN_STATUS_BAD_PARAM);
 
-    constexpr size_t buffer_size = 512;
-    std::array<char, buffer_size> buffer;
-    hipdnnGetLastErrorString(buffer.data(), buffer_size);
+    constexpr size_t BUFFER_SIZE = 512;
+    std::array<char, BUFFER_SIZE> buffer;
+    hipdnnGetLastErrorString(buffer.data(), BUFFER_SIZE);
 
     ASSERT_EQ(
         std::string{buffer.data()},
         "EngineDescriptor::finalize() failed: Engine id is not in a valid range of engine IDs");
 }
 
-TEST_F(Plugin_loading_tests, DuplicateEngineIds)
+TEST_F(PluginLoadingTests, DuplicateEngineIds)
 {
     const std::array<const char*, 2> paths
         = {hipdnn_tests::plugin_constants::test_duplicate_id_a_plugin_path().c_str(),
@@ -189,10 +189,10 @@ TEST_F(Plugin_loading_tests, DuplicateEngineIds)
 
     // TODO: Warning is logged, but we don't have means of querying the last warning
 
-    EXPECT_EQ(test_util::get_loaded_plugins(_handle).size(), 1);
+    EXPECT_EQ(test_util::getLoadedPlugins(_handle).size(), 1);
 }
 
-TEST_F(Plugin_loading_tests, IncompleteAPI)
+TEST_F(PluginLoadingTests, IncompleteAPI)
 {
     using namespace hipdnn_sdk::utilities;
     using namespace hipdnn_tests::plugin_constants;
@@ -206,10 +206,10 @@ TEST_F(Plugin_loading_tests, IncompleteAPI)
 
     // TODO: Warning is logged, but we don't have means of querying the last warning
 
-    EXPECT_EQ(test_util::get_loaded_plugins(_handle).size(), 0);
+    EXPECT_EQ(test_util::getLoadedPlugins(_handle).size(), 0);
 }
 
-TEST_F(Plugin_loading_tests, MultiplePluginsOneApplicableEngine)
+TEST_F(PluginLoadingTests, MultiplePluginsOneApplicableEngine)
 {
     const std::array<const char*, 1> paths
         = {hipdnn_tests::plugin_constants::test_no_applicable_engines_plugin_path().c_str()};
@@ -218,28 +218,28 @@ TEST_F(Plugin_loading_tests, MultiplePluginsOneApplicableEngine)
         HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
-    EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engine_config),
+    EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engineConfig),
               HIPDNN_STATUS_SUCCESS);
-    ASSERT_NE(_engine_config, nullptr);
+    ASSERT_NE(_engineConfig, nullptr);
 
-    test_util::create_test_graph(&_graph, _handle);
+    test_util::createTestGraph(&_graph, _handle);
     hipdnnBackendFinalize(_graph);
 
-    create_heuristic_descriptor(&_heuristic_descriptor, &_graph, true);
+    createHeuristicDescriptor(&_heuristicDescriptor, &_graph, true);
 
-    int64_t available_engine_count = -1;
-    EXPECT_EQ(hipdnnBackendGetAttribute(_heuristic_descriptor,
+    auto availableEngineCount = int64_t{-1};
+    EXPECT_EQ(hipdnnBackendGetAttribute(_heuristicDescriptor,
                                         HIPDNN_ATTR_ENGINEHEUR_RESULTS,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         0,
-                                        &available_engine_count,
+                                        &availableEngineCount,
                                         nullptr),
               HIPDNN_STATUS_SUCCESS);
 
-    EXPECT_EQ(available_engine_count, 1);
+    EXPECT_EQ(availableEngineCount, 1);
 }
 
-TEST_F(Plugin_loading_tests, MultiplePluginsMultipleApplicableEngines)
+TEST_F(PluginLoadingTests, MultiplePluginsMultipleApplicableEngines)
 {
     const std::array<const char*, 1> paths
         = {hipdnn_tests::plugin_constants::test_good_plugin_path().c_str()};
@@ -248,23 +248,23 @@ TEST_F(Plugin_loading_tests, MultiplePluginsMultipleApplicableEngines)
         HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
-    EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engine_config),
+    EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engineConfig),
               HIPDNN_STATUS_SUCCESS);
-    ASSERT_NE(_engine_config, nullptr);
+    ASSERT_NE(_engineConfig, nullptr);
 
-    test_util::create_test_graph(&_graph, _handle);
+    test_util::createTestGraph(&_graph, _handle);
     hipdnnBackendFinalize(_graph);
 
-    create_heuristic_descriptor(&_heuristic_descriptor, &_graph, true);
+    createHeuristicDescriptor(&_heuristicDescriptor, &_graph, true);
 
-    int64_t available_engine_count = -1;
-    EXPECT_EQ(hipdnnBackendGetAttribute(_heuristic_descriptor,
+    auto availableEngineCount = int64_t{-1};
+    EXPECT_EQ(hipdnnBackendGetAttribute(_heuristicDescriptor,
                                         HIPDNN_ATTR_ENGINEHEUR_RESULTS,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         0,
-                                        &available_engine_count,
+                                        &availableEngineCount,
                                         nullptr),
               HIPDNN_STATUS_SUCCESS);
 
-    EXPECT_EQ(available_engine_count, 2);
+    EXPECT_EQ(availableEngineCount, 2);
 }

--- a/tests/backend/test_util.cpp
+++ b/tests/backend/test_util.cpp
@@ -13,16 +13,16 @@
 namespace test_util
 {
 
-void create_test_handle(hipdnnHandle_t* handle)
+void createTestHandle(hipdnnHandle_t* handle)
 {
     ASSERT_EQ(hipdnnCreate(handle), HIPDNN_STATUS_SUCCESS);
 }
 
-void create_test_graph(hipdnnBackendDescriptor_t* descriptor, hipdnnHandle_t handle)
+void createTestGraph(hipdnnBackendDescriptor_t* descriptor, hipdnnHandle_t handle)
 {
     flatbuffers::FlatBufferBuilder builder;
     std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::TensorAttributes>>
-        tensor_attributes;
+        tensorAttributes;
     std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::Node>> nodes;
     auto graph
         = hipdnn_sdk::data_objects::CreateGraphDirect(builder,
@@ -30,13 +30,13 @@ void create_test_graph(hipdnnBackendDescriptor_t* descriptor, hipdnnHandle_t han
                                                       hipdnn_sdk::data_objects::DataType_FLOAT,
                                                       hipdnn_sdk::data_objects::DataType_FLOAT,
                                                       hipdnn_sdk::data_objects::DataType_FLOAT,
-                                                      &tensor_attributes,
+                                                      &tensorAttributes,
                                                       &nodes);
     builder.Finish(graph);
-    flatbuffers::DetachedBuffer serialized_graph = builder.Release();
+    flatbuffers::DetachedBuffer serializedGraph = builder.Release();
 
     ASSERT_EQ(hipdnnBackendCreateAndDeserializeGraph_ext(
-                  descriptor, serialized_graph.data(), serialized_graph.size()),
+                  descriptor, serializedGraph.data(), serializedGraph.size()),
               HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnBackendSetAttribute(
@@ -44,15 +44,15 @@ void create_test_graph(hipdnnBackendDescriptor_t* descriptor, hipdnnHandle_t han
               HIPDNN_STATUS_SUCCESS);
 }
 
-void populate_test_engine(hipdnnBackendDescriptor_t engine,
-                          hipdnnBackendDescriptor_t* graph,
-                          hipdnnHandle_t handle,
-                          int64_t gidx,
-                          bool finalize)
+void populateTestEngine(hipdnnBackendDescriptor_t engine,
+                        hipdnnBackendDescriptor_t* graph,
+                        hipdnnHandle_t handle,
+                        int64_t gidx,
+                        bool finalize)
 {
     if(*graph == nullptr)
     {
-        create_test_graph(graph, handle);
+        createTestGraph(graph, handle);
     }
 
     ASSERT_EQ(hipdnnBackendFinalize(*graph), HIPDNN_STATUS_SUCCESS);
@@ -70,30 +70,30 @@ void populate_test_engine(hipdnnBackendDescriptor_t engine,
     }
 }
 
-void create_test_engine(hipdnnBackendDescriptor_t* engine,
-                        hipdnnBackendDescriptor_t* graph,
-                        hipdnnHandle_t handle,
-                        int64_t gidx,
-                        bool finalize)
+void createTestEngine(hipdnnBackendDescriptor_t* engine,
+                      hipdnnBackendDescriptor_t* graph,
+                      hipdnnHandle_t handle,
+                      int64_t gidx,
+                      bool finalize)
 {
     ASSERT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINE_DESCRIPTOR, engine),
               HIPDNN_STATUS_SUCCESS);
-    populate_test_engine(*engine, graph, handle, gidx, finalize);
+    populateTestEngine(*engine, graph, handle, gidx, finalize);
 }
 
-void populate_test_engine_config(hipdnnBackendDescriptor_t* engine_config,
-                                 hipdnnBackendDescriptor_t* engine,
-                                 hipdnnBackendDescriptor_t* graph,
-                                 hipdnnHandle_t handle,
-                                 int64_t gidx,
-                                 bool finalize)
+void populateTestEngineConfig(hipdnnBackendDescriptor_t* engineConfig,
+                              hipdnnBackendDescriptor_t* engine,
+                              hipdnnBackendDescriptor_t* graph,
+                              hipdnnHandle_t handle,
+                              int64_t gidx,
+                              bool finalize)
 {
     if(*engine == nullptr)
     {
-        create_test_engine(engine, graph, handle, gidx, true);
+        createTestEngine(engine, graph, handle, gidx, true);
     }
 
-    ASSERT_EQ(hipdnnBackendSetAttribute(*engine_config,
+    ASSERT_EQ(hipdnnBackendSetAttribute(*engineConfig,
                                         HIPDNN_ATTR_ENGINECFG_ENGINE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
@@ -102,57 +102,57 @@ void populate_test_engine_config(hipdnnBackendDescriptor_t* engine_config,
 
     if(finalize)
     {
-        ASSERT_EQ(hipdnnBackendFinalize(*engine_config), HIPDNN_STATUS_SUCCESS);
+        ASSERT_EQ(hipdnnBackendFinalize(*engineConfig), HIPDNN_STATUS_SUCCESS);
     }
 }
 
-void create_test_engine_config(hipdnnBackendDescriptor_t* engine_config,
+void createTestEngineConfig(hipdnnBackendDescriptor_t* engineConfig,
+                            hipdnnBackendDescriptor_t* engine,
+                            hipdnnBackendDescriptor_t* graph,
+                            hipdnnHandle_t handle,
+                            int64_t gidx,
+                            bool finalize)
+{
+    ASSERT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, engineConfig),
+              HIPDNN_STATUS_SUCCESS);
+    populateTestEngineConfig(engineConfig, engine, graph, handle, gidx, finalize);
+}
+
+void populateTestExecutionPlan(hipdnnBackendDescriptor_t* executionPlan,
+                               hipdnnBackendDescriptor_t* engineConfig,
                                hipdnnBackendDescriptor_t* engine,
                                hipdnnBackendDescriptor_t* graph,
                                hipdnnHandle_t handle,
                                int64_t gidx,
                                bool finalize)
 {
-    ASSERT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, engine_config),
-              HIPDNN_STATUS_SUCCESS);
-    populate_test_engine_config(engine_config, engine, graph, handle, gidx, finalize);
-}
-
-void populate_test_execution_plan(hipdnnBackendDescriptor_t* execution_plan,
-                                  hipdnnBackendDescriptor_t* engine_config,
-                                  hipdnnBackendDescriptor_t* engine,
-                                  hipdnnBackendDescriptor_t* graph,
-                                  hipdnnHandle_t handle,
-                                  int64_t gidx,
-                                  bool finalize)
-{
     ASSERT_EQ(
         hipdnnBackendSetAttribute(
-            *execution_plan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+            *executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
         HIPDNN_STATUS_SUCCESS);
 
-    if(*engine_config == nullptr)
+    if(*engineConfig == nullptr)
     {
-        create_test_engine_config(engine_config, engine, graph, handle, gidx, true);
+        createTestEngineConfig(engineConfig, engine, graph, handle, gidx, true);
     }
 
-    ASSERT_EQ(hipdnnBackendSetAttribute(*execution_plan,
+    ASSERT_EQ(hipdnnBackendSetAttribute(*executionPlan,
                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        engine_config),
+                                        engineConfig),
               HIPDNN_STATUS_SUCCESS);
 
     if(finalize)
     {
-        ASSERT_EQ(hipdnnBackendFinalize(*execution_plan), HIPDNN_STATUS_SUCCESS);
+        ASSERT_EQ(hipdnnBackendFinalize(*executionPlan), HIPDNN_STATUS_SUCCESS);
     }
 }
 
-void* allocate_tensor_memory([[maybe_unused]] const int64_t* dims,
-                             [[maybe_unused]] size_t dims_count,
-                             [[maybe_unused]] hipdnnBackendAttributeType_t data_type,
-                             [[maybe_unused]] bool initialize)
+void* allocateTensorMemory([[maybe_unused]] const int64_t* dims,
+                           [[maybe_unused]] size_t dimsCount,
+                           [[maybe_unused]] hipdnnBackendAttributeType_t dataType,
+                           [[maybe_unused]] bool initialize)
 {
     // TODO: Implement memory allocation logic based on the data type and dimensions
     // For now, just return a dummy pointer
@@ -160,38 +160,38 @@ void* allocate_tensor_memory([[maybe_unused]] const int64_t* dims,
     return memory;
 }
 
-void free_tensor_memory(void* data_ptr)
+void freeTensorMemory(void* dataPtr)
 {
-    if(data_ptr != nullptr)
+    if(dataPtr != nullptr)
     {
-        free(data_ptr);
+        free(dataPtr);
     }
 }
 
-void set_tensor_mappings_in_variant_pack(hipdnnBackendDescriptor_t variant_pack,
-                                         const std::vector<int64_t>& tensor_ids,
-                                         const std::vector<void*>& data_ptrs)
+void setTensorMappingsInVariantPack(hipdnnBackendDescriptor_t variantPack,
+                                    const std::vector<int64_t>& tensorIds,
+                                    const std::vector<void*>& dataPtrs)
 {
-    ASSERT_EQ(hipdnnBackendSetAttribute(variant_pack,
+    ASSERT_EQ(hipdnnBackendSetAttribute(variantPack,
                                         HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
                                         HIPDNN_TYPE_INT64,
-                                        static_cast<int64_t>(tensor_ids.size()),
-                                        tensor_ids.data()),
+                                        static_cast<int64_t>(tensorIds.size()),
+                                        tensorIds.data()),
               HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(hipdnnBackendSetAttribute(variant_pack,
+    ASSERT_EQ(hipdnnBackendSetAttribute(variantPack,
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_VOID_PTR,
-                                        static_cast<int64_t>(data_ptrs.size()),
-                                        data_ptrs.data()),
+                                        static_cast<int64_t>(dataPtrs.size()),
+                                        dataPtrs.data()),
               HIPDNN_STATUS_SUCCESS);
 }
 
-void set_workspace_in_variant_pack(hipdnnBackendDescriptor_t variant_pack, void* workspace)
+void setWorkspaceInVariantPack(hipdnnBackendDescriptor_t variantPack, void* workspace)
 {
     if(workspace != nullptr)
     {
-        ASSERT_EQ(hipdnnBackendSetAttribute(variant_pack,
+        ASSERT_EQ(hipdnnBackendSetAttribute(variantPack,
                                             HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
                                             HIPDNN_TYPE_VOID_PTR,
                                             1,
@@ -200,144 +200,144 @@ void set_workspace_in_variant_pack(hipdnnBackendDescriptor_t variant_pack, void*
     }
 }
 
-void finalize_variant_pack(hipdnnBackendDescriptor_t variant_pack)
+void finalizeVariantPack(hipdnnBackendDescriptor_t variantPack)
 {
-    ASSERT_EQ(hipdnnBackendFinalize(variant_pack), HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendFinalize(variantPack), HIPDNN_STATUS_SUCCESS);
 }
 
-void extract_tensor_mappings(const std::unordered_map<int64_t, void*>& data_ptr_mappings,
-                             std::vector<int64_t>& tensor_ids,
-                             std::vector<void*>& data_ptrs)
+void extractTensorMappings(const std::unordered_map<int64_t, void*>& dataPtrMappings,
+                           std::vector<int64_t>& tensorIds,
+                           std::vector<void*>& dataPtrs)
 {
-    for(const auto& [id, data_ptr] : data_ptr_mappings)
+    for(const auto& [id, dataPtr] : dataPtrMappings)
     {
-        ASSERT_NE(data_ptr, nullptr);
-        tensor_ids.push_back(id);
-        data_ptrs.push_back(data_ptr);
+        ASSERT_NE(dataPtr, nullptr);
+        tensorIds.push_back(id);
+        dataPtrs.push_back(dataPtr);
     }
-    ASSERT_EQ(tensor_ids.size(), data_ptrs.size());
-    ASSERT_FALSE(tensor_ids.empty());
-    ASSERT_FALSE(data_ptrs.empty());
+    ASSERT_EQ(tensorIds.size(), dataPtrs.size());
+    ASSERT_FALSE(tensorIds.empty());
+    ASSERT_FALSE(dataPtrs.empty());
 }
 
-void populate_variant_pack_with_mappings(
-    hipdnnBackendDescriptor_t variant_pack,
-    const std::unordered_map<int64_t, void*>& data_ptr_mappings,
+void populateVariantPackWithMappings(
+    hipdnnBackendDescriptor_t variantPack,
+    const std::unordered_map<int64_t, void*>& dataPtrMappings,
     void* workspace)
 {
-    std::vector<int64_t> tensor_ids;
-    std::vector<void*> data_ptrs;
+    std::vector<int64_t> tensorIds;
+    std::vector<void*> dataPtrs;
 
-    extract_tensor_mappings(data_ptr_mappings, tensor_ids, data_ptrs);
-    set_tensor_mappings_in_variant_pack(variant_pack, tensor_ids, data_ptrs);
-    set_workspace_in_variant_pack(variant_pack, workspace);
-    finalize_variant_pack(variant_pack);
+    extractTensorMappings(dataPtrMappings, tensorIds, dataPtrs);
+    setTensorMappingsInVariantPack(variantPack, tensorIds, dataPtrs);
+    setWorkspaceInVariantPack(variantPack, workspace);
+    finalizeVariantPack(variantPack);
 }
 
-void create_and_initialize_backend_descriptor(hipdnnBackendDescriptor_t* backend_descriptor,
-                                              const flatbuffers::DetachedBuffer& serialized_graph,
-                                              hipdnnHandle_t handle)
+void createAndInitializeBackendDescriptor(hipdnnBackendDescriptor_t* backendDescriptor,
+                                          const flatbuffers::DetachedBuffer& serializedGraph,
+                                          hipdnnHandle_t handle)
 {
-    ASSERT_EQ(*backend_descriptor, nullptr);
+    ASSERT_EQ(*backendDescriptor, nullptr);
 
     auto status = hipdnnBackendCreateAndDeserializeGraph_ext(
-        backend_descriptor, serialized_graph.data(), serialized_graph.size());
+        backendDescriptor, serializedGraph.data(), serializedGraph.size());
     ASSERT_EQ(status, HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(
         hipdnnBackendSetAttribute(
-            *backend_descriptor, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+            *backendDescriptor, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
         HIPDNN_STATUS_SUCCESS);
 
-    status = hipdnnBackendFinalize(*backend_descriptor);
+    status = hipdnnBackendFinalize(*backendDescriptor);
     ASSERT_EQ(status, HIPDNN_STATUS_SUCCESS);
 }
 
-flatbuffers::FlatBufferBuilder create_and_populate_batchnorm_node()
+flatbuffers::FlatBufferBuilder createAndPopulateBatchnormNode()
 {
     return flatbuffer_test_utils::createValidBatchnormGraph();
 }
 
-void extract_tensor_info_from_graph(
-    const flatbuffers::DetachedBuffer& serialized_graph,
-    std::unordered_map<int64_t, std::string>& uid_to_name_map,
-    std::unordered_map<std::string, int64_t>& name_to_uid_map,
-    std::unordered_map<int64_t, std::vector<int64_t>>& uid_to_dims_map)
+void extractTensorInfoFromGraph(
+    const flatbuffers::DetachedBuffer& serializedGraph,
+    std::unordered_map<int64_t, std::string>& uidToNameMap,
+    std::unordered_map<std::string, int64_t>& nameToUidMap,
+    std::unordered_map<int64_t, std::vector<int64_t>>& uidToDimsMap)
 {
-    uid_to_name_map.clear();
-    name_to_uid_map.clear();
-    uid_to_dims_map.clear();
+    uidToNameMap.clear();
+    nameToUidMap.clear();
+    uidToDimsMap.clear();
 
-    auto deserialized_graph = hipdnn_sdk::data_objects::UnPackGraph(serialized_graph.data());
-    ASSERT_NE(deserialized_graph, nullptr);
+    auto deserializedGraph = hipdnn_sdk::data_objects::UnPackGraph(serializedGraph.data());
+    ASSERT_NE(deserializedGraph, nullptr);
 
     // Extract all tensor information from the deserialized graph
-    for(const auto& tensor : deserialized_graph->tensors)
+    for(const auto& tensor : deserializedGraph->tensors)
     {
         int64_t uid = tensor->uid;
         std::string name = tensor->name;
 
-        uid_to_name_map[uid] = name;
-        name_to_uid_map[name] = uid;
+        uidToNameMap[uid] = name;
+        nameToUidMap[name] = uid;
 
         if(!tensor->dims.empty())
         {
-            uid_to_dims_map[uid] = tensor->dims;
+            uidToDimsMap[uid] = tensor->dims;
         }
     }
 
-    ASSERT_FALSE(uid_to_name_map.empty());
+    ASSERT_FALSE(uidToNameMap.empty());
 }
 
-std::vector<std::string> get_loaded_plugins(hipdnnHandle_t handle)
+std::vector<std::string> getLoadedPlugins(hipdnnHandle_t handle)
 {
-    size_t num_plugins = 0;
-    size_t max_path_length = 0;
+    size_t numPlugins = 0;
+    size_t maxPathLength = 0;
     auto status
-        = hipdnnGetLoadedEnginePluginPaths_ext(handle, &num_plugins, nullptr, &max_path_length);
+        = hipdnnGetLoadedEnginePluginPaths_ext(handle, &numPlugins, nullptr, &maxPathLength);
 
     if(status != HIPDNN_STATUS_SUCCESS)
     {
         throw std::runtime_error("Failed to get loaded plugin paths");
     }
 
-    if(num_plugins == 0)
+    if(numPlugins == 0)
     {
         return {};
     }
 
-    std::vector<std::vector<char>> path_buffers(num_plugins, std::vector<char>(max_path_length));
-    std::vector<char*> plugin_paths_c(num_plugins);
-    for(size_t i = 0; i < num_plugins; ++i)
+    std::vector<std::vector<char>> pathBuffers(numPlugins, std::vector<char>(maxPathLength));
+    std::vector<char*> pluginPathsC(numPlugins);
+    for(size_t i = 0; i < numPlugins; ++i)
     {
-        plugin_paths_c[i] = path_buffers[i].data();
+        pluginPathsC[i] = pathBuffers[i].data();
     }
 
     status = hipdnnGetLoadedEnginePluginPaths_ext(
-        handle, &num_plugins, plugin_paths_c.data(), &max_path_length);
+        handle, &numPlugins, pluginPathsC.data(), &maxPathLength);
     if(status != HIPDNN_STATUS_SUCCESS)
     {
         throw std::runtime_error("Failed to get loaded plugin paths");
     }
 
-    std::vector<std::string> plugin_paths;
-    plugin_paths.reserve(num_plugins);
-    for(size_t i = 0; i < num_plugins; ++i)
+    std::vector<std::string> pluginPaths;
+    pluginPaths.reserve(numPlugins);
+    for(size_t i = 0; i < numPlugins; ++i)
     {
-        plugin_paths.emplace_back(plugin_paths_c[i]);
+        pluginPaths.emplace_back(pluginPathsC[i]);
     }
-    return plugin_paths;
+    return pluginPaths;
 }
 
-bool is_plugin_loaded(const std::vector<std::string>& loaded_plugins,
-                      const std::string& plugin_name)
+bool isPluginLoaded(const std::vector<std::string>& loadedPlugins,
+                    const std::string& pluginName)
 {
     namespace fs = std::filesystem;
 
-    return std::ranges::any_of(loaded_plugins, [&](const std::string& loaded_path_str) {
+    return std::ranges::any_of(loadedPlugins, [&](const std::string& loadedPathStr) {
         try
         {
-            return fs::canonical(loaded_path_str) == fs::canonical(plugin_name);
+            return fs::canonical(loadedPathStr) == fs::canonical(pluginName);
         }
         catch(const fs::filesystem_error&)
         {

--- a/tests/backend/test_util.cpp
+++ b/tests/backend/test_util.cpp
@@ -21,8 +21,7 @@ void createTestHandle(hipdnnHandle_t* handle)
 void createTestGraph(hipdnnBackendDescriptor_t* descriptor, hipdnnHandle_t handle)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::TensorAttributes>>
-        tensorAttributes;
+    std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::TensorAttributes>> tensorAttributes;
     std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::Node>> nodes;
     auto graph
         = hipdnn_sdk::data_objects::CreateGraphDirect(builder,
@@ -93,12 +92,10 @@ void populateTestEngineConfig(hipdnnBackendDescriptor_t* engineConfig,
         createTestEngine(engine, graph, handle, gidx, true);
     }
 
-    ASSERT_EQ(hipdnnBackendSetAttribute(*engineConfig,
-                                        HIPDNN_ATTR_ENGINECFG_ENGINE,
-                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                        1,
-                                        engine),
-              HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(
+        hipdnnBackendSetAttribute(
+            *engineConfig, HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, engine),
+        HIPDNN_STATUS_SUCCESS);
 
     if(finalize)
     {
@@ -220,10 +217,9 @@ void extractTensorMappings(const std::unordered_map<int64_t, void*>& dataPtrMapp
     ASSERT_FALSE(dataPtrs.empty());
 }
 
-void populateVariantPackWithMappings(
-    hipdnnBackendDescriptor_t variantPack,
-    const std::unordered_map<int64_t, void*>& dataPtrMappings,
-    void* workspace)
+void populateVariantPackWithMappings(hipdnnBackendDescriptor_t variantPack,
+                                     const std::unordered_map<int64_t, void*>& dataPtrMappings,
+                                     void* workspace)
 {
     std::vector<int64_t> tensorIds;
     std::vector<void*> dataPtrs;
@@ -258,11 +254,10 @@ flatbuffers::FlatBufferBuilder createAndPopulateBatchnormNode()
     return flatbuffer_test_utils::createValidBatchnormGraph();
 }
 
-void extractTensorInfoFromGraph(
-    const flatbuffers::DetachedBuffer& serializedGraph,
-    std::unordered_map<int64_t, std::string>& uidToNameMap,
-    std::unordered_map<std::string, int64_t>& nameToUidMap,
-    std::unordered_map<int64_t, std::vector<int64_t>>& uidToDimsMap)
+void extractTensorInfoFromGraph(const flatbuffers::DetachedBuffer& serializedGraph,
+                                std::unordered_map<int64_t, std::string>& uidToNameMap,
+                                std::unordered_map<std::string, int64_t>& nameToUidMap,
+                                std::unordered_map<int64_t, std::vector<int64_t>>& uidToDimsMap)
 {
     uidToNameMap.clear();
     nameToUidMap.clear();
@@ -329,8 +324,7 @@ std::vector<std::string> getLoadedPlugins(hipdnnHandle_t handle)
     return pluginPaths;
 }
 
-bool isPluginLoaded(const std::vector<std::string>& loadedPlugins,
-                    const std::string& pluginName)
+bool isPluginLoaded(const std::vector<std::string>& loadedPlugins, const std::string& pluginName)
 {
     namespace fs = std::filesystem;
 

--- a/tests/backend/test_util.hpp
+++ b/tests/backend/test_util.hpp
@@ -56,24 +56,21 @@ void* allocateTensorMemory([[maybe_unused]] const int64_t* dims,
 
 void freeTensorMemory(void* dataPtr);
 
-void populateVariantPackWithMappings(
-    hipdnnBackendDescriptor_t variantPack,
-    const std::unordered_map<int64_t, void*>& dataPtrMappings,
-    void* workspace = nullptr);
+void populateVariantPackWithMappings(hipdnnBackendDescriptor_t variantPack,
+                                     const std::unordered_map<int64_t, void*>& dataPtrMappings,
+                                     void* workspace = nullptr);
 
 void createAndInitializeBackendDescriptor(hipdnnBackendDescriptor_t* backendDescriptor,
                                           const flatbuffers::DetachedBuffer& serializedGraph,
                                           hipdnnHandle_t handle);
 
-void extractTensorInfoFromGraph(
-    const flatbuffers::DetachedBuffer& serializedGraph,
-    std::unordered_map<int64_t, std::string>& uidToNameMap,
-    std::unordered_map<std::string, int64_t>& nameToUidMap,
-    std::unordered_map<int64_t, std::vector<int64_t>>& uidToDimsMap);
+void extractTensorInfoFromGraph(const flatbuffers::DetachedBuffer& serializedGraph,
+                                std::unordered_map<int64_t, std::string>& uidToNameMap,
+                                std::unordered_map<std::string, int64_t>& nameToUidMap,
+                                std::unordered_map<int64_t, std::vector<int64_t>>& uidToDimsMap);
 
 std::vector<std::string> getLoadedPlugins(hipdnnHandle_t handle);
 
-bool isPluginLoaded(const std::vector<std::string>& loadedPlugins,
-                    const std::string& pluginName);
+bool isPluginLoaded(const std::vector<std::string>& loadedPlugins, const std::string& pluginName);
 
 } // namespace test_util

--- a/tests/backend/test_util.hpp
+++ b/tests/backend/test_util.hpp
@@ -9,71 +9,71 @@
 namespace test_util
 {
 
-void create_test_handle(hipdnnHandle_t* handle);
+void createTestHandle(hipdnnHandle_t* handle);
 
-void create_test_graph(hipdnnBackendDescriptor_t* descriptor, hipdnnHandle_t handle);
+void createTestGraph(hipdnnBackendDescriptor_t* descriptor, hipdnnHandle_t handle);
 
-void populate_test_engine(hipdnnBackendDescriptor_t engine,
-                          hipdnnBackendDescriptor_t* graph,
-                          hipdnnHandle_t handle,
-                          int64_t gidx,
-                          bool finalize = false);
-
-void create_test_engine(hipdnnBackendDescriptor_t* engine,
+void populateTestEngine(hipdnnBackendDescriptor_t engine,
                         hipdnnBackendDescriptor_t* graph,
                         hipdnnHandle_t handle,
                         int64_t gidx,
                         bool finalize = false);
 
-void populate_test_engine_config(hipdnnBackendDescriptor_t* engine_config,
-                                 hipdnnBackendDescriptor_t* engine,
-                                 hipdnnBackendDescriptor_t* graph,
-                                 hipdnnHandle_t handle,
-                                 int64_t gidx,
-                                 bool finalize = false);
+void createTestEngine(hipdnnBackendDescriptor_t* engine,
+                      hipdnnBackendDescriptor_t* graph,
+                      hipdnnHandle_t handle,
+                      int64_t gidx,
+                      bool finalize = false);
 
-void create_test_engine_config(hipdnnBackendDescriptor_t* engine_config,
+void populateTestEngineConfig(hipdnnBackendDescriptor_t* engineConfig,
+                              hipdnnBackendDescriptor_t* engine,
+                              hipdnnBackendDescriptor_t* graph,
+                              hipdnnHandle_t handle,
+                              int64_t gidx,
+                              bool finalize = false);
+
+void createTestEngineConfig(hipdnnBackendDescriptor_t* engineConfig,
+                            hipdnnBackendDescriptor_t* engine,
+                            hipdnnBackendDescriptor_t* graph,
+                            hipdnnHandle_t handle,
+                            int64_t gidx,
+                            bool finalize = false);
+
+void populateTestExecutionPlan(hipdnnBackendDescriptor_t* executionPlan,
+                               hipdnnBackendDescriptor_t* engineConfig,
                                hipdnnBackendDescriptor_t* engine,
                                hipdnnBackendDescriptor_t* graph,
                                hipdnnHandle_t handle,
                                int64_t gidx,
                                bool finalize = false);
 
-void populate_test_execution_plan(hipdnnBackendDescriptor_t* execution_plan,
-                                  hipdnnBackendDescriptor_t* engine_config,
-                                  hipdnnBackendDescriptor_t* engine,
-                                  hipdnnBackendDescriptor_t* graph,
-                                  hipdnnHandle_t handle,
-                                  int64_t gidx,
-                                  bool finalize = false);
+flatbuffers::FlatBufferBuilder createAndPopulateBatchnormNode();
 
-flatbuffers::FlatBufferBuilder create_and_populate_batchnorm_node();
+void* allocateTensorMemory([[maybe_unused]] const int64_t* dims,
+                           [[maybe_unused]] size_t dimsCount,
+                           [[maybe_unused]] hipdnnBackendAttributeType_t dataType,
+                           [[maybe_unused]] bool initialize);
 
-void* allocate_tensor_memory([[maybe_unused]] const int64_t* dims,
-                             [[maybe_unused]] size_t dims_count,
-                             [[maybe_unused]] hipdnnBackendAttributeType_t data_type,
-                             [[maybe_unused]] bool initialize);
+void freeTensorMemory(void* dataPtr);
 
-void free_tensor_memory(void* data_ptr);
-
-void populate_variant_pack_with_mappings(
-    hipdnnBackendDescriptor_t variant_pack,
-    const std::unordered_map<int64_t, void*>& data_ptr_mappings,
+void populateVariantPackWithMappings(
+    hipdnnBackendDescriptor_t variantPack,
+    const std::unordered_map<int64_t, void*>& dataPtrMappings,
     void* workspace = nullptr);
 
-void create_and_initialize_backend_descriptor(hipdnnBackendDescriptor_t* backend_descriptor,
-                                              const flatbuffers::DetachedBuffer& serialized_graph,
-                                              hipdnnHandle_t handle);
+void createAndInitializeBackendDescriptor(hipdnnBackendDescriptor_t* backendDescriptor,
+                                          const flatbuffers::DetachedBuffer& serializedGraph,
+                                          hipdnnHandle_t handle);
 
-void extract_tensor_info_from_graph(
-    const flatbuffers::DetachedBuffer& serialized_graph,
-    std::unordered_map<int64_t, std::string>& uid_to_name_map,
-    std::unordered_map<std::string, int64_t>& name_to_uid_map,
-    std::unordered_map<int64_t, std::vector<int64_t>>& uid_to_dims_map);
+void extractTensorInfoFromGraph(
+    const flatbuffers::DetachedBuffer& serializedGraph,
+    std::unordered_map<int64_t, std::string>& uidToNameMap,
+    std::unordered_map<std::string, int64_t>& nameToUidMap,
+    std::unordered_map<int64_t, std::vector<int64_t>>& uidToDimsMap);
 
-std::vector<std::string> get_loaded_plugins(hipdnnHandle_t handle);
+std::vector<std::string> getLoadedPlugins(hipdnnHandle_t handle);
 
-bool is_plugin_loaded(const std::vector<std::string>& loaded_plugins,
-                      const std::string& plugin_name);
+bool isPluginLoaded(const std::vector<std::string>& loadedPlugins,
+                    const std::string& pluginName);
 
 } // namespace test_util

--- a/tests/backend/test_variant_pack_api.cpp
+++ b/tests/backend/test_variant_pack_api.cpp
@@ -90,12 +90,10 @@ TEST_F(VariantPackDescriptorApiTests, InvalidSetAttributes)
     void* workspace = reinterpret_cast<void*>(0xdeadbeef);
 
     // HIPDNN_STATUS_BAD_PARAM since HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS expects HIPDNN_TYPE_VOID_PTR
-    EXPECT_EQ(hipdnnBackendSetAttribute(_varpack,
-                                        HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                                        HIPDNN_TYPE_INT64,
-                                        3,
-                                        devPtrs.data()),
-              HIPDNN_STATUS_BAD_PARAM);
+    EXPECT_EQ(
+        hipdnnBackendSetAttribute(
+            _varpack, HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS, HIPDNN_TYPE_INT64, 3, devPtrs.data()),
+        HIPDNN_STATUS_BAD_PARAM);
 
     // HIPDNN_STATUS_BAD_PARAM since HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS expects HIPDNN_TYPE_INT64
     EXPECT_EQ(
@@ -237,8 +235,7 @@ TEST_F(FinalizedVariantPackDescriptorApiTests, ValidGetAttributes)
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(elementCount, 3);
     EXPECT_EQ(
-        std::memcmp(retrievedDevPtrs.data(), _devPtrs.data(), _devPtrs.size() * sizeof(void*)),
-        0);
+        std::memcmp(retrievedDevPtrs.data(), _devPtrs.data(), _devPtrs.size() * sizeof(void*)), 0);
 
     EXPECT_EQ(hipdnnBackendGetAttribute(_varpack,
                                         HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,

--- a/tests/backend/test_variant_pack_api.cpp
+++ b/tests/backend/test_variant_pack_api.cpp
@@ -5,7 +5,7 @@
 #include <cstring>
 #include <gtest/gtest.h>
 
-class Variant_pack_descriptor_api_tests : public ::testing::Test
+class VariantPackDescriptorApiTests : public ::testing::Test
 {
 protected:
     hipdnnBackendDescriptor_t _varpack;
@@ -23,11 +23,11 @@ protected:
     }
 };
 
-TEST_F(Variant_pack_descriptor_api_tests, ValidSetAttributesAndFinalize)
+TEST_F(VariantPackDescriptorApiTests, ValidSetAttributesAndFinalize)
 {
-    std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
-                                     reinterpret_cast<void*>(0x5678),
-                                     reinterpret_cast<void*>(0x9abc)};
+    std::array<void*, 3> devPtrs = {reinterpret_cast<void*>(0x1234),
+                                    reinterpret_cast<void*>(0x5678),
+                                    reinterpret_cast<void*>(0x9abc)};
     std::array<int64_t, 3> uids = {1, 2, 3};
     void* workspace = reinterpret_cast<void*>(0xdeadbeef);
 
@@ -35,7 +35,7 @@ TEST_F(Variant_pack_descriptor_api_tests, ValidSetAttributesAndFinalize)
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_VOID_PTR,
                                         3,
-                                        dev_ptrs.data()),
+                                        devPtrs.data()),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(hipdnnBackendSetAttribute(
                   _varpack, HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, 3, uids.data()),
@@ -47,11 +47,11 @@ TEST_F(Variant_pack_descriptor_api_tests, ValidSetAttributesAndFinalize)
     EXPECT_EQ(hipdnnBackendFinalize(_varpack), HIPDNN_STATUS_SUCCESS);
 }
 
-TEST_F(Variant_pack_descriptor_api_tests, ValidSetAttributesAndGetAttributesBeforeFinalize)
+TEST_F(VariantPackDescriptorApiTests, ValidSetAttributesAndGetAttributesBeforeFinalize)
 {
-    std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
-                                     reinterpret_cast<void*>(0x5678),
-                                     reinterpret_cast<void*>(0x9abc)};
+    std::array<void*, 3> devPtrs = {reinterpret_cast<void*>(0x1234),
+                                    reinterpret_cast<void*>(0x5678),
+                                    reinterpret_cast<void*>(0x9abc)};
     std::array<int64_t, 3> uids = {1, 2, 3};
     void* workspace = reinterpret_cast<void*>(0xdeadbeef);
 
@@ -59,7 +59,7 @@ TEST_F(Variant_pack_descriptor_api_tests, ValidSetAttributesAndGetAttributesBefo
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_VOID_PTR,
                                         3,
-                                        dev_ptrs.data()),
+                                        devPtrs.data()),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(hipdnnBackendSetAttribute(
                   _varpack, HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, 3, uids.data()),
@@ -69,23 +69,23 @@ TEST_F(Variant_pack_descriptor_api_tests, ValidSetAttributesAndGetAttributesBefo
             _varpack, HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace),
         HIPDNN_STATUS_SUCCESS);
 
-    std::array<void*, 3> retrieved_dev_ptrs;
-    int64_t element_count = 0;
+    std::array<void*, 3> retrievedDevPtrs;
+    int64_t elementCount = 0;
 
     EXPECT_EQ(hipdnnBackendGetAttribute(_varpack,
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_INT64,
                                         3,
-                                        &element_count,
-                                        retrieved_dev_ptrs.data()),
+                                        &elementCount,
+                                        retrievedDevPtrs.data()),
               HIPDNN_STATUS_NOT_INITIALIZED);
 }
 
-TEST_F(Variant_pack_descriptor_api_tests, InvalidSetAttributes)
+TEST_F(VariantPackDescriptorApiTests, InvalidSetAttributes)
 {
-    std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
-                                     reinterpret_cast<void*>(0x5678),
-                                     reinterpret_cast<void*>(0x9abc)};
+    std::array<void*, 3> devPtrs = {reinterpret_cast<void*>(0x1234),
+                                    reinterpret_cast<void*>(0x5678),
+                                    reinterpret_cast<void*>(0x9abc)};
     std::array<int64_t, 3> uids = {1, 2, 3};
     void* workspace = reinterpret_cast<void*>(0xdeadbeef);
 
@@ -94,7 +94,7 @@ TEST_F(Variant_pack_descriptor_api_tests, InvalidSetAttributes)
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_INT64,
                                         3,
-                                        dev_ptrs.data()),
+                                        devPtrs.data()),
               HIPDNN_STATUS_BAD_PARAM);
 
     // HIPDNN_STATUS_BAD_PARAM since HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS expects HIPDNN_TYPE_INT64
@@ -116,39 +116,39 @@ TEST_F(Variant_pack_descriptor_api_tests, InvalidSetAttributes)
         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST_F(Variant_pack_descriptor_api_tests, InvalidGetAttributes)
+TEST_F(VariantPackDescriptorApiTests, InvalidGetAttributes)
 {
-    std::array<void*, 3> retrieved_dev_ptrs;
-    int64_t element_count = 0;
+    std::array<void*, 3> retrievedDevPtrs;
+    int64_t elementCount = 0;
 
     EXPECT_EQ(hipdnnBackendGetAttribute(_varpack,
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_INT64,
                                         3,
-                                        &element_count,
-                                        retrieved_dev_ptrs.data()),
+                                        &elementCount,
+                                        retrievedDevPtrs.data()),
               HIPDNN_STATUS_NOT_INITIALIZED);
 }
 
-// Invalid finalize since no dev_ptrs, or ids were set
-TEST_F(Variant_pack_descriptor_api_tests, InvalidFinalizeEmpty)
+// Invalid finalize since no devPtrs, or ids were set
+TEST_F(VariantPackDescriptorApiTests, InvalidFinalizeEmpty)
 {
     EXPECT_EQ(hipdnnBackendFinalize(_varpack), HIPDNN_STATUS_BAD_PARAM);
 }
 
-// Invalid finalize since dev_ptrs, and ids do not have the same size.
-TEST_F(Variant_pack_descriptor_api_tests, InvalidFinalizeParams)
+// Invalid finalize since devPtrs, and ids do not have the same size.
+TEST_F(VariantPackDescriptorApiTests, InvalidFinalizeParams)
 {
-    std::array<void*, 3> dev_ptrs = {reinterpret_cast<void*>(0x1234),
-                                     reinterpret_cast<void*>(0x5678),
-                                     reinterpret_cast<void*>(0x9abc)};
+    std::array<void*, 3> devPtrs = {reinterpret_cast<void*>(0x1234),
+                                    reinterpret_cast<void*>(0x5678),
+                                    reinterpret_cast<void*>(0x9abc)};
     std::array<int64_t, 2> uids = {1, 2};
 
     EXPECT_EQ(hipdnnBackendSetAttribute(_varpack,
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_VOID_PTR,
-                                        dev_ptrs.size(),
-                                        dev_ptrs.data()),
+                                        devPtrs.size(),
+                                        devPtrs.data()),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendSetAttribute(_varpack,
@@ -161,32 +161,32 @@ TEST_F(Variant_pack_descriptor_api_tests, InvalidFinalizeParams)
     EXPECT_EQ(hipdnnBackendFinalize(_varpack), HIPDNN_STATUS_BAD_PARAM);
 }
 
-TEST_F(Variant_pack_descriptor_api_tests, InvalidNullDescriptor)
+TEST_F(VariantPackDescriptorApiTests, InvalidNullDescriptor)
 {
-    hipdnnBackendDescriptor_t null_descriptor = nullptr;
-    int64_t dummy_data = 42;
-    hipdnnStatus_t status = hipdnnBackendSetAttribute(
-        null_descriptor, HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, 1, &dummy_data);
+    hipdnnBackendDescriptor_t nullDescriptor = nullptr;
+    int64_t dummyData = 42;
+    auto status = hipdnnBackendSetAttribute(
+        nullDescriptor, HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, 1, &dummyData);
     EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    int64_t retrieved_data = 0;
-    int64_t element_count = 0;
-    status = hipdnnBackendGetAttribute(null_descriptor,
+    int64_t retrievedData = 0;
+    int64_t elementCount = 0;
+    status = hipdnnBackendGetAttribute(nullDescriptor,
                                        HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
                                        HIPDNN_TYPE_INT64,
                                        1,
-                                       &element_count,
-                                       &retrieved_data);
+                                       &elementCount,
+                                       &retrievedData);
     EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-class Finalized_variant_pack_descriptor_api_tests : public ::testing::Test
+class FinalizedVariantPackDescriptorApiTests : public ::testing::Test
 {
 protected:
     hipdnnBackendDescriptor_t _varpack;
-    std::array<void*, 3> _dev_ptrs = {reinterpret_cast<void*>(0x1234),
-                                      reinterpret_cast<void*>(0x5678),
-                                      reinterpret_cast<void*>(0x9abc)};
+    std::array<void*, 3> _devPtrs = {reinterpret_cast<void*>(0x1234),
+                                     reinterpret_cast<void*>(0x5678),
+                                     reinterpret_cast<void*>(0x9abc)};
     std::array<int64_t, 3> _uids = {1, 2, 3};
     void* _workspace = reinterpret_cast<void*>(0xdeadbeef);
 
@@ -199,8 +199,8 @@ protected:
         EXPECT_EQ(hipdnnBackendSetAttribute(_varpack,
                                             HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                             HIPDNN_TYPE_VOID_PTR,
-                                            static_cast<int64_t>(_dev_ptrs.size()),
-                                            _dev_ptrs.data()),
+                                            static_cast<int64_t>(_devPtrs.size()),
+                                            _devPtrs.data()),
                   HIPDNN_STATUS_SUCCESS);
         EXPECT_EQ(hipdnnBackendSetAttribute(_varpack,
                                             HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
@@ -221,60 +221,60 @@ protected:
     }
 };
 
-TEST_F(Finalized_variant_pack_descriptor_api_tests, ValidGetAttributes)
+TEST_F(FinalizedVariantPackDescriptorApiTests, ValidGetAttributes)
 {
-    std::array<void*, 3> retrieved_dev_ptrs;
-    std::array<int64_t, 3> retrieved_uids;
-    void* retrieved_workspace = nullptr;
-    int64_t element_count = 0;
+    std::array<void*, 3> retrievedDevPtrs;
+    std::array<int64_t, 3> retrievedUids;
+    void* retrievedWorkspace = nullptr;
+    int64_t elementCount = 0;
 
     EXPECT_EQ(hipdnnBackendGetAttribute(_varpack,
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_VOID_PTR,
                                         3,
-                                        &element_count,
-                                        retrieved_dev_ptrs.data()),
+                                        &elementCount,
+                                        retrievedDevPtrs.data()),
               HIPDNN_STATUS_SUCCESS);
-    EXPECT_EQ(element_count, 3);
+    EXPECT_EQ(elementCount, 3);
     EXPECT_EQ(
-        std::memcmp(retrieved_dev_ptrs.data(), _dev_ptrs.data(), _dev_ptrs.size() * sizeof(void*)),
+        std::memcmp(retrievedDevPtrs.data(), _devPtrs.data(), _devPtrs.size() * sizeof(void*)),
         0);
 
     EXPECT_EQ(hipdnnBackendGetAttribute(_varpack,
                                         HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
                                         HIPDNN_TYPE_INT64,
                                         3,
-                                        &element_count,
-                                        retrieved_uids.data()),
+                                        &elementCount,
+                                        retrievedUids.data()),
               HIPDNN_STATUS_SUCCESS);
-    EXPECT_EQ(element_count, 3);
-    EXPECT_EQ(std::memcmp(retrieved_uids.data(), _uids.data(), _uids.size() * sizeof(int64_t)), 0);
+    EXPECT_EQ(elementCount, 3);
+    EXPECT_EQ(std::memcmp(retrievedUids.data(), _uids.data(), _uids.size() * sizeof(int64_t)), 0);
 
     EXPECT_EQ(hipdnnBackendGetAttribute(_varpack,
                                         HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
                                         HIPDNN_TYPE_VOID_PTR,
                                         1,
-                                        &element_count,
-                                        &retrieved_workspace),
+                                        &elementCount,
+                                        &retrievedWorkspace),
               HIPDNN_STATUS_SUCCESS);
-    EXPECT_EQ(element_count, 1);
-    EXPECT_EQ(retrieved_workspace, _workspace);
+    EXPECT_EQ(elementCount, 1);
+    EXPECT_EQ(retrievedWorkspace, _workspace);
 }
 
-TEST_F(Finalized_variant_pack_descriptor_api_tests, InvalidGetAttributes)
+TEST_F(FinalizedVariantPackDescriptorApiTests, InvalidGetAttributes)
 {
-    std::array<void*, 3> retrieved_dev_ptrs;
-    std::array<int64_t, 3> retrieved_uids;
-    void* retrieved_workspace = nullptr;
-    int64_t element_count = 0;
+    std::array<void*, 3> retrievedDevPtrs;
+    std::array<int64_t, 3> retrievedUids;
+    void* retrievedWorkspace = nullptr;
+    int64_t elementCount = 0;
 
     // HIPDNN_STATUS_BAD_PARAM since HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS expects HIPDNN_TYPE_VOID_PTR
     EXPECT_EQ(hipdnnBackendGetAttribute(_varpack,
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_INT64,
                                         3,
-                                        &element_count,
-                                        retrieved_dev_ptrs.data()),
+                                        &elementCount,
+                                        retrievedDevPtrs.data()),
               HIPDNN_STATUS_BAD_PARAM);
 
     // HIPDNN_STATUS_BAD_PARAM since HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS expects HIPDNN_TYPE_INT64
@@ -282,45 +282,45 @@ TEST_F(Finalized_variant_pack_descriptor_api_tests, InvalidGetAttributes)
                                         HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
                                         HIPDNN_TYPE_VOID_PTR,
                                         3,
-                                        &element_count,
-                                        retrieved_uids.data()),
+                                        &elementCount,
+                                        retrievedUids.data()),
               HIPDNN_STATUS_BAD_PARAM);
 
     // HIPDNN_STATUS_BAD_PARAM since HIPDNN_ATTR_VARIANT_PACK_WORKSPACE expects HIPDNN_TYPE_VOID_PTR
-    // but element_count should be 1
+    // but elementCount should be 1
     EXPECT_EQ(hipdnnBackendGetAttribute(_varpack,
                                         HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
                                         HIPDNN_TYPE_VOID_PTR,
                                         2,
-                                        &element_count,
-                                        &retrieved_workspace),
+                                        &elementCount,
+                                        &retrievedWorkspace),
               HIPDNN_STATUS_BAD_PARAM);
 
-    // HIPDNN_STATUS_BAD_PARAM since array_of_elements cannot be nullptr
+    // HIPDNN_STATUS_BAD_PARAM since arrayOfElements cannot be nullptr
     EXPECT_EQ(hipdnnBackendGetAttribute(_varpack,
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_VOID_PTR,
                                         3,
-                                        &element_count,
+                                        &elementCount,
                                         nullptr),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    // HIPDNN_STATUS_BAD_PARAM since element_count cannot be nullptr
+    // HIPDNN_STATUS_BAD_PARAM since elementCount cannot be nullptr
     EXPECT_EQ(hipdnnBackendGetAttribute(_varpack,
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_VOID_PTR,
                                         3,
                                         nullptr,
-                                        retrieved_dev_ptrs.data()),
+                                        retrievedDevPtrs.data()),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST_F(Finalized_variant_pack_descriptor_api_tests, InvalidSetAttributes)
+TEST_F(FinalizedVariantPackDescriptorApiTests, InvalidSetAttributes)
 {
     EXPECT_EQ(hipdnnBackendSetAttribute(_varpack,
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_VOID_PTR,
-                                        static_cast<int64_t>(_dev_ptrs.size()),
-                                        _dev_ptrs.data()),
+                                        static_cast<int64_t>(_devPtrs.size()),
+                                        _devPtrs.data()),
               HIPDNN_STATUS_NOT_INITIALIZED);
 }


### PR DESCRIPTION
Rename backend integration tests to follow new naming rules.