### PR TITLE
Fix clean rebuild by adding dependency on the generated files

### DIFF
--- a/frontend/tests/CMakeLists.txt
+++ b/frontend/tests/CMakeLists.txt
@@ -50,6 +50,4 @@ target_link_libraries(hipdnn_frontend_tests
 )
 clang_tidy_check(hipdnn_frontend_tests)
 
-add_dependencies(hipdnn_frontend_tests generate_hipdnn_sdk_headers)
-
 add_unit_test_target(hipdnn_frontend_tests ${CMAKE_CURRENT_BINARY_DIR})

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -36,13 +36,13 @@ _save_var(FLATBUFFERS_FLATC_SCHEMA_EXTRA_ARGS)
 
 SET(FLATBUFFERS_FLATC_SCHEMA_EXTRA_ARGS "--gen-object-api;--gen-mutable;--gen-compare;--defaults-json")
 build_flatbuffers(
-    "${SCHEMA_FILES}" 
-    "" 
-    generate_hipdnn_sdk_headers 
-    "" 
-    ${HIP_DNN_SDK_INCLUDE_DIR}/hipdnn_sdk/data_objects 
-    "" 
-    ""
+    "${SCHEMA_FILES}" #flatbuffers_schemas
+    "" # schema_include_dirs
+    generate_hipdnn_sdk_headers  #custom_target_name
+    "" # additional_dependencies
+    ${HIP_DNN_SDK_INCLUDE_DIR}/hipdnn_sdk/data_objects  # generated_includes_dir
+    ""  # binary_schemas_dir
+    "" #copy_text_schemas_dir
 ) 
 
 # Flatc build has some warnings that trigger and print to the console.  Since we dont want these we can
@@ -57,6 +57,7 @@ hipdnn_add_dependency(spdlog VERSION 1.15.2)
 
 add_library(hipdnn_sdk INTERFACE)
 target_link_libraries(hipdnn_sdk INTERFACE FlatBuffers spdlog_header_only)
+add_dependencies(hipdnn_sdk generate_hipdnn_sdk_headers)
 
 target_include_directories(hipdnn_sdk INTERFACE
     $<BUILD_INTERFACE:${HIP_DNN_SDK_INCLUDE_DIR}>


### PR DESCRIPTION
## Proposed changes

Clean rebuild could fail if the build order happened incorrectly.  This dependency addition should make it so the files are generated before any other part of the build starts.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [x ] I have added automated tests relevant to the introduced functionality
- [ x] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [ x] I have ran the tests, and they are all passing locally
- [ x] I have ran the tests with ASAN, and they are all passing locally
- [ x] I have added relevant documentation for the changes
- [ x] I have removed the stale documentation which is no longer relevant after this pull request
- [ x] I have ran `make format` & `make check_format` to ensure the changes have been formatted
