### PR TITLE
[ALMIOPEN-168] - Adding bfloat16 and half to TensorAttribute value

### DIFF
--- a/frontend/include/hipdnn_frontend/attributes/TensorAttributes.hpp
+++ b/frontend/include/hipdnn_frontend/attributes/TensorAttributes.hpp
@@ -7,6 +7,8 @@
 #include <hipdnn_frontend/Types.hpp>
 #include <hipdnn_sdk/data_objects/graph_generated.h>
 #include <hipdnn_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_sdk/utilities/HalfUtils.hpp>
+#include <hipdnn_sdk/utilities/HipBfloat16Utils.hpp>
 #include <optional>
 #include <string>
 #include <type_traits>
@@ -21,39 +23,15 @@ namespace graph
 class TensorAttributes
 {
 public:
-    using ValueVariant = std::variant<std::monostate, double, float, uint16_t, uint8_t, int32_t>;
+    using ValueVariant
+        = std::variant<std::monostate, double, float, half, hip_bfloat16, uint8_t, int32_t>;
 
     TensorAttributes() = default;
 
-    TensorAttributes(double const& scalar)
+    template <typename T>
+    TensorAttributes(T const& scalar)
     {
-        _value = scalar;
-        _dim = _stride = {1};
-        _dataType = DataType_t::DOUBLE;
-    }
-    TensorAttributes(float const& scalar)
-    {
-        _value = scalar;
-        _dim = _stride = {1};
-        _dataType = DataType_t::FLOAT;
-    }
-    TensorAttributes(uint16_t const& scalar)
-    {
-        _value = scalar;
-        _dim = _stride = {1};
-        _dataType = DataType_t::HALF;
-    }
-    TensorAttributes(uint8_t const& scalar)
-    {
-        _value = scalar;
-        _dim = _stride = {1};
-        _dataType = DataType_t::UINT8;
-    }
-    TensorAttributes(int32_t const& scalar)
-    {
-        _value = scalar;
-        _dim = _stride = {1};
-        _dataType = DataType_t::INT32;
+        set_value(scalar);
     }
 
     bool has_value() const // NOLINT(readability-identifier-naming)
@@ -74,13 +52,17 @@ public:
     template <typename T>
     TensorAttributes& set_value(T v) // NOLINT(readability-identifier-naming)
     {
+
         static_assert(std::disjunction_v<std::is_same<T, float>,
                                          std::is_same<T, double>,
-                                         std::is_same<T, uint16_t>,
+                                         std::is_same<T, half>,
+                                         std::is_same<T, hip_bfloat16>,
                                          std::is_same<T, uint8_t>,
                                          std::is_same<T, int32_t>>,
                       "Unsupported type for Tensor_attributes::set_value");
         _value = v;
+        _dataType = getDataTypeEnumFromType<T>();
+        _dim = _stride = {1};
         return *this;
     }
 
@@ -236,11 +218,17 @@ public:
                     return {hipdnn_sdk::data_objects::TensorValue_Float64Value,
                             builder.CreateStruct(doubleVal).Union()};
                 }
-                else if constexpr(std::is_same_v<T, uint16_t>)
+                else if constexpr(std::is_same_v<T, half>)
                 {
                     hipdnn_sdk::data_objects::Float16Value halfVal(arg);
                     return {hipdnn_sdk::data_objects::TensorValue_Float16Value,
                             builder.CreateStruct(halfVal).Union()};
+                }
+                else if constexpr(std::is_same_v<T, hip_bfloat16>)
+                {
+                    hipdnn_sdk::data_objects::BFloat16Value bfVal(arg);
+                    return {hipdnn_sdk::data_objects::TensorValue_BFloat16Value,
+                            builder.CreateStruct(bfVal).Union()};
                 }
                 else if constexpr(std::is_same_v<T, uint8_t>)
                 {

--- a/frontend/tests/CMakeLists.txt
+++ b/frontend/tests/CMakeLists.txt
@@ -43,7 +43,6 @@ target_link_libraries(hipdnn_frontend_tests
     GTest::gtest 
     GTest::gmock
     hip::host
-    hip::device
     Threads::Threads 
     hipdnn_sdk 
     hipdnn_frontend

--- a/frontend/tests/TestTensorValueAttributes.cpp
+++ b/frontend/tests/TestTensorValueAttributes.cpp
@@ -32,7 +32,18 @@ TEST(TestTensorValueAttributes, SetGetClearFloat)
     EXPECT_FALSE(tensor.get_value<float>().has_value());
 }
 
-TEST(TestTensorValueAttributes, PackUnpackFloat)
+TEST(TestTensorValueAttributes, ConstructorValues)
+{
+    constexpr int32_t TEST_VALUE = 42;
+    hipdnn_frontend::graph::TensorAttributes tensor(TEST_VALUE);
+    EXPECT_TRUE(tensor.has_value());
+
+    auto opt = tensor.get_value<int32_t>();
+    ASSERT_TRUE(opt.has_value());
+    EXPECT_EQ(opt.value(), TEST_VALUE);
+}
+
+TEST(TestTensorValueAttributes, PackUnpackFloatValue)
 {
     hipdnn_frontend::graph::TensorAttributes tensor;
     tensor.set_uid(7)
@@ -53,8 +64,8 @@ TEST(TestTensorValueAttributes, PackUnpackFloat)
     EXPECT_EQ(fbTensor->uid(), 7);
     EXPECT_STREQ(fbTensor->name()->c_str(), "value_tensor");
     EXPECT_EQ(fbTensor->data_type(), DataType_FLOAT);
-    EXPECT_EQ(fbTensor->strides()->size(), 2u);
-    EXPECT_EQ(fbTensor->dims()->size(), 2u);
+    EXPECT_EQ(fbTensor->strides()->size(), 1u);
+    EXPECT_EQ(fbTensor->dims()->size(), 1u);
     EXPECT_FALSE(fbTensor->virtual_());
 
     EXPECT_EQ(fbTensor->value_type(), TensorValue_Float32Value);
@@ -67,8 +78,8 @@ TEST(TestTensorValueAttributes, PackUnpackFloat)
     EXPECT_EQ(unpacked->name, "value_tensor");
     EXPECT_EQ(unpacked->data_type, DataType_FLOAT);
 
-    std::vector<int64_t> expectedStrides = {1, 2};
-    std::vector<int64_t> expectedDims = {3, 4};
+    std::vector<int64_t> expectedStrides = {1};
+    std::vector<int64_t> expectedDims = {1};
     EXPECT_EQ(unpacked->strides, expectedStrides);
     EXPECT_EQ(unpacked->dims, expectedDims);
 
@@ -80,16 +91,14 @@ TEST(TestTensorValueAttributes, PackUnpackFloat)
     EXPECT_FLOAT_EQ(floatVal->value(), std::numbers::e_v<float>);
 }
 
-TEST(TestTensorValueAttributes, PackUnpackHalf)
+TEST(TestTensorValueAttributes, PackUnpackHalfValue)
 {
     hipdnn_frontend::graph::TensorAttributes tensor;
     tensor.set_uid(8)
         .set_name("half_tensor")
         .set_data_type(DataType_t::HALF)
-        .set_stride({1, 2})
-        .set_dim({3, 4})
         .set_is_virtual(false)
-        .set_value(uint16_t{16384});
+        .set_value(1.0_h);
 
     flatbuffers::FlatBufferBuilder builder;
     auto fbOffset = tensor.pack_attributes(builder);
@@ -101,23 +110,49 @@ TEST(TestTensorValueAttributes, PackUnpackHalf)
     EXPECT_EQ(fbTensor->value_type(), TensorValue_Float16Value);
     auto hval = fbTensor->value_as_Float16Value();
     ASSERT_NE(hval, nullptr);
-    EXPECT_EQ(hval->value(), uint16_t{16384});
+    EXPECT_EQ(hval->value(), 1.0_h);
 
     auto unpacked = std::unique_ptr<TensorAttributesT>(fbTensor->UnPack());
     ASSERT_EQ(unpacked->value.type, TensorValue_Float16Value);
     auto* halfVal = unpacked->value.AsFloat16Value();
     ASSERT_NE(halfVal, nullptr);
-    EXPECT_EQ(halfVal->value(), uint16_t{16384});
+    EXPECT_EQ(halfVal->value(), 1.0_h);
 }
 
-TEST(TestTensorValueAttributes, PackUnpackDouble)
+TEST(TestTensorValueAttributes, PackUnpackBFloat1Value)
+{
+    hipdnn_frontend::graph::TensorAttributes tensor;
+    tensor.set_uid(8)
+        .set_name("half_tensor")
+        .set_data_type(DataType_t::BFLOAT16)
+        .set_is_virtual(false)
+        .set_value(1.0_bf);
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto fbOffset = tensor.pack_attributes(builder);
+    builder.Finish(fbOffset);
+
+    auto bufferPointer = builder.GetBufferPointer();
+    auto fbTensor = flatbuffers::GetRoot<TensorAttributes>(bufferPointer);
+
+    EXPECT_EQ(fbTensor->value_type(), TensorValue_BFloat16Value);
+    auto hval = fbTensor->value_as_BFloat16Value();
+    ASSERT_NE(hval, nullptr);
+    EXPECT_EQ(hval->value(), 1.0_bf);
+
+    auto unpacked = std::unique_ptr<TensorAttributesT>(fbTensor->UnPack());
+    ASSERT_EQ(unpacked->value.type, TensorValue_BFloat16Value);
+    auto* halfVal = unpacked->value.AsBFloat16Value();
+    ASSERT_NE(halfVal, nullptr);
+    EXPECT_EQ(halfVal->value(), 1.0_bf);
+}
+
+TEST(TestTensorValueAttributes, PackUnpackDoubleValue)
 {
     hipdnn_frontend::graph::TensorAttributes tensor;
     tensor.set_uid(9)
         .set_name("double_tensor")
         .set_data_type(DataType_t::DOUBLE)
-        .set_stride({1, 2})
-        .set_dim({3, 4})
         .set_is_virtual(false)
         .set_value(std::numbers::pi_v<double>);
 
@@ -174,7 +209,8 @@ TEST(TestTensorValueAttributes, TypeSafety)
     ASSERT_TRUE(floatOpt.has_value());
     EXPECT_FLOAT_EQ(floatOpt.value(), 42.0f);
 
-    EXPECT_FALSE(tensor.get_value<uint16_t>().has_value());
+    EXPECT_FALSE(tensor.get_value<half>().has_value());
+    EXPECT_FALSE(tensor.get_value<hip_bfloat16>().has_value());
     EXPECT_FALSE(tensor.get_value<uint8_t>().has_value());
     EXPECT_FALSE(tensor.get_value<int32_t>().has_value());
     EXPECT_FALSE(tensor.get_value<double>().has_value());

--- a/plugins/miopen_legacy_plugin/integration_tests/CMakeLists.txt
+++ b/plugins/miopen_legacy_plugin/integration_tests/CMakeLists.txt
@@ -29,7 +29,6 @@ target_compile_definitions(miopen_plugin_integration_test PRIVATE
 target_link_libraries(miopen_plugin_integration_test PUBLIC 
     GTest::gtest
     hip::host
-    hip::device
     miopen_legacy_plugin
     hipdnn_frontend
     hipdnn_sdk

--- a/plugins/miopen_legacy_plugin/tests/CMakeLists.txt
+++ b/plugins/miopen_legacy_plugin/tests/CMakeLists.txt
@@ -14,7 +14,6 @@ if(HIP_DNN_SKIP_TESTS)
 endif()
 
 add_compile_definitions(__HIP_PLATFORM_AMD__)
-add_compile_definitions(__HIPCC__)
 find_package(hip REQUIRED)
 find_package(Threads REQUIRED)
 enable_language(HIP)
@@ -46,7 +45,6 @@ target_link_libraries(miopen_legacy_plugin_tests PUBLIC
     GTest::gtest
     GTest::gmock
     hip::host
-    hip::device
     miopen_legacy_plugin
     miopen_legacy_plugin_private
     Threads::Threads

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -14,7 +14,6 @@ function(add_hipdnn_sample NAME SOURCE)
     add_executable(${NAME} ${SOURCE})
     target_link_libraries(${NAME} PRIVATE 
         hip::host
-        hip::device
         hipdnn_frontend
         hipdnn_backend
         hipdnn_sdk

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -7,16 +7,12 @@ set(CMAKE_CXX_STANDARD 20)
 
 find_package(hip REQUIRED)
 find_package(hipdnn_frontend CONFIG REQUIRED)
-find_package(hipdnn_backend CONFIG REQUIRED)
-find_package(hipdnn_sdk CONFIG REQUIRED)
 
 function(add_hipdnn_sample NAME SOURCE)
     add_executable(${NAME} ${SOURCE})
     target_link_libraries(${NAME} PRIVATE 
         hip::host
         hipdnn_frontend
-        hipdnn_backend
-        hipdnn_sdk
     )
 endfunction()
 

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -63,7 +63,7 @@ target_include_directories(hipdnn_sdk INTERFACE
     $<BUILD_INTERFACE:${HIP_DNN_SDK_INCLUDE_DIR}>
     $<INSTALL_INTERFACE:${HIP_DNN_SDK_INSTALL_INCLUDE_DIR}>
 )
-
+target_compile_definitions(hipdnn_sdk INTERFACE __HIPCC__)
 install( 
     TARGETS hipdnn_sdk FlatBuffers spdlog_header_only
     EXPORT hipdnn_sdk_targets

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -63,7 +63,11 @@ target_include_directories(hipdnn_sdk INTERFACE
     $<BUILD_INTERFACE:${HIP_DNN_SDK_INCLUDE_DIR}>
     $<INSTALL_INTERFACE:${HIP_DNN_SDK_INSTALL_INCLUDE_DIR}>
 )
+
+# This is required to use hip/hip_fp16.h and hip/hip_bfloat16.h in any code that includes the sdk
+# By doing this, we don't need to link to hip::device
 target_compile_definitions(hipdnn_sdk INTERFACE __HIPCC__)
+
 install( 
     TARGETS hipdnn_sdk FlatBuffers spdlog_header_only
     EXPORT hipdnn_sdk_targets

--- a/sdk/include/hipdnn_sdk/data_objects/tensor_attributes_generated.h
+++ b/sdk/include/hipdnn_sdk/data_objects/tensor_attributes_generated.h
@@ -22,6 +22,8 @@ struct Float32Value;
 
 struct Float16Value;
 
+struct BFloat16Value;
+
 struct Float8Value;
 
 struct Int32Value;
@@ -36,6 +38,8 @@ bool operator==(const Float32Value &lhs, const Float32Value &rhs);
 bool operator!=(const Float32Value &lhs, const Float32Value &rhs);
 bool operator==(const Float16Value &lhs, const Float16Value &rhs);
 bool operator!=(const Float16Value &lhs, const Float16Value &rhs);
+bool operator==(const BFloat16Value &lhs, const BFloat16Value &rhs);
+bool operator!=(const BFloat16Value &lhs, const BFloat16Value &rhs);
 bool operator==(const Float8Value &lhs, const Float8Value &rhs);
 bool operator!=(const Float8Value &lhs, const Float8Value &rhs);
 bool operator==(const Int32Value &lhs, const Int32Value &rhs);
@@ -49,18 +53,20 @@ enum TensorValue : uint8_t {
   TensorValue_NONE = 0,
   TensorValue_Float32Value = 1,
   TensorValue_Float16Value = 2,
-  TensorValue_Float8Value = 3,
-  TensorValue_Int32Value = 4,
-  TensorValue_Float64Value = 5,
+  TensorValue_BFloat16Value = 3,
+  TensorValue_Float8Value = 4,
+  TensorValue_Int32Value = 5,
+  TensorValue_Float64Value = 6,
   TensorValue_MIN = TensorValue_NONE,
   TensorValue_MAX = TensorValue_Float64Value
 };
 
-inline const TensorValue (&EnumValuesTensorValue())[6] {
+inline const TensorValue (&EnumValuesTensorValue())[7] {
   static const TensorValue values[] = {
     TensorValue_NONE,
     TensorValue_Float32Value,
     TensorValue_Float16Value,
+    TensorValue_BFloat16Value,
     TensorValue_Float8Value,
     TensorValue_Int32Value,
     TensorValue_Float64Value
@@ -69,10 +75,11 @@ inline const TensorValue (&EnumValuesTensorValue())[6] {
 }
 
 inline const char * const *EnumNamesTensorValue() {
-  static const char * const names[7] = {
+  static const char * const names[8] = {
     "NONE",
     "Float32Value",
     "Float16Value",
+    "BFloat16Value",
     "Float8Value",
     "Int32Value",
     "Float64Value",
@@ -99,6 +106,10 @@ template<> struct TensorValueTraits<hipdnn_sdk::data_objects::Float16Value> {
   static const TensorValue enum_value = TensorValue_Float16Value;
 };
 
+template<> struct TensorValueTraits<hipdnn_sdk::data_objects::BFloat16Value> {
+  static const TensorValue enum_value = TensorValue_BFloat16Value;
+};
+
 template<> struct TensorValueTraits<hipdnn_sdk::data_objects::Float8Value> {
   static const TensorValue enum_value = TensorValue_Float8Value;
 };
@@ -121,6 +132,10 @@ template<> struct TensorValueUnionTraits<hipdnn_sdk::data_objects::Float32Value>
 
 template<> struct TensorValueUnionTraits<hipdnn_sdk::data_objects::Float16Value> {
   static const TensorValue enum_value = TensorValue_Float16Value;
+};
+
+template<> struct TensorValueUnionTraits<hipdnn_sdk::data_objects::BFloat16Value> {
+  static const TensorValue enum_value = TensorValue_BFloat16Value;
 };
 
 template<> struct TensorValueUnionTraits<hipdnn_sdk::data_objects::Float8Value> {
@@ -181,6 +196,14 @@ struct TensorValueUnion {
     return type == TensorValue_Float16Value ?
       reinterpret_cast<const hipdnn_sdk::data_objects::Float16Value *>(value) : nullptr;
   }
+  hipdnn_sdk::data_objects::BFloat16Value *AsBFloat16Value() {
+    return type == TensorValue_BFloat16Value ?
+      reinterpret_cast<hipdnn_sdk::data_objects::BFloat16Value *>(value) : nullptr;
+  }
+  const hipdnn_sdk::data_objects::BFloat16Value *AsBFloat16Value() const {
+    return type == TensorValue_BFloat16Value ?
+      reinterpret_cast<const hipdnn_sdk::data_objects::BFloat16Value *>(value) : nullptr;
+  }
   hipdnn_sdk::data_objects::Float8Value *AsFloat8Value() {
     return type == TensorValue_Float8Value ?
       reinterpret_cast<hipdnn_sdk::data_objects::Float8Value *>(value) : nullptr;
@@ -221,6 +244,10 @@ inline bool operator==(const TensorValueUnion &lhs, const TensorValueUnion &rhs)
     case TensorValue_Float16Value: {
       return *(reinterpret_cast<const hipdnn_sdk::data_objects::Float16Value *>(lhs.value)) ==
              *(reinterpret_cast<const hipdnn_sdk::data_objects::Float16Value *>(rhs.value));
+    }
+    case TensorValue_BFloat16Value: {
+      return *(reinterpret_cast<const hipdnn_sdk::data_objects::BFloat16Value *>(lhs.value)) ==
+             *(reinterpret_cast<const hipdnn_sdk::data_objects::BFloat16Value *>(rhs.value));
     }
     case TensorValue_Float8Value: {
       return *(reinterpret_cast<const hipdnn_sdk::data_objects::Float8Value *>(lhs.value)) ==
@@ -277,25 +304,25 @@ inline bool operator!=(const Float32Value &lhs, const Float32Value &rhs) {
 }
 
 
-FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(2) Float16Value FLATBUFFERS_FINAL_CLASS {
+FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Float16Value FLATBUFFERS_FINAL_CLASS {
  private:
-  uint16_t value_;
+  float value_;
 
  public:
   Float16Value()
       : value_(0) {
   }
-  Float16Value(uint16_t _value)
+  Float16Value(float _value)
       : value_(::flatbuffers::EndianScalar(_value)) {
   }
-  uint16_t value() const {
+  float value() const {
     return ::flatbuffers::EndianScalar(value_);
   }
-  void mutate_value(uint16_t _value) {
+  void mutate_value(float _value) {
     ::flatbuffers::WriteScalar(&value_, _value);
   }
 };
-FLATBUFFERS_STRUCT_END(Float16Value, 2);
+FLATBUFFERS_STRUCT_END(Float16Value, 4);
 
 inline bool operator==(const Float16Value &lhs, const Float16Value &rhs) {
   return
@@ -303,6 +330,36 @@ inline bool operator==(const Float16Value &lhs, const Float16Value &rhs) {
 }
 
 inline bool operator!=(const Float16Value &lhs, const Float16Value &rhs) {
+    return !(lhs == rhs);
+}
+
+
+FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) BFloat16Value FLATBUFFERS_FINAL_CLASS {
+ private:
+  float value_;
+
+ public:
+  BFloat16Value()
+      : value_(0) {
+  }
+  BFloat16Value(float _value)
+      : value_(::flatbuffers::EndianScalar(_value)) {
+  }
+  float value() const {
+    return ::flatbuffers::EndianScalar(value_);
+  }
+  void mutate_value(float _value) {
+    ::flatbuffers::WriteScalar(&value_, _value);
+  }
+};
+FLATBUFFERS_STRUCT_END(BFloat16Value, 4);
+
+inline bool operator==(const BFloat16Value &lhs, const BFloat16Value &rhs) {
+  return
+      (lhs.value() == rhs.value());
+}
+
+inline bool operator!=(const BFloat16Value &lhs, const BFloat16Value &rhs) {
     return !(lhs == rhs);
 }
 
@@ -470,6 +527,9 @@ struct TensorAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const hipdnn_sdk::data_objects::Float16Value *value_as_Float16Value() const {
     return value_type() == hipdnn_sdk::data_objects::TensorValue_Float16Value ? static_cast<const hipdnn_sdk::data_objects::Float16Value *>(value()) : nullptr;
   }
+  const hipdnn_sdk::data_objects::BFloat16Value *value_as_BFloat16Value() const {
+    return value_type() == hipdnn_sdk::data_objects::TensorValue_BFloat16Value ? static_cast<const hipdnn_sdk::data_objects::BFloat16Value *>(value()) : nullptr;
+  }
   const hipdnn_sdk::data_objects::Float8Value *value_as_Float8Value() const {
     return value_type() == hipdnn_sdk::data_objects::TensorValue_Float8Value ? static_cast<const hipdnn_sdk::data_objects::Float8Value *>(value()) : nullptr;
   }
@@ -509,6 +569,10 @@ template<> inline const hipdnn_sdk::data_objects::Float32Value *TensorAttributes
 
 template<> inline const hipdnn_sdk::data_objects::Float16Value *TensorAttributes::value_as<hipdnn_sdk::data_objects::Float16Value>() const {
   return value_as_Float16Value();
+}
+
+template<> inline const hipdnn_sdk::data_objects::BFloat16Value *TensorAttributes::value_as<hipdnn_sdk::data_objects::BFloat16Value>() const {
+  return value_as_BFloat16Value();
 }
 
 template<> inline const hipdnn_sdk::data_objects::Float8Value *TensorAttributes::value_as<hipdnn_sdk::data_objects::Float8Value>() const {
@@ -684,7 +748,10 @@ inline bool VerifyTensorValue(::flatbuffers::Verifier &verifier, const void *obj
       return verifier.VerifyField<hipdnn_sdk::data_objects::Float32Value>(static_cast<const uint8_t *>(obj), 0, 4);
     }
     case TensorValue_Float16Value: {
-      return verifier.VerifyField<hipdnn_sdk::data_objects::Float16Value>(static_cast<const uint8_t *>(obj), 0, 2);
+      return verifier.VerifyField<hipdnn_sdk::data_objects::Float16Value>(static_cast<const uint8_t *>(obj), 0, 4);
+    }
+    case TensorValue_BFloat16Value: {
+      return verifier.VerifyField<hipdnn_sdk::data_objects::BFloat16Value>(static_cast<const uint8_t *>(obj), 0, 4);
     }
     case TensorValue_Float8Value: {
       return verifier.VerifyField<hipdnn_sdk::data_objects::Float8Value>(static_cast<const uint8_t *>(obj), 0, 1);
@@ -722,6 +789,10 @@ inline void *TensorValueUnion::UnPack(const void *obj, TensorValue type, const :
       auto ptr = reinterpret_cast<const hipdnn_sdk::data_objects::Float16Value *>(obj);
       return new hipdnn_sdk::data_objects::Float16Value(*ptr);
     }
+    case TensorValue_BFloat16Value: {
+      auto ptr = reinterpret_cast<const hipdnn_sdk::data_objects::BFloat16Value *>(obj);
+      return new hipdnn_sdk::data_objects::BFloat16Value(*ptr);
+    }
     case TensorValue_Float8Value: {
       auto ptr = reinterpret_cast<const hipdnn_sdk::data_objects::Float8Value *>(obj);
       return new hipdnn_sdk::data_objects::Float8Value(*ptr);
@@ -747,6 +818,10 @@ inline ::flatbuffers::Offset<void> TensorValueUnion::Pack(::flatbuffers::FlatBuf
     }
     case TensorValue_Float16Value: {
       auto ptr = reinterpret_cast<const hipdnn_sdk::data_objects::Float16Value *>(value);
+      return _fbb.CreateStruct(*ptr).Union();
+    }
+    case TensorValue_BFloat16Value: {
+      auto ptr = reinterpret_cast<const hipdnn_sdk::data_objects::BFloat16Value *>(value);
       return _fbb.CreateStruct(*ptr).Union();
     }
     case TensorValue_Float8Value: {
@@ -775,6 +850,10 @@ inline TensorValueUnion::TensorValueUnion(const TensorValueUnion &u) : type(u.ty
       value = new hipdnn_sdk::data_objects::Float16Value(*reinterpret_cast<hipdnn_sdk::data_objects::Float16Value *>(u.value));
       break;
     }
+    case TensorValue_BFloat16Value: {
+      value = new hipdnn_sdk::data_objects::BFloat16Value(*reinterpret_cast<hipdnn_sdk::data_objects::BFloat16Value *>(u.value));
+      break;
+    }
     case TensorValue_Float8Value: {
       value = new hipdnn_sdk::data_objects::Float8Value(*reinterpret_cast<hipdnn_sdk::data_objects::Float8Value *>(u.value));
       break;
@@ -801,6 +880,11 @@ inline void TensorValueUnion::Reset() {
     }
     case TensorValue_Float16Value: {
       auto ptr = reinterpret_cast<hipdnn_sdk::data_objects::Float16Value *>(value);
+      delete ptr;
+      break;
+    }
+    case TensorValue_BFloat16Value: {
+      auto ptr = reinterpret_cast<hipdnn_sdk::data_objects::BFloat16Value *>(value);
       delete ptr;
       break;
     }

--- a/sdk/include/hipdnn_sdk/test_utilities/CpuFpReferenceImplementation.hpp
+++ b/sdk/include/hipdnn_sdk/test_utilities/CpuFpReferenceImplementation.hpp
@@ -4,14 +4,10 @@
 #pragma once
 
 #include <hipdnn_sdk/test_utilities/ReferenceImplementationInterface.hpp>
-#include <numeric>
-#include <vector>
-
-#if defined(__HIP_PLATFORM_AMD__)
-// Need these for the half and bfloat16 types
 #include <hipdnn_sdk/utilities/HalfUtils.hpp>
 #include <hipdnn_sdk/utilities/HipBfloat16Utils.hpp>
-#endif
+#include <numeric>
+#include <vector>
 
 namespace hipdnn_sdk
 {

--- a/sdk/include/hipdnn_sdk/test_utilities/CpuFpReferenceImplementation.hpp
+++ b/sdk/include/hipdnn_sdk/test_utilities/CpuFpReferenceImplementation.hpp
@@ -182,7 +182,7 @@ private:
 
     float sqrtInternal(float value) const
     {
-        return std::sqrtf(value);
+        return sqrtf(value);
     }
 };
 

--- a/sdk/include/hipdnn_sdk/test_utilities/CpuFpReferenceMiopenRmsValidation.hpp
+++ b/sdk/include/hipdnn_sdk/test_utilities/CpuFpReferenceMiopenRmsValidation.hpp
@@ -31,7 +31,7 @@ public:
     CpuFpReferenceMiopenRmsValidation(T relativeTolerance = std::numeric_limits<T>::epsilon())
         : _relativeTolerance(static_cast<double>(relativeTolerance))
     {
-        if(relativeTolerance < T{0})
+        if(relativeTolerance < T{0.0})
         {
             throw std::invalid_argument("Tolerances must be non-negative");
         }

--- a/sdk/include/hipdnn_sdk/test_utilities/CpuFpReferenceMiopenRmsValidation.hpp
+++ b/sdk/include/hipdnn_sdk/test_utilities/CpuFpReferenceMiopenRmsValidation.hpp
@@ -3,14 +3,10 @@
 
 #pragma once
 
-#if defined(__HIP_PLATFORM_AMD__)
-// Need these for the half and bfloat16 types
-#include <hipdnn_sdk/utilities/HalfUtils.hpp>
-#include <hipdnn_sdk/utilities/HipBfloat16Utils.hpp>
-#endif
-
 #include <hipdnn_sdk/logging/Logger.hpp>
 #include <hipdnn_sdk/test_utilities/ReferenceValidationInterface.hpp>
+#include <hipdnn_sdk/utilities/HalfUtils.hpp>
+#include <hipdnn_sdk/utilities/HipBfloat16Utils.hpp>
 
 namespace hipdnn_sdk
 {

--- a/sdk/include/hipdnn_sdk/utilities/HalfUtils.hpp
+++ b/sdk/include/hipdnn_sdk/utilities/HalfUtils.hpp
@@ -7,21 +7,54 @@
 #include <hipdnn_sdk/logging/Logger.hpp>
 #include <string>
 
+inline __HOST_DEVICE__ half __ushort_as_half(unsigned short x)
+{
+    __half_raw r;
+    r.x = x;
+    return r;
+}
+
 inline __HOST_DEVICE__ half operator""_h(long double value)
 {
     return {static_cast<float>(value)};
+}
+
+inline __HOST_DEVICE__ half __habs(__half num)
+{
+    auto raw = static_cast<__half_raw>(num);
+    raw.x &= 0x7FFFu;
+    return raw;
+}
+
+inline __HOST_DEVICE__ bool __hisnan(__half x)
+{
+    __half_raw hr = x;
+    return (hr.x & 0x7FFFU) > 0x7C00u;
+}
+
+inline __HOST_DEVICE__ __half __hmax(const __half a, const __half b)
+{
+    if(__hisnan(a) && !__hisnan(b))
+        return b;
+    if(!__hisnan(a) && __hisnan(b))
+        return a;
+    if(__hisnan(a) && __hisnan(b))
+        return HIPRT_NAN_FP16;
+    if(static_cast<__half_raw>(a).x > static_cast<__half_raw>(b).x)
+        return __half_raw{static_cast<__half_raw>(a).x};
+    return __half_raw{static_cast<__half_raw>(b).x};
 }
 
 namespace std
 {
 inline __HOST_DEVICE__ half fabs(half num)
 {
-    return num > 0.0_h ? num : static_cast<half>(num * -1.0_h);
+    return __habs(num);
 }
 
 inline __HOST_DEVICE__ half max(half a, half b)
 {
-    return a > b ? a : b;
+    return __hmax(a, b);
 }
 
 }

--- a/sdk/include/hipdnn_sdk/utilities/HalfUtils.hpp
+++ b/sdk/include/hipdnn_sdk/utilities/HalfUtils.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <hip/amd_detail/amd_hip_fp16.h>
+#include <hip/hip_fp16.h>
 #include <hipdnn_sdk/logging/Logger.hpp>
 #include <string>
 
@@ -16,7 +16,8 @@ namespace std
 {
 inline __HOST_DEVICE__ half fabs(half num)
 {
-    return num > 0.0_h ? num : num * -1.0_h;
+    auto f = static_cast<float>(num);
+    return f > 0.0f ? num : half{-f};
 }
 
 inline __HOST_DEVICE__ half max(half a, half b)

--- a/sdk/include/hipdnn_sdk/utilities/HalfUtils.hpp
+++ b/sdk/include/hipdnn_sdk/utilities/HalfUtils.hpp
@@ -7,57 +7,65 @@
 #include <hipdnn_sdk/logging/Logger.hpp>
 #include <string>
 
-inline __HOST_DEVICE__ half __ushort_as_half(unsigned short x)
-{
-    __half_raw r;
-    r.x = x;
-    return r;
-}
+#define HIPDNN_NAN_FP16 ushort_as_half(static_cast<unsigned short>(0x7FFFU))
 
 inline __HOST_DEVICE__ half operator""_h(long double value)
 {
     return {static_cast<float>(value)};
 }
 
-inline __HOST_DEVICE__ half __habs(__half num)
+namespace hipdnn_sdk::utilities::fp16
+{
+
+inline __HOST_DEVICE__ half ushort_as_half(unsigned short x)
+{
+    __half_raw r;
+    r.x = x;
+    return r;
+}
+
+inline __HOST_DEVICE__ half habs(half num)
 {
     auto raw = static_cast<__half_raw>(num);
     raw.x &= 0x7FFFu;
     return raw;
 }
 
-inline __HOST_DEVICE__ bool __hisnan(__half x)
+inline __HOST_DEVICE__ bool hisnan(__half x)
 {
     __half_raw hr = x;
     return (hr.x & 0x7FFFU) > 0x7C00u;
 }
 
-inline __HOST_DEVICE__ __half __hmax(const __half a, const __half b)
+inline __HOST_DEVICE__ half hmax(const half a, const half b)
 {
-    if(__hisnan(a) && !__hisnan(b))
+    if(hisnan(a) && !hisnan(b))
         return b;
-    if(!__hisnan(a) && __hisnan(b))
+    if(!hisnan(a) && hisnan(b))
         return a;
-    if(__hisnan(a) && __hisnan(b))
-        return HIPRT_NAN_FP16;
+    if(hisnan(a) && hisnan(b))
+        return HIPDNN_NAN_FP16;
     if(static_cast<__half_raw>(a).x > static_cast<__half_raw>(b).x)
         return __half_raw{static_cast<__half_raw>(a).x};
     return __half_raw{static_cast<__half_raw>(b).x};
 }
 
+} // namespace hipdnn_sdk::utilities::fp16
+
 namespace std
 {
+
 inline __HOST_DEVICE__ half fabs(half num)
 {
-    return __habs(num);
+    return hipdnn_sdk::utilities::fp16::habs(num);
 }
 
 inline __HOST_DEVICE__ half max(half a, half b)
 {
-    return __hmax(a, b);
+    return hipdnn_sdk::utilities::fp16::hmax(a, b);
 }
 
-}
+} // namespace std
 
 template <>
 struct fmt::formatter<half> : fmt::formatter<float>

--- a/sdk/include/hipdnn_sdk/utilities/HalfUtils.hpp
+++ b/sdk/include/hipdnn_sdk/utilities/HalfUtils.hpp
@@ -16,8 +16,7 @@ namespace std
 {
 inline __HOST_DEVICE__ half fabs(half num)
 {
-    auto f = static_cast<float>(num);
-    return f > 0.0f ? num : half{-f};
+    return num > 0.0_h ? num : static_cast<half>(num * -1.0_h);
 }
 
 inline __HOST_DEVICE__ half max(half a, half b)

--- a/sdk/include/hipdnn_sdk/utilities/HipBfloat16Utils.hpp
+++ b/sdk/include/hipdnn_sdk/utilities/HipBfloat16Utils.hpp
@@ -7,57 +7,64 @@
 #include <hipdnn_sdk/logging/Logger.hpp>
 #include <string>
 
-#define HIPRT_NAN_BF16 __ushort_as_bfloat16(static_cast<unsigned short>(0x7FFFU))
-
-inline __HOST_DEVICE__ hip_bfloat16 __ushort_as_bfloat16(const unsigned short int a)
-{
-    hip_bfloat16 val;
-    val.data = a;
-    return val;
-}
+#define HIPDNN_NAN_BF16 ushort_as_bfloat16(static_cast<unsigned short>(0x7FFFU))
 
 inline __HOST_DEVICE__ hip_bfloat16 operator""_bf(long double value)
 {
     return hip_bfloat16(static_cast<float>(value));
 }
 
-inline __HOST_DEVICE__ hip_bfloat16 __habs(const hip_bfloat16 a)
+namespace hipdnn_sdk::utilities::bfp16
+{
+
+inline __HOST_DEVICE__ hip_bfloat16 ushort_as_bfloat16(const unsigned short int a)
+{
+    hip_bfloat16 val;
+    val.data = a;
+    return val;
+}
+
+inline __HOST_DEVICE__ hip_bfloat16 habs(const hip_bfloat16 a)
 {
     hip_bfloat16 abs = a;
     abs.data &= 0x7FFF;
     return abs;
 }
 
-inline __HOST_DEVICE__ bool __hisnan(const hip_bfloat16 a)
+inline __HOST_DEVICE__ bool hisnan(const hip_bfloat16 a)
 {
     hip_bfloat16 hr = a;
     return !(~hr.data & 0x7f80) && +(hr.data & 0x7f);
 }
 
-inline __HOST_DEVICE__ hip_bfloat16 __hmax(const hip_bfloat16 a, const hip_bfloat16 b)
+inline __HOST_DEVICE__ hip_bfloat16 hmax(const hip_bfloat16 a, const hip_bfloat16 b)
 {
-    auto a_nan = __hisnan(a), b_nan = __hisnan(b);
+    auto a_nan = hisnan(a), b_nan = hisnan(b);
     if(a_nan || b_nan)
     {
         if(a_nan && b_nan)
-            return HIPRT_NAN_BF16; // return canonical NaN
+            return HIPDNN_NAN_BF16; // return canonical NaN
         return a_nan ? b : a;
     }
     return a.data > b.data ? a : b;
 }
 
+} // namespace hipdnn_sdk::utilities::bfp16
+
 namespace std
 {
+
 inline __HOST_DEVICE__ hip_bfloat16 fabs(hip_bfloat16 num)
 {
-    return __habs(num);
+    return hipdnn_sdk::utilities::bfp16::habs(num);
 }
 
 inline __HOST_DEVICE__ hip_bfloat16 max(hip_bfloat16 a, hip_bfloat16 b)
 {
-    return __hmax(a, b);
+    return hipdnn_sdk::utilities::bfp16::hmax(a, b);
 }
-}
+
+} // namespace std
 
 template <>
 struct fmt::formatter<hip_bfloat16> : fmt::formatter<float>

--- a/sdk/include/hipdnn_sdk/utilities/HipBfloat16Utils.hpp
+++ b/sdk/include/hipdnn_sdk/utilities/HipBfloat16Utils.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <hip/amd_detail/amd_hip_bfloat16.h>
+#include <hip/hip_bfloat16.h>
 #include <hipdnn_sdk/logging/Logger.hpp>
 #include <string>
 

--- a/sdk/include/hipdnn_sdk/utilities/HipBfloat16Utils.hpp
+++ b/sdk/include/hipdnn_sdk/utilities/HipBfloat16Utils.hpp
@@ -34,8 +34,6 @@ inline __HOST_DEVICE__ bool __hisnan(const hip_bfloat16 a)
     return !(~hr.data & 0x7f80) && +(hr.data & 0x7f);
 }
 
-//#define HIPRT_NAN_BF16 __ushort_as_bfloat16((unsigned short)0x7FFFU)
-
 inline __HOST_DEVICE__ hip_bfloat16 __hmax(const hip_bfloat16 a, const hip_bfloat16 b)
 {
     auto a_nan = __hisnan(a), b_nan = __hisnan(b);

--- a/sdk/include/hipdnn_sdk/utilities/HipBfloat16Utils.hpp
+++ b/sdk/include/hipdnn_sdk/utilities/HipBfloat16Utils.hpp
@@ -7,21 +7,57 @@
 #include <hipdnn_sdk/logging/Logger.hpp>
 #include <string>
 
+#define HIPRT_NAN_BF16 __ushort_as_bfloat16(static_cast<unsigned short>(0x7FFFU))
+
+inline __HOST_DEVICE__ hip_bfloat16 __ushort_as_bfloat16(const unsigned short int a)
+{
+    hip_bfloat16 val;
+    val.data = a;
+    return val;
+}
+
 inline __HOST_DEVICE__ hip_bfloat16 operator""_bf(long double value)
 {
     return hip_bfloat16(static_cast<float>(value));
+}
+
+inline __HOST_DEVICE__ hip_bfloat16 __habs(const hip_bfloat16 a)
+{
+    hip_bfloat16 abs = a;
+    abs.data &= 0x7FFF;
+    return abs;
+}
+
+inline __HOST_DEVICE__ bool __hisnan(const hip_bfloat16 a)
+{
+    hip_bfloat16 hr = a;
+    return !(~hr.data & 0x7f80) && +(hr.data & 0x7f);
+}
+
+//#define HIPRT_NAN_BF16 __ushort_as_bfloat16((unsigned short)0x7FFFU)
+
+inline __HOST_DEVICE__ hip_bfloat16 __hmax(const hip_bfloat16 a, const hip_bfloat16 b)
+{
+    auto a_nan = __hisnan(a), b_nan = __hisnan(b);
+    if(a_nan || b_nan)
+    {
+        if(a_nan && b_nan)
+            return HIPRT_NAN_BF16; // return canonical NaN
+        return a_nan ? b : a;
+    }
+    return a.data > b.data ? a : b;
 }
 
 namespace std
 {
 inline __HOST_DEVICE__ hip_bfloat16 fabs(hip_bfloat16 num)
 {
-    return num > 0.0_bf ? num : num * -1.0_bf;
+    return __habs(num);
 }
 
 inline __HOST_DEVICE__ hip_bfloat16 max(hip_bfloat16 a, hip_bfloat16 b)
 {
-    return a > b ? a : b;
+    return __hmax(a, b);
 }
 }
 

--- a/sdk/schemas/tensor_attributes.fbs
+++ b/sdk/schemas/tensor_attributes.fbs
@@ -10,7 +10,11 @@ struct Float32Value {
 }
 
 struct Float16Value {
-  value: ushort;
+  value: float;
+}
+
+struct BFloat16Value {
+  value: float;
 }
 
 struct Float8Value {
@@ -28,6 +32,7 @@ struct Float64Value {
 union TensorValue {
   Float32Value,
   Float16Value,
+  BFloat16Value,
   Float8Value,
   Int32Value,
   Float64Value

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ if(HIP_DNN_SKIP_TESTS)
 endif()
 
 add_compile_definitions(__HIP_PLATFORM_AMD__)
-add_compile_definitions(__HIPCC__)
+#add_compile_definitions(__HIPCC__)
 find_package(hip REQUIRED)
 find_package(Threads REQUIRED)
 enable_language(HIP)
@@ -45,7 +45,6 @@ target_link_libraries(hipdnn_sdk_tests
     Threads::Threads
     hipdnn_sdk
     hip::host
-    hip::device
     spdlog_header_only
     ${CMAKE_DL_LIBS}
 )

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -9,7 +9,6 @@ if(HIP_DNN_SKIP_TESTS)
 endif()
 
 add_compile_definitions(__HIP_PLATFORM_AMD__)
-#add_compile_definitions(__HIPCC__)
 find_package(hip REQUIRED)
 find_package(Threads REQUIRED)
 enable_language(HIP)

--- a/tests/backend/CMakeLists.txt
+++ b/tests/backend/CMakeLists.txt
@@ -28,7 +28,6 @@ target_link_libraries(public_hipdnn_backend_tests
     hipdnn_sdk
     hipdnn_backend
     hip::host
-    hip::device
 )
 
 target_include_directories(public_hipdnn_backend_tests

--- a/tests/frontend/CMakeLists.txt
+++ b/tests/frontend/CMakeLists.txt
@@ -19,7 +19,6 @@ target_link_libraries(public_hipdnn_frontend_tests
     hipdnn_backend
     hipdnn_frontend
     hip::host
-    hip::device
 )
 
 target_include_directories(public_hipdnn_frontend_tests


### PR DESCRIPTION
## Proposed changes
- Reworking how we use hip half and bfloat16 to remove hip::device link
- Reworked constructors to share the set_value method

## Checklist

- [x] I have added automated tests relevant to the introduced functionality
- [x] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [x] I have ran the tests, and they are all passing locally
- [x] I have ran the tests with ASAN, and they are all passing locally
- [x] I have added relevant documentation for the changes
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] I have ran `make format` & `make check_format` to ensure the changes have been formatted
