### PR TITLE
Followup on unhappy path testing PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BrianHarrisonAMD @BradPepersAMD @adickin-amd @JonathanLichtnerAMD @bghimireamd @averinevg @SamuelReeder @mousdahl-amd
+* @BrianHarrisonAMD @BradPepersAMD @adickin-amd @JonathanLichtnerAMD @bghimireamd @averinevg @SamuelReeder @mousdahl-amd @jerehartAMD

--- a/backend/include/HipdnnBackendLimits.h
+++ b/backend/include/HipdnnBackendLimits.h
@@ -9,5 +9,5 @@
  *
  * This value is used across the API and backend to size buffers for error strings.
  */
-#define HIPDNN_MAX_ERROR_STRING_SIZE 256
+#define HIPDNN_ERROR_STRING_MAX_LENGTH 2048
 // NOLINTEND

--- a/backend/include/hipdnn_backend.h
+++ b/backend/include/hipdnn_backend.h
@@ -242,7 +242,7 @@ HIPDNN_BACKEND_EXPORT const char* hipdnnGetErrorString(hipdnnStatus_t status);
  *
  * This function copies the last error message associated with the calling thread into the provided
  * message buffer, up to max_size bytes (including the null terminator).
- * Note the max size for an error message is HIPDNN_MAX_ERROR_STRING_SIZE characters.
+ * Note the max size for an error message is HIPDNN_ERROR_STRING_MAX_LENGTH characters.
  * 
  * @param[out] message   Pointer to a character buffer where the error message will be copied.
  * @param[in]  maxSize   Maximum number of bytes to copy, including the null terminator.

--- a/backend/src/Helpers.hpp
+++ b/backend/src/Helpers.hpp
@@ -12,7 +12,7 @@ namespace hipdnn_backend
 {
 
 template <class F>
-hipdnnStatus_t tryCatch(F f)
+hipdnnStatus_t tryCatch(F f, std::string const& prefix = std::string{})
 {
     try
     {
@@ -20,16 +20,17 @@ hipdnnStatus_t tryCatch(F f)
     }
     catch(const HipdnnException& ex)
     {
-        return LastErrorManager::setLastError(ex.getStatus(), ex.what());
+        return LastErrorManager::setLastError(ex.getStatus(), (prefix + ex.what()).c_str());
     }
     catch(const std::exception& ex)
     {
-        return LastErrorManager::setLastError(HIPDNN_STATUS_INTERNAL_ERROR, ex.what());
+        return LastErrorManager::setLastError(HIPDNN_STATUS_INTERNAL_ERROR,
+                                              (prefix + ex.what()).c_str());
     }
     catch(...)
     {
         return LastErrorManager::setLastError(HIPDNN_STATUS_INTERNAL_ERROR,
-                                              "Unknown exception occured");
+                                              (prefix + "Unknown exception occured").c_str());
     }
     return HIPDNN_STATUS_SUCCESS;
 }

--- a/backend/src/LastErrorManager.cpp
+++ b/backend/src/LastErrorManager.cpp
@@ -7,7 +7,8 @@
 #include <hipdnn_sdk/utilities/StringUtil.hpp>
 
 // NOLINTNEXTLINE
-thread_local char hipdnn_backend::LastErrorManager::s_lastError[HIPDNN_MAX_ERROR_STRING_SIZE] = "";
+thread_local char hipdnn_backend::LastErrorManager::s_lastError[HIPDNN_ERROR_STRING_MAX_LENGTH]
+    = "";
 
 hipdnnStatus_t hipdnn_backend::LastErrorManager::setLastError(hipdnnStatus_t status,
                                                               const char* message)
@@ -21,7 +22,7 @@ hipdnnStatus_t hipdnn_backend::LastErrorManager::setLastError(hipdnnStatus_t sta
         "Error occured in status:{} message:{}", hipdnnGetStatusString(status), message);
 
     hipdnn_sdk::utilities::copyMaxSizeWithNullTerminator(
-        s_lastError, message, HIPDNN_MAX_ERROR_STRING_SIZE);
+        s_lastError, message, HIPDNN_ERROR_STRING_MAX_LENGTH);
 
     return status;
 }

--- a/backend/src/LastErrorManager.hpp
+++ b/backend/src/LastErrorManager.hpp
@@ -17,7 +17,7 @@ private:
     // This prevents the shared object (plugin) from being unloaded until the program terminates.
     // Note: We need to nolint this to avoid issues since static confused clang-tidy.
     // NOLINTNEXTLINE
-    thread_local static char s_lastError[HIPDNN_MAX_ERROR_STRING_SIZE];
+    thread_local static char s_lastError[HIPDNN_ERROR_STRING_MAX_LENGTH];
 
 public:
     static hipdnnStatus_t setLastError(hipdnnStatus_t status, const char* message);

--- a/backend/src/plugin/PluginCore.hpp
+++ b/backend/src/plugin/PluginCore.hpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "Helpers.hpp"
 #include "HipdnnBackendPluginLoadingMode.h"
 #include "PlatformUtils.hpp"
 #include "logging/Logging.hpp"
@@ -244,53 +245,50 @@ private:
 
         HIPDNN_LOG_INFO("Attempting to load plugin from [{}]", filePath.string());
 
-        try
-        {
-            SharedLibrary lib(filePath);
-            const auto libraryPath = lib.libraryPath();
+        hipdnn_backend::tryCatch(
+            [&]() {
+                SharedLibrary lib(filePath);
+                const auto libraryPath = lib.libraryPath();
 
-            // Shared library ensures an injective, weakly canonical mapping to a path
-            if(_loadedPluginFiles.contains(libraryPath))
-            {
-                return;
-            }
+                // Shared library ensures an injective, weakly canonical mapping to a path
+                if(_loadedPluginFiles.contains(libraryPath))
+                {
+                    return;
+                }
 
-            std::shared_ptr<Plugin> plugin = std::shared_ptr<Plugin>(new Plugin(std::move(lib)));
+                std::shared_ptr<Plugin> plugin
+                    = std::shared_ptr<Plugin>(new Plugin(std::move(lib)));
 
-            const auto name = plugin->name();
-            const auto version = plugin->version();
-            const auto type = plugin->type();
+                const auto name = plugin->name();
+                const auto version = plugin->version();
+                const auto type = plugin->type();
 
-            // For now only use engine or unspecified plugin types
-            if(type != Plugin::getPluginType())
-            {
-                throw HipdnnException(HIPDNN_STATUS_PLUGIN_ERROR,
-                                      std::string("Plugin type mismatch: expected ")
-                                          + toString(Plugin::getPluginType()) + ", got "
-                                          + toString(type));
-            }
+                // For now only use engine or unspecified plugin types
+                if(type != Plugin::getPluginType())
+                {
+                    throw HipdnnException(HIPDNN_STATUS_PLUGIN_ERROR,
+                                          std::string("Plugin type mismatch: expected ")
+                                              + toString(Plugin::getPluginType()) + ", got "
+                                              + toString(type));
+                }
 
-            plugin->setLoggingCallback(logging::hipdnnLoggingCallback);
+                plugin->setLoggingCallback(logging::hipdnnLoggingCallback);
 
-            validateBeforeAdding(*plugin);
+                validateBeforeAdding(*plugin);
 
-            _plugins.emplace_back(std::move(plugin));
-            _loadedPluginFiles.insert(libraryPath);
+                _plugins.emplace_back(std::move(plugin));
+                _loadedPluginFiles.insert(libraryPath);
 
-            HIPDNN_LOG_INFO("Plugin loaded successfully: {}", filePath.string());
-            HIPDNN_LOG_INFO("Plugin info: name={}, version={}, type={}({})",
-                            name,
-                            version,
-                            type,
-                            static_cast<int>(type));
+                HIPDNN_LOG_INFO("Plugin loaded successfully: {}", filePath.string());
+                HIPDNN_LOG_INFO("Plugin info: name={}, version={}, type={}({})",
+                                name,
+                                version,
+                                type,
+                                static_cast<int>(type));
 
-            actionAfterAdding(*_plugins.back());
-        }
-        catch(const HipdnnException& e)
-        {
-            HIPDNN_LOG_WARN(
-                "Error loading plugin from [{}]: {}", filePath.string(), e.getMessage());
-        }
+                actionAfterAdding(*_plugins.back());
+            },
+            fmt::format("Error loading plugin from [{}]: ", filePath.string()).c_str());
     }
 
     std::vector<std::shared_ptr<Plugin>> _plugins;

--- a/backend/tests/TestPlugin.cpp
+++ b/backend/tests/TestPlugin.cpp
@@ -15,6 +15,7 @@
 #include <hipdnn_sdk/test_utilities/TempDirectory.hpp>
 
 using namespace hipdnn_backend;
+using namespace hipdnn_sdk::test_utilities;
 
 namespace
 {

--- a/docs/Environment.md
+++ b/docs/Environment.md
@@ -70,7 +70,7 @@ hipDNN provides functions for retrieving error information:
 const char* error_str = hipdnnGetErrorString(status);
 
 // Get detailed error message for the current thread
-char message[HIPDNN_MAX_ERROR_STRING_SIZE];
+char message[HIPDNN_ERROR_STRING_MAX_LENGTH];
 hipdnnGetLastErrorString(message, sizeof(message));
 ```
 

--- a/frontend/include/hipdnn_frontend/backend/ScopedHipdnnBackendDescriptor.hpp
+++ b/frontend/include/hipdnn_frontend/backend/ScopedHipdnnBackendDescriptor.hpp
@@ -23,7 +23,7 @@ private:
     static void logBackendError([[maybe_unused]] const std::string& errorString,
                                 [[maybe_unused]] const hipdnnStatus_t status)
     {
-        std::array<char, HIPDNN_MAX_ERROR_STRING_SIZE> backendErrMsg;
+        std::array<char, HIPDNN_ERROR_STRING_MAX_LENGTH> backendErrMsg;
         hipdnn_frontend::hipdnnBackend()->getLastErrorString(backendErrMsg.data(),
                                                              backendErrMsg.size());
         HIPDNN_LOG_ERROR(

--- a/sdk/include/hipdnn_sdk/plugin/PluginApi.h
+++ b/sdk/include/hipdnn_sdk/plugin/PluginApi.h
@@ -85,7 +85,7 @@ HIPDNN_PLUGIN_EXPORT void hipdnnPluginGetLastErrorString(const char** error_str)
  * The length includes the null-terminating character.
  * This is the recommended size for the internal per-thread buffer.
  */
-#define HIPDNN_PLUGIN_ERROR_STRING_MAX_LENGTH 256
+#define HIPDNN_PLUGIN_ERROR_STRING_MAX_LENGTH 2048
 
 /**
  * @brief Sets the logging callback function for the plugin.

--- a/sdk/include/hipdnn_sdk/test_utilities/TempDirectory.hpp
+++ b/sdk/include/hipdnn_sdk/test_utilities/TempDirectory.hpp
@@ -2,6 +2,9 @@
 
 #include <filesystem>
 
+namespace hipdnn_sdk::test_utilities
+{
+
 class TempDirectory
 {
     std::filesystem::path _path;
@@ -35,3 +38,5 @@ public:
         }
     }
 };
+
+}

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(hipdnn_sdk_tests
     test_utilities/TestCpuFpReferenceImplementation.cpp
     test_utilities/TestCpuFpReferenceValidation.cpp
     test_utilities/TestCpuFpReferenceMiopenRmsValidation.cpp
+    test_utilities/TestTempDirectory.cpp
 )
 
 target_compile_definitions(hipdnn_sdk_tests PRIVATE

--- a/sdk/tests/test_utilities/TestTempDirectory.cpp
+++ b/sdk/tests/test_utilities/TestTempDirectory.cpp
@@ -1,0 +1,35 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+
+#include <hipdnn_sdk/test_utilities/TempDirectory.hpp>
+
+using namespace hipdnn_sdk::test_utilities;
+
+TEST(TestTempDirectory, CreatesAndDestroys)
+{
+    std::filesystem::path folderPath = "OIJIR44E";
+    ASSERT_FALSE(std::filesystem::exists(folderPath));
+
+    {
+        TempDirectory temp(folderPath);
+        ASSERT_TRUE(std::filesystem::exists(folderPath));
+    }
+
+    ASSERT_FALSE(std::filesystem::exists(folderPath));
+}
+
+TEST(TestTempDirectory, ExistingPath)
+{
+    std::filesystem::path folderPath = "REPOIEHJv28";
+    ASSERT_FALSE(std::filesystem::exists(folderPath));
+    std::filesystem::create_directory(folderPath);
+    ASSERT_TRUE(std::filesystem::exists(folderPath));
+
+    EXPECT_THROW(TempDirectory{folderPath}, std::runtime_error);
+
+    ASSERT_TRUE(std::filesystem::exists(folderPath));
+
+    std::filesystem::remove_all(folderPath);
+}

--- a/tests/backend/CMakeLists.txt
+++ b/tests/backend/CMakeLists.txt
@@ -40,7 +40,8 @@ target_compile_definitions(public_hipdnn_backend_tests
     PRIVATE
     TEST_GOOD_PLUGIN_NAME="${TEST_GOOD_PLUGIN_NAME}"
     TEST_EXECUTE_FAILS_PLUGIN_NAME="${TEST_EXECUTE_FAILS_PLUGIN_NAME}"
-    TEST_NO_APPLICABLE_ENGINES_PLUGIN_NAME="${TEST_NO_APPLICABLE_ENGINES_PLUGIN_NAME}"
+    TEST_NO_APPLICABLE_ENGINES_A_PLUGIN_NAME="${TEST_NO_APPLICABLE_ENGINES_A_PLUGIN_NAME}"
+    TEST_NO_APPLICABLE_ENGINES_B_PLUGIN_NAME="${TEST_NO_APPLICABLE_ENGINES_B_PLUGIN_NAME}"
     TEST_DUPLICATE_ID_A_PLUGIN_NAME="${TEST_DUPLICATE_ID_A_PLUGIN_NAME}"
     TEST_DUPLICATE_ID_B_PLUGIN_NAME="${TEST_DUPLICATE_ID_B_PLUGIN_NAME}"
     TEST_INCOMPLETE_API_PLUGIN_NAME="${TEST_INCOMPLETE_API_PLUGIN_NAME}"
@@ -50,7 +51,8 @@ target_compile_definitions(public_hipdnn_backend_tests
 add_dependencies(public_hipdnn_backend_tests 
     test_good_plugin 
     test_execute_fails_plugin 
-    test_no_applicable_engines_plugin 
+    test_no_applicable_engines_a_plugin
+    test_no_applicable_engines_b_plugin
     test_good_default_plugin
     test_duplicate_id_a_plugin
     test_duplicate_id_b_plugin

--- a/tests/backend/IntegrationGetLastErrorString.cpp
+++ b/tests/backend/IntegrationGetLastErrorString.cpp
@@ -41,7 +41,7 @@ TEST(IntegrationGetErrorString, AllStatusCodes)
 
 TEST(IntegrationGetLastErrorString, ReturnLastError)
 {
-    char buffer[HIPDNN_MAX_ERROR_STRING_SIZE];
+    char buffer[HIPDNN_ERROR_STRING_MAX_LENGTH];
     hipdnnStatus_t status = hipdnnDestroy(nullptr);
     ASSERT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
@@ -75,19 +75,19 @@ TEST(IntegrationGetLastErrorString, PerThreadErrorIsolation)
 {
     // Set error in main thread
     hipdnnDestroy(nullptr);
-    char mainBuf[HIPDNN_MAX_ERROR_STRING_SIZE];
+    char mainBuf[HIPDNN_ERROR_STRING_MAX_LENGTH];
     hipdnnGetLastErrorString(mainBuf, sizeof(mainBuf));
 
     std::string threadError;
     std::thread t([&threadError]() {
-        char buf[HIPDNN_MAX_ERROR_STRING_SIZE];
+        char buf[HIPDNN_ERROR_STRING_MAX_LENGTH];
         hipdnnGetLastErrorString(buf, sizeof(buf));
         threadError = buf;
     });
     t.join();
 
     // Main thread error should be unchanged
-    char mainBuf2[HIPDNN_MAX_ERROR_STRING_SIZE];
+    char mainBuf2[HIPDNN_ERROR_STRING_MAX_LENGTH];
     hipdnnGetLastErrorString(mainBuf2, sizeof(mainBuf2));
     ASSERT_STREQ(mainBuf, mainBuf2);
     ASSERT_TRUE(threadError.empty());
@@ -99,7 +99,7 @@ TEST(IntegrationGetLastErrorString, BufferLargerThanMax)
     char mainBuf[1028];
     hipdnnGetLastErrorString(mainBuf, sizeof(mainBuf));
 
-    char mainBuf2[HIPDNN_MAX_ERROR_STRING_SIZE];
+    char mainBuf2[HIPDNN_ERROR_STRING_MAX_LENGTH];
     hipdnnGetLastErrorString(mainBuf2, sizeof(mainBuf2));
     ASSERT_STREQ(mainBuf, mainBuf2);
 }

--- a/tests/backend/IntegrationPluginLoading.cpp
+++ b/tests/backend/IntegrationPluginLoading.cpp
@@ -141,9 +141,8 @@ TEST_F(IntegrationPluginLoading, IncorrectEngineID)
 
     ASSERT_EQ(hipdnnBackendFinalize(_engine), HIPDNN_STATUS_BAD_PARAM);
 
-    constexpr size_t BUFFER_SIZE = 512;
-    std::array<char, BUFFER_SIZE> buffer;
-    hipdnnGetLastErrorString(buffer.data(), BUFFER_SIZE);
+    std::array<char, HIPDNN_ERROR_STRING_MAX_LENGTH> buffer;
+    hipdnnGetLastErrorString(buffer.data(), buffer.size());
 
     ASSERT_EQ(
         std::string{buffer.data()},
@@ -161,14 +160,13 @@ TEST_F(IntegrationPluginLoading, DuplicateEngineIds)
 
     ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
 
-    constexpr size_t BUFFER_SIZE = 2048;
-    std::array<char, BUFFER_SIZE> buffer;
-    hipdnnGetLastErrorString(buffer.data(), BUFFER_SIZE);
+    std::array<char, HIPDNN_ERROR_STRING_MAX_LENGTH> buffer;
+    hipdnnGetLastErrorString(buffer.data(), buffer.size());
 
     std::string expectedError
         = fmt::format("Engine ID {} already exists",
                       hipdnn_tests::plugin_constants::engineId<DuplicateIdBPlugin>());
-    ;
+
     EXPECT_NE(std::string{buffer.data()}.find(expectedError), std::string::npos);
 
     EXPECT_EQ(test_util::getLoadedPlugins(_handle).size(), 1);
@@ -186,9 +184,8 @@ TEST_F(IntegrationPluginLoading, IncompleteAPI)
 
     ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
 
-    constexpr size_t BUFFER_SIZE = 2048;
-    std::array<char, BUFFER_SIZE> buffer;
-    hipdnnGetLastErrorString(buffer.data(), BUFFER_SIZE);
+    std::array<char, HIPDNN_ERROR_STRING_MAX_LENGTH> buffer;
+    hipdnnGetLastErrorString(buffer.data(), buffer.size());
 
     EXPECT_NE(std::string{buffer.data()}.find("Failed to get symbol"), std::string::npos);
     EXPECT_EQ(test_util::getLoadedPlugins(_handle).size(), 0);

--- a/tests/backend/IntegrationPluginLoading.cpp
+++ b/tests/backend/IntegrationPluginLoading.cpp
@@ -14,8 +14,10 @@
 #include <HipdnnBackendHeuristicType.h>
 #include <hipdnn_sdk/test_utilities/TempDirectory.hpp>
 #include <test_plugins/TestPluginConstants.hpp>
+#include <test_plugins/TestPluginEngineIdMap.hpp>
 
 #include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
 
 class IntegrationPluginLoading : public ::testing::Test
 {
@@ -189,7 +191,15 @@ TEST_F(IntegrationPluginLoading, DuplicateEngineIds)
 
     ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
 
-    // TODO: Warning is logged, but we don't have means of querying the last warning
+    constexpr size_t BUFFER_SIZE = 2048;
+    std::array<char, BUFFER_SIZE> buffer;
+    hipdnnGetLastErrorString(buffer.data(), BUFFER_SIZE);
+
+    std::string expectedError
+        = fmt::format("Engine ID {} already exists",
+                      hipdnn_tests::plugin_constants::engineId<DuplicateIdBPlugin>());
+    ;
+    EXPECT_NE(std::string{buffer.data()}.find(expectedError), std::string::npos);
 
     EXPECT_EQ(test_util::getLoadedPlugins(_handle).size(), 1);
 }
@@ -206,8 +216,11 @@ TEST_F(IntegrationPluginLoading, IncompleteAPI)
 
     ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
 
-    // TODO: Warning is logged, but we don't have means of querying the last warning
+    constexpr size_t BUFFER_SIZE = 2048;
+    std::array<char, BUFFER_SIZE> buffer;
+    hipdnnGetLastErrorString(buffer.data(), BUFFER_SIZE);
 
+    EXPECT_NE(std::string{buffer.data()}.find("Failed to get symbol"), std::string::npos);
     EXPECT_EQ(test_util::getLoadedPlugins(_handle).size(), 0);
 }
 

--- a/tests/backend/IntegrationPluginLoading.cpp
+++ b/tests/backend/IntegrationPluginLoading.cpp
@@ -92,7 +92,7 @@ void createHeuristicDescriptor(hipdnnBackendDescriptor_t* heuristicDescriptor,
 
 TEST_F(IntegrationPluginLoading, EmptyPluginPath)
 {
-    TempDirectory pluginDir("empty_plugins");
+    hipdnn_sdk::test_utilities::TempDirectory pluginDir("empty_plugins");
     auto pluginPath = pluginDir.path().string();
     const std::array<const char*, 1> paths = {pluginPath.c_str()};
     ASSERT_EQ(

--- a/tests/backend/IntegrationPluginLoading.cpp
+++ b/tests/backend/IntegrationPluginLoading.cpp
@@ -121,40 +121,10 @@ TEST_F(IntegrationPluginLoading, EmptyPluginPath)
     EXPECT_EQ(availableEngineCount, 0);
 }
 
-TEST_F(IntegrationPluginLoading, NoPluginsSupportGraph)
-{
-    const std::array<const char*, 1> paths
-        = {hipdnn_tests::plugin_constants::testNoApplicableEnginesPluginPath().c_str()};
-    ASSERT_EQ(
-        hipdnnSetEnginePluginPaths_ext(paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
-        HIPDNN_STATUS_SUCCESS);
-
-    ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
-    EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engineConfig),
-              HIPDNN_STATUS_SUCCESS);
-    ASSERT_NE(_engineConfig, nullptr);
-
-    test_util::createTestGraph(&_graph, _handle);
-    hipdnnBackendFinalize(_graph);
-
-    createHeuristicDescriptor(&_heuristicDescriptor, &_graph, true);
-
-    auto availableEngineCount = int64_t{-1};
-    EXPECT_EQ(hipdnnBackendGetAttribute(_heuristicDescriptor,
-                                        HIPDNN_ATTR_ENGINEHEUR_RESULTS,
-                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                        0,
-                                        &availableEngineCount,
-                                        nullptr),
-              HIPDNN_STATUS_SUCCESS);
-
-    EXPECT_EQ(availableEngineCount, 0);
-}
-
 TEST_F(IntegrationPluginLoading, IncorrectEngineID)
 {
     const std::array<const char*, 1> paths
-        = {hipdnn_tests::plugin_constants::testNoApplicableEnginesPluginPath().c_str()};
+        = {hipdnn_tests::plugin_constants::testNoApplicableEnginesAPluginPath().c_str()};
     ASSERT_EQ(
         hipdnnSetEnginePluginPaths_ext(paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
         HIPDNN_STATUS_SUCCESS);
@@ -224,10 +194,71 @@ TEST_F(IntegrationPluginLoading, IncompleteAPI)
     EXPECT_EQ(test_util::getLoadedPlugins(_handle).size(), 0);
 }
 
+TEST_F(IntegrationPluginLoading, SinglePluginNoApplicableEngines)
+{
+    const std::array<const char*, 1> paths
+        = {hipdnn_tests::plugin_constants::testNoApplicableEnginesAPluginPath().c_str()};
+    ASSERT_EQ(
+        hipdnnSetEnginePluginPaths_ext(paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
+    EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engineConfig),
+              HIPDNN_STATUS_SUCCESS);
+    ASSERT_NE(_engineConfig, nullptr);
+
+    test_util::createTestGraph(&_graph, _handle);
+    hipdnnBackendFinalize(_graph);
+
+    createHeuristicDescriptor(&_heuristicDescriptor, &_graph, true);
+
+    auto availableEngineCount = int64_t{-1};
+    EXPECT_EQ(hipdnnBackendGetAttribute(_heuristicDescriptor,
+                                        HIPDNN_ATTR_ENGINEHEUR_RESULTS,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        0,
+                                        &availableEngineCount,
+                                        nullptr),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(availableEngineCount, 0);
+}
+
+TEST_F(IntegrationPluginLoading, MultiplePluginsNoApplicableEngines)
+{
+    const std::array<const char*, 2> paths
+        = {hipdnn_tests::plugin_constants::testNoApplicableEnginesAPluginPath().c_str(),
+           hipdnn_tests::plugin_constants::testNoApplicableEnginesBPluginPath().c_str()};
+    ASSERT_EQ(
+        hipdnnSetEnginePluginPaths_ext(paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
+    EXPECT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engineConfig),
+              HIPDNN_STATUS_SUCCESS);
+    ASSERT_NE(_engineConfig, nullptr);
+
+    test_util::createTestGraph(&_graph, _handle);
+    hipdnnBackendFinalize(_graph);
+
+    createHeuristicDescriptor(&_heuristicDescriptor, &_graph, true);
+
+    auto availableEngineCount = int64_t{-1};
+    EXPECT_EQ(hipdnnBackendGetAttribute(_heuristicDescriptor,
+                                        HIPDNN_ATTR_ENGINEHEUR_RESULTS,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        0,
+                                        &availableEngineCount,
+                                        nullptr),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(availableEngineCount, 0);
+}
+
 TEST_F(IntegrationPluginLoading, MultiplePluginsOneApplicableEngine)
 {
     const std::array<const char*, 1> paths
-        = {hipdnn_tests::plugin_constants::testNoApplicableEnginesPluginPath().c_str()};
+        = {hipdnn_tests::plugin_constants::testNoApplicableEnginesAPluginPath().c_str()};
     ASSERT_EQ(
         hipdnnSetEnginePluginPaths_ext(paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ADDITIVE),
         HIPDNN_STATUS_SUCCESS);

--- a/tests/frontend/CMakeLists.txt
+++ b/tests/frontend/CMakeLists.txt
@@ -31,14 +31,23 @@ target_compile_definitions(public_hipdnn_frontend_tests
     PRIVATE
     TEST_GOOD_PLUGIN_NAME="${TEST_GOOD_PLUGIN_NAME}"
     TEST_EXECUTE_FAILS_PLUGIN_NAME="${TEST_EXECUTE_FAILS_PLUGIN_NAME}"
-    TEST_NO_APPLICABLE_ENGINES_PLUGIN_NAME="${TEST_NO_APPLICABLE_ENGINES_PLUGIN_NAME}"
+    TEST_NO_APPLICABLE_ENGINES_A_PLUGIN_NAME="${TEST_NO_APPLICABLE_ENGINES_A_PLUGIN_NAME}"
+    TEST_NO_APPLICABLE_ENGINES_B_PLUGIN_NAME="${TEST_NO_APPLICABLE_ENGINES_B_PLUGIN_NAME}"
     TEST_DUPLICATE_ID_A_PLUGIN_NAME="${TEST_DUPLICATE_ID_A_PLUGIN_NAME}"
     TEST_DUPLICATE_ID_B_PLUGIN_NAME="${TEST_DUPLICATE_ID_B_PLUGIN_NAME}"
     TEST_INCOMPLETE_API_PLUGIN_NAME="${TEST_INCOMPLETE_API_PLUGIN_NAME}"
 )
 
 # Ensure test plugins are built before tests
-add_dependencies(public_hipdnn_frontend_tests test_good_plugin test_execute_fails_plugin test_no_applicable_engines_plugin)
+add_dependencies(public_hipdnn_frontend_tests 
+    test_good_plugin
+    test_execute_fails_plugin
+    test_no_applicable_engines_a_plugin
+    test_no_applicable_engines_b_plugin
+    test_duplicate_id_a_plugin
+    test_duplicate_id_b_plugin
+    test_incomplete_api_plugin
+)
 
 clang_tidy_check(public_hipdnn_frontend_tests)
 add_integration_test_target(public_hipdnn_frontend_tests ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/frontend/FrontendIntegrationTest.cpp
+++ b/tests/frontend/FrontendIntegrationTest.cpp
@@ -317,7 +317,7 @@ INSTANTIATE_TEST_SUITE_P(
                             "ExecuteFailsPluginBatchnormTest",
                             FailurePoint::EXECUTE,
                             true},
-        IntegrationTestCase{hipdnn_tests::plugin_constants::testNoApplicableEnginesPluginPath(),
+        IntegrationTestCase{hipdnn_tests::plugin_constants::testNoApplicableEnginesAPluginPath(),
                             "NoApplicableEnginesPlugin",
                             "NoEnginesPluginBatchnormTest",
                             FailurePoint::CREATE_EXECUTION_PLAN,

--- a/tests/frontend/IntegrationBatchnormForwardInference.cpp
+++ b/tests/frontend/IntegrationBatchnormForwardInference.cpp
@@ -317,7 +317,7 @@ INSTANTIATE_TEST_SUITE_P(
                             "ExecuteFailsPluginBatchnormTest",
                             FailurePoint::EXECUTE,
                             true},
-        IntegrationTestCase{hipdnn_tests::plugin_constants::testNoApplicableEnginesPluginPath(),
+        IntegrationTestCase{hipdnn_tests::plugin_constants::testNoApplicableEnginesAPluginPath(),
                             "NoApplicableEnginesPlugin",
                             "NoEnginesPluginBatchnormTest",
                             FailurePoint::CREATE_EXECUTION_PLAN,

--- a/tests/test_plugins/CMakeLists.txt
+++ b/tests/test_plugins/CMakeLists.txt
@@ -10,7 +10,8 @@ find_package(hip REQUIRED)
 # Define plugin names as variables
 set(TEST_GOOD_PLUGIN_NAME "test_good_plugin")
 set(TEST_EXECUTE_FAILS_PLUGIN_NAME "test_execute_fails_plugin")
-set(TEST_NO_APPLICABLE_ENGINES_PLUGIN_NAME "test_no_applicable_engines_plugin")
+set(TEST_NO_APPLICABLE_ENGINES_A_PLUGIN_NAME "test_no_applicable_engines_a_plugin")
+set(TEST_NO_APPLICABLE_ENGINES_B_PLUGIN_NAME "test_no_applicable_engines_b_plugin")
 set(TEST_DUPLICATE_ID_A_PLUGIN_NAME "test_duplicate_id_a_plugin")
 set(TEST_DUPLICATE_ID_B_PLUGIN_NAME "test_duplicate_id_b_plugin")
 set(TEST_INCOMPLETE_API_PLUGIN_NAME "test_incomplete_api_plugin")
@@ -60,8 +61,9 @@ add_test_plugin(${TEST_GOOD_PLUGIN_NAME} TestGoodPlugin.cpp)
 # test_execute_fails_plugin is a plugin that fails during execution
 add_test_plugin(${TEST_EXECUTE_FAILS_PLUGIN_NAME} TestExecuteFailsPlugin.cpp)
 
-# test_no_applicable_engines_plugin is a plugin that reports no applicable engines
-add_test_plugin(${TEST_NO_APPLICABLE_ENGINES_PLUGIN_NAME} TestNoApplicableEnginesPlugin.cpp)
+# test_no_applicable_engines_a/b_plugin is a plugin that reports no applicable engines
+add_test_plugin(${TEST_NO_APPLICABLE_ENGINES_A_PLUGIN_NAME} TestNoApplicableEnginesAPlugin.cpp)
+add_test_plugin(${TEST_NO_APPLICABLE_ENGINES_B_PLUGIN_NAME} TestNoApplicableEnginesBPlugin.cpp)
 
 # test_good_plugin_duplicate_id_a/b shares an engine id with each other
 add_test_plugin(${TEST_DUPLICATE_ID_A_PLUGIN_NAME} TestDuplicateIdAPlugin.cpp)
@@ -88,7 +90,8 @@ add_custom_command(TARGET test_good_default_plugin POST_BUILD
 # Export plugin names to parent scope for use in test compilation
 set(TEST_GOOD_PLUGIN_NAME "${TEST_GOOD_PLUGIN_NAME}" PARENT_SCOPE)
 set(TEST_EXECUTE_FAILS_PLUGIN_NAME "${TEST_EXECUTE_FAILS_PLUGIN_NAME}" PARENT_SCOPE)
-set(TEST_NO_APPLICABLE_ENGINES_PLUGIN_NAME "${TEST_NO_APPLICABLE_ENGINES_PLUGIN_NAME}" PARENT_SCOPE)
+set(TEST_NO_APPLICABLE_ENGINES_A_PLUGIN_NAME "${TEST_NO_APPLICABLE_ENGINES_A_PLUGIN_NAME}" PARENT_SCOPE)
+set(TEST_NO_APPLICABLE_ENGINES_B_PLUGIN_NAME "${TEST_NO_APPLICABLE_ENGINES_B_PLUGIN_NAME}" PARENT_SCOPE)
 set(TEST_DUPLICATE_ID_A_PLUGIN_NAME "${TEST_DUPLICATE_ID_A_PLUGIN_NAME}" PARENT_SCOPE)
 set(TEST_DUPLICATE_ID_B_PLUGIN_NAME "${TEST_DUPLICATE_ID_B_PLUGIN_NAME}" PARENT_SCOPE)
 set(TEST_INCOMPLETE_API_PLUGIN_NAME "${TEST_INCOMPLETE_API_PLUGIN_NAME}" PARENT_SCOPE)

--- a/tests/test_plugins/TestNoApplicableEnginesAPlugin.cpp
+++ b/tests/test_plugins/TestNoApplicableEnginesAPlugin.cpp
@@ -13,7 +13,7 @@ class NoApplicableEnginesAPlugin : public TestPluginBase
 public:
     const char* getPluginName() const override
     {
-        return "test_NoApplicableEnginesPlugin";
+        return "test_NoApplicableEnginesAPlugin";
     }
     const char* getPluginVersion() const override
     {

--- a/tests/test_plugins/TestNoApplicableEnginesAPlugin.cpp
+++ b/tests/test_plugins/TestNoApplicableEnginesAPlugin.cpp
@@ -8,7 +8,7 @@ thread_local char
     hipdnn_plugin::PluginLastErrorManager::s_lastError[HIPDNN_PLUGIN_ERROR_STRING_MAX_LENGTH]
     = "";
 
-class NoApplicableEnginesPlugin : public TestPluginBase
+class NoApplicableEnginesAPlugin : public TestPluginBase
 {
 public:
     const char* getPluginName() const override
@@ -21,7 +21,7 @@ public:
     }
     int64_t getEngineId() const override
     {
-        return hipdnn_tests::plugin_constants::engineId<NoApplicableEnginesPlugin>();
+        return hipdnn_tests::plugin_constants::engineId<NoApplicableEnginesAPlugin>();
     }
     uint32_t getNumEngines() const override
     {
@@ -39,7 +39,7 @@ public:
 // Initialize plugin instance on load
 __attribute__((constructor)) static void initializePlugin()
 {
-    TestPluginBase::setInstance(std::make_unique<NoApplicableEnginesPlugin>());
+    TestPluginBase::setInstance(std::make_unique<NoApplicableEnginesAPlugin>());
 }
 
 // Register all API functions

--- a/tests/test_plugins/TestNoApplicableEnginesBPlugin.cpp
+++ b/tests/test_plugins/TestNoApplicableEnginesBPlugin.cpp
@@ -13,7 +13,7 @@ class NoApplicableEnginesBPlugin : public TestPluginBase
 public:
     const char* getPluginName() const override
     {
-        return "test_NoApplicableEnginesPlugin";
+        return "test_NoApplicableEnginesBPlugin";
     }
     const char* getPluginVersion() const override
     {

--- a/tests/test_plugins/TestNoApplicableEnginesBPlugin.cpp
+++ b/tests/test_plugins/TestNoApplicableEnginesBPlugin.cpp
@@ -8,7 +8,7 @@ thread_local char
     hipdnn_plugin::PluginLastErrorManager::s_lastError[HIPDNN_PLUGIN_ERROR_STRING_MAX_LENGTH]
     = "";
 
-class NoApplicableEnginesAPlugin : public TestPluginBase
+class NoApplicableEnginesBPlugin : public TestPluginBase
 {
 public:
     const char* getPluginName() const override
@@ -21,7 +21,7 @@ public:
     }
     int64_t getEngineId() const override
     {
-        return hipdnn_tests::plugin_constants::engineId<NoApplicableEnginesAPlugin>();
+        return hipdnn_tests::plugin_constants::engineId<NoApplicableEnginesBPlugin>();
     }
     uint32_t getNumEngines() const override
     {
@@ -39,7 +39,7 @@ public:
 // Initialize plugin instance on load
 __attribute__((constructor)) static void initializePlugin()
 {
-    TestPluginBase::setInstance(std::make_unique<NoApplicableEnginesAPlugin>());
+    TestPluginBase::setInstance(std::make_unique<NoApplicableEnginesBPlugin>());
 }
 
 // Register all API functions

--- a/tests/test_plugins/TestNoApplicableEnginesBPlugin.cpp
+++ b/tests/test_plugins/TestNoApplicableEnginesBPlugin.cpp
@@ -1,0 +1,46 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "TestPluginCommon.hpp"
+#include "TestPluginEngineIdMap.hpp"
+// NOLINTNEXTLINE
+thread_local char
+    hipdnn_plugin::PluginLastErrorManager::s_lastError[HIPDNN_PLUGIN_ERROR_STRING_MAX_LENGTH]
+    = "";
+
+class NoApplicableEnginesAPlugin : public TestPluginBase
+{
+public:
+    const char* getPluginName() const override
+    {
+        return "test_NoApplicableEnginesPlugin";
+    }
+    const char* getPluginVersion() const override
+    {
+        return "1.0.0";
+    }
+    int64_t getEngineId() const override
+    {
+        return hipdnn_tests::plugin_constants::engineId<NoApplicableEnginesAPlugin>();
+    }
+    uint32_t getNumEngines() const override
+    {
+        return 0;
+    }
+    uint32_t getNumApplicableEngines() const override
+    {
+        return 0;
+    }
+
+    // Since no engines are applicable, SupportsEngineOperations returns false
+    // This will cause all engine operations to throw appropriate errors
+};
+
+// Initialize plugin instance on load
+__attribute__((constructor)) static void initializePlugin()
+{
+    TestPluginBase::setInstance(std::make_unique<NoApplicableEnginesAPlugin>());
+}
+
+// Register all API functions
+REGISTER_TEST_PLUGIN_API()

--- a/tests/test_plugins/TestPluginConstants.hpp
+++ b/tests/test_plugins/TestPluginConstants.hpp
@@ -45,10 +45,17 @@ inline const std::string& testExecuteFailsPluginPath()
     return s_testExecuteFailsPluginPath;
 }
 
-inline const std::string& testNoApplicableEnginesPluginPath()
+inline const std::string& testNoApplicableEnginesAPluginPath()
 {
     static const std::string s_testNoApplicableEnginesPluginPath
-        = getPluginPath(TEST_NO_APPLICABLE_ENGINES_PLUGIN_NAME);
+        = getPluginPath(TEST_NO_APPLICABLE_ENGINES_A_PLUGIN_NAME);
+    return s_testNoApplicableEnginesPluginPath;
+}
+
+inline const std::string& testNoApplicableEnginesBPluginPath()
+{
+    static const std::string s_testNoApplicableEnginesPluginPath
+        = getPluginPath(TEST_NO_APPLICABLE_ENGINES_B_PLUGIN_NAME);
     return s_testNoApplicableEnginesPluginPath;
 }
 

--- a/tests/test_plugins/TestPluginEngineIdMap.hpp
+++ b/tests/test_plugins/TestPluginEngineIdMap.hpp
@@ -22,7 +22,7 @@ constexpr int64_t engineId() = delete;
 HIPDNN_MAP_TO_ID(GoodPlugin, -2);
 HIPDNN_MAP_TO_ID(GoodDefaultPlugin, -3);
 HIPDNN_MAP_TO_ID(NoApplicableEnginesAPlugin, -4);
-HIPDNN_MAP_TO_ID(NoApplicableEnginesPluginB, -5);
+HIPDNN_MAP_TO_ID(NoApplicableEnginesBPlugin, -5);
 HIPDNN_MAP_TO_ID(ExecuteFailsPlugin, -6);
 HIPDNN_MAP_TO_ID(DuplicateIdAPlugin, -7);
 HIPDNN_MAP_TO_ID(DuplicateIdBPlugin, -7);

--- a/tests/test_plugins/TestPluginEngineIdMap.hpp
+++ b/tests/test_plugins/TestPluginEngineIdMap.hpp
@@ -21,7 +21,8 @@ constexpr int64_t engineId() = delete;
 
 HIPDNN_MAP_TO_ID(GoodPlugin, -2);
 HIPDNN_MAP_TO_ID(GoodDefaultPlugin, -3);
-HIPDNN_MAP_TO_ID(NoApplicableEnginesPlugin, -4);
-HIPDNN_MAP_TO_ID(ExecuteFailsPlugin, -5);
-HIPDNN_MAP_TO_ID(DuplicateIdAPlugin, -6);
-HIPDNN_MAP_TO_ID(DuplicateIdBPlugin, -6);
+HIPDNN_MAP_TO_ID(NoApplicableEnginesAPlugin, -4);
+HIPDNN_MAP_TO_ID(NoApplicableEnginesPluginB, -5);
+HIPDNN_MAP_TO_ID(ExecuteFailsPlugin, -6);
+HIPDNN_MAP_TO_ID(DuplicateIdAPlugin, -7);
+HIPDNN_MAP_TO_ID(DuplicateIdBPlugin, -7);


### PR DESCRIPTION
## Proposed changes
- Adds testing for Temp_directory class
- Adds test for multiple plugins, no applicable engines
- Changes warnings into errors and test logs in the Plugin_loading_tests::DuplicateEngineIds and Plugin_loading_tests::IncompleteAPI tests

## Checklist

- [x] I have added automated tests relevant to the introduced functionality
- [x] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [ ] I have ran the tests, and they are all passing locally
- [ ] I have ran the tests with ASAN, and they are all passing locally
- [x] I have added relevant documentation for the changes
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] I have ran `make format` & `make check_format` to ensure the changes have been formatted
