### PR TITLE
Add exports + ensure install paths are relative

### DIFF
--- a/backend/src/CMakeLists.txt
+++ b/backend/src/CMakeLists.txt
@@ -79,6 +79,11 @@ install(
     EXPORT hipdnn_backend_targets
 )
 
+export(
+    TARGETS hipdnn_backend
+    FILE  ${CMAKE_BINARY_DIR}/lib/cmake/hipdnn_backend/hipdnn_backendConfig.cmake
+)
+
 install(
     DIRECTORY ${HIP_DNN_BACKEND_INCLUDE_DIR}/
     DESTINATION ${HIP_DNN_BACKEND_INSTALL_INCLUDE_DIR}
@@ -91,6 +96,6 @@ install(
 
 install(
     EXPORT hipdnn_backend_targets
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/hipdnn_backend
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_backend
     FILE hipdnn_backendConfig.cmake
 )

--- a/frontend/CMakeLists.txt
+++ b/frontend/CMakeLists.txt
@@ -21,12 +21,17 @@ install(
     EXPORT hipdnn-frontend
 )
 
+export(
+    TARGETS hipdnn_frontend hipdnn_sdk hipdnn_backend FlatBuffers spdlog_header_only
+    FILE  ${CMAKE_BINARY_DIR}/lib/cmake/hipdnn_frontend/hipdnn_frontendConfig.cmake
+)
+
 install(
     DIRECTORY ${HIP_DNN_FRONTEND_INCLUDE_DIR}/
     DESTINATION ${HIP_DNN_FRONTEND_INSTALL_INCLUDE_DIR}
 )
 
 install(EXPORT hipdnn-frontend
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/hipdnn_frontend
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_frontend
     FILE hipdnn_frontendConfig.cmake
 )

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(FlatBuffers PROPERTIES
 
 set(HIP_DNN_SDK_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-set(SCHEMA_FILES 
+set(SCHEMA_FILES
     schemas/batchnorm_attributes.fbs
     schemas/batchnorm_backward_attributes.fbs
     schemas/batchnorm_inference_attributes.fbs
@@ -43,7 +43,7 @@ build_flatbuffers(
     ${HIP_DNN_SDK_INCLUDE_DIR}/hipdnn_sdk/data_objects  # generated_includes_dir
     ""  # binary_schemas_dir
     "" #copy_text_schemas_dir
-) 
+)
 
 # Flatc build has some warnings that trigger and print to the console.  Since we dont want these we can
 # suppress all warnings by using the -w compile flag.  This command prepends -w to the compile flats for
@@ -68,9 +68,14 @@ target_include_directories(hipdnn_sdk INTERFACE
 # By doing this, we don't need to link to hip::device
 target_compile_definitions(hipdnn_sdk INTERFACE __HIPCC__)
 
-install( 
+install(
     TARGETS hipdnn_sdk FlatBuffers spdlog_header_only
     EXPORT hipdnn_sdk_targets
+)
+
+export(
+    TARGETS hipdnn_sdk FlatBuffers spdlog_header_only
+    FILE  ${CMAKE_BINARY_DIR}/lib/cmake/hipdnn_sdk/hipdnn_sdkConfig.cmake
 )
 
 #todo, get spdlog to install its headers
@@ -80,7 +85,7 @@ install(
 )
 
 install(EXPORT hipdnn_sdk_targets
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/hipdnn_sdk
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_sdk
     FILE hipdnn_sdkConfig.cmake
 )
 


### PR DESCRIPTION
## Proposed changes

This PR adds exports so that a consuming project can build against hipDNN from either the build or install directory. It also updates install targets to use relative rather than absolute install locations. ${CMAKE_INSTALL_PREFIX} in path created an absolute path. With absolute paths, `cmake --install build --prefix <something>` installs at the absolute path irrespective of the prefix provided.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [ ] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [ ] I have ran the tests, and they are all passing locally
- [ ] I have ran the tests with ASAN, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] I have ran `make format` & `make check_format` to ensure the changes have been formatted
