### PR TITLE
[ALMIOPEN-256] Transitioned from std::ignore to [[maybe_unused]]

### DIFF
--- a/backend/src/plugin/PluginCore.hpp
+++ b/backend/src/plugin/PluginCore.hpp
@@ -128,16 +128,10 @@ protected:
 
     // This function is called before adding a plugin to the plugin list.
     // The function must throw Hipdnn_exception if the plugin is not valid.
-    virtual void validateBeforeAdding(const Plugin& plugin)
-    {
-        std::ignore = plugin;
-    }
+    virtual void validateBeforeAdding([[maybe_unused]] const Plugin& plugin) {}
 
     // This function is called after the plugin is added to the plugin list.
-    virtual void actionAfterAdding(const Plugin& plugin)
-    {
-        std::ignore = plugin;
-    }
+    virtual void actionAfterAdding([[maybe_unused]] const Plugin& plugin) {}
 
 public:
     virtual ~PluginManagerBase() = default;

--- a/backend/tests/plugins/EnginePlugin1.cpp
+++ b/backend/tests/plugins/EnginePlugin1.cpp
@@ -72,15 +72,12 @@ void getAllEngineIds(int64_t* engineIds, uint32_t maxEngines, uint32_t* numEngin
     *numEngines = PLUGIN_NUM_ENGINES;
 }
 
-void getApplicableEngineIds(hipdnnEnginePluginHandle_t handle,
-                            const hipdnnPluginConstData_t* opGraph,
+void getApplicableEngineIds([[maybe_unused]] hipdnnEnginePluginHandle_t handle,
+                            [[maybe_unused]] const hipdnnPluginConstData_t* opGraph,
                             int64_t* engineIds,
                             uint32_t maxEngines,
                             uint32_t* numEngines)
 {
-    std::ignore = handle;
-    std::ignore = opGraph;
-
     // TODO Implement actual logic to determine applicable engine IDs.
     // Now we just return a fixed set of engine IDs.
     for(uint32_t i = 0; i < maxEngines && i < PLUGIN_NUM_ENGINES; ++i)
@@ -99,15 +96,11 @@ void checkEngineIdValidity(int64_t engineId)
     }
 }
 
-void getEngineDetails(hipdnnEnginePluginHandle_t handle,
-                      int64_t engineId,
-                      const hipdnnPluginConstData_t* opGraph,
+void getEngineDetails([[maybe_unused]] hipdnnEnginePluginHandle_t handle,
+                      [[maybe_unused]] int64_t engineId,
+                      [[maybe_unused]] const hipdnnPluginConstData_t* opGraph,
                       hipdnnPluginConstData_t* engineDetails)
 {
-    std::ignore = handle;
-    std::ignore = engineId;
-    std::ignore = opGraph;
-
     // TODO Implement actual logic
     // For now, we just allocate some memory for engine details.
     size_t size = 1024;
@@ -115,60 +108,45 @@ void getEngineDetails(hipdnnEnginePluginHandle_t handle,
     engineDetails->size = size;
 }
 
-void destroyEngineDetails(hipdnnEnginePluginHandle_t handle, hipdnnPluginConstData_t* engineDetails)
+void destroyEngineDetails([[maybe_unused]] hipdnnEnginePluginHandle_t handle,
+                          hipdnnPluginConstData_t* engineDetails)
 {
-    std::ignore = handle;
-
     delete[] static_cast<const uint8_t*>(engineDetails->ptr);
     engineDetails->ptr = nullptr;
     engineDetails->size = 0;
 }
 
-size_t getWorkspaceSize(hipdnnEnginePluginHandle_t handle,
-                        const hipdnnPluginConstData_t* engineConfig,
-                        const hipdnnPluginConstData_t* opGraph)
+size_t getWorkspaceSize([[maybe_unused]] hipdnnEnginePluginHandle_t handle,
+                        [[maybe_unused]] const hipdnnPluginConstData_t* engineConfig,
+                        [[maybe_unused]] const hipdnnPluginConstData_t* opGraph)
 {
-    std::ignore = handle;
-    std::ignore = engineConfig;
-    std::ignore = opGraph;
-
     // TODO Implement actual logic
     // For now, we just return a fixed workspace size.
     return 4096;
 }
 
 hipdnnEnginePluginExecutionContext_t
-    createExecutionContext(hipdnnEnginePluginHandle_t handle,
-                           const hipdnnPluginConstData_t* engineConfig,
-                           const hipdnnPluginConstData_t* opGraph)
+    createExecutionContext([[maybe_unused]] hipdnnEnginePluginHandle_t handle,
+                           [[maybe_unused]] const hipdnnPluginConstData_t* engineConfig,
+                           [[maybe_unused]] const hipdnnPluginConstData_t* opGraph)
 {
-    std::ignore = handle;
-    std::ignore = engineConfig;
-    std::ignore = opGraph;
-
     auto executionContext = new HipdnnEnginePluginExecutionContext(0);
     return executionContext;
 }
 
-void destroyExecutionContext(hipdnnEnginePluginHandle_t handle,
+void destroyExecutionContext([[maybe_unused]] hipdnnEnginePluginHandle_t handle,
                              hipdnnEnginePluginExecutionContext_t executionContext)
 {
-    std::ignore = handle;
-
     // Free the memory allocated for the execution context.
     delete executionContext;
 }
 
-void executeOpGraph(hipdnnEnginePluginHandle_t handle,
-                    hipdnnEnginePluginExecutionContext_t executionContext,
-                    void* workspace,
+void executeOpGraph([[maybe_unused]] hipdnnEnginePluginHandle_t handle,
+                    [[maybe_unused]] hipdnnEnginePluginExecutionContext_t executionContext,
+                    [[maybe_unused]] void* workspace,
                     const hipdnnPluginDeviceBuffer_t* deviceBuffers,
                     uint32_t numDeviceBuffers)
 {
-    std::ignore = handle;
-    std::ignore = executionContext;
-    std::ignore = workspace;
-
     if(numDeviceBuffers != 2)
     {
         throw HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INVALID_VALUE,

--- a/docs/CodingStyleAndNamingGuidelines.md
+++ b/docs/CodingStyleAndNamingGuidelines.md
@@ -7,6 +7,7 @@ This document defines the canonical project-wide coding and test naming conventi
 - [1. Naming Summary](#1-naming-summary)
 - [2. File & Class Naming](#2-file--class-naming)
 - [3. Functions](#3-functions)
+  - [3.1 Unused Function Arguments](#31-unused-function-arguments)
 - [4. Variables](#4-variables)
 - [5. Members](#5-members)
 - [6. Globals](#6-globals)
@@ -59,6 +60,11 @@ This document defines the canonical project-wide coding and test naming conventi
 ## 3. Functions
 
 - Use descriptive action-oriented verbs: `createPlan`, `finalizeConfig`, `launchKernels`.
+
+### 3.1 Unused Function Arguments
+
+- Prefer use of `[[maybe_unused]]` rather than commenting-out argument names or using std::ignore
+  - Exception is for arguments that *shall not* be used, such as the case in a legacy version of a method that has an argument that is no longer relevant and shouldn't be used.  In this case, comment-out the argument name and leave a comment indicating the reason.
 
 ## 4. Variables
 

--- a/frontend/tests/TestGraph.cpp
+++ b/frontend/tests/TestGraph.cpp
@@ -37,10 +37,9 @@ protected:
     {
         EXPECT_CALL(*_mockBackend,
                     backendCreateAndDeserializeGraphExt(::testing::_, ::testing::_, ::testing::_))
-            .WillOnce([&deserializedGraph](hipdnnBackendDescriptor_t* descriptor,
+            .WillOnce([&deserializedGraph]([[maybe_unused]] hipdnnBackendDescriptor_t* descriptor,
                                            const uint8_t* serializedGraph,
                                            size_t graphByteSize) {
-                std::ignore = descriptor;
                 deserializedGraph = hipdnn_sdk::data_objects::UnPackGraph(serializedGraph);
                 EXPECT_NE(deserializedGraph, nullptr);
                 EXPECT_GE(graphByteSize, 0);

--- a/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormBwdPlan.cpp
+++ b/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormBwdPlan.cpp
@@ -82,10 +82,8 @@ BatchnormBwdPlan::BatchnormBwdPlan(std::unique_ptr<BatchnormBwdParams> params)
 void BatchnormBwdPlan::execute(const HipdnnEnginePluginHandle& handle,
                                const hipdnnPluginDeviceBuffer_t* deviceBuffers,
                                uint32_t numDeviceBuffers,
-                               void* workspace) const
+                               [[maybe_unused]] void* workspace) const
 {
-    std::ignore = workspace;
-
     float alphaDataDiff = 1.0f;
     float betaDataDiff = 0.0f;
     float alphaParamDiff = 1.0f;

--- a/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormFwdInferencePlan.cpp
+++ b/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormFwdInferencePlan.cpp
@@ -69,10 +69,8 @@ BatchnormFwdInferencePlan::BatchnormFwdInferencePlan(
 void BatchnormFwdInferencePlan::execute(const HipdnnEnginePluginHandle& handle,
                                         const hipdnnPluginDeviceBuffer_t* deviceBuffers,
                                         uint32_t numDeviceBuffers,
-                                        void* workspace) const
+                                        [[maybe_unused]] void* workspace) const
 {
-    std::ignore = workspace;
-
     // Hardcoded values from bn_driver in miopen
     auto alpha = static_cast<float>(1);
     auto beta = static_cast<float>(0);

--- a/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormPlanBuilder.cpp
+++ b/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormPlanBuilder.cpp
@@ -36,11 +36,10 @@ bool MiopenBatchnormPlanBuilder::isApplicable(const hipdnn_plugin::IGraph& opGra
     return true;
 }
 
-size_t MiopenBatchnormPlanBuilder::getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
-                                                    const hipdnn_plugin::IGraph& opGraph) const
+size_t MiopenBatchnormPlanBuilder::getWorkspaceSize(
+    [[maybe_unused]] const HipdnnEnginePluginHandle& handle,
+    [[maybe_unused]] const hipdnn_plugin::IGraph& opGraph) const
 {
-    std::ignore = handle;
-    std::ignore = opGraph;
     //batchnorm plan builder does not require workspace size
     return 0u;
 }
@@ -53,13 +52,11 @@ std::string getNodeName(const hipdnn_sdk::data_objects::Node& node)
     return node.name() != nullptr ? node.name()->str() : "";
 }
 
-void buildPlanInferenceSingleNode(const HipdnnEnginePluginHandle& handle,
+void buildPlanInferenceSingleNode([[maybe_unused]] const HipdnnEnginePluginHandle& handle,
                                   const hipdnn_plugin::IGraph& opGraph,
                                   const hipdnn_sdk::data_objects::Node& node,
                                   HipdnnEnginePluginExecutionContext& executionContext)
 {
-    std::ignore = handle;
-
     const auto* attr = node.attributes_as_BatchnormInferenceAttributes();
     if(attr == nullptr)
     {
@@ -74,13 +71,11 @@ void buildPlanInferenceSingleNode(const HipdnnEnginePluginHandle& handle,
     executionContext.setPlan(std::move(plan));
 }
 
-void buildPlanBwdSingleNode(const HipdnnEnginePluginHandle& handle,
+void buildPlanBwdSingleNode([[maybe_unused]] const HipdnnEnginePluginHandle& handle,
                             const hipdnn_plugin::IGraph& opGraph,
                             const hipdnn_sdk::data_objects::Node& node,
                             HipdnnEnginePluginExecutionContext& executionContext)
 {
-    std::ignore = handle;
-
     const auto* attr = node.attributes_as_BatchnormBackwardAttributes();
     if(attr == nullptr)
     {

--- a/sdk/include/hipdnn_sdk/utilities/Allocators.hpp
+++ b/sdk/include/hipdnn_sdk/utilities/Allocators.hpp
@@ -120,9 +120,8 @@ public:
     HostAllocator(const HostAllocator&) noexcept = default;
 
     template <typename U>
-    HostAllocator(const HostAllocator<U>& other) noexcept
+    HostAllocator([[maybe_unused]] const HostAllocator<U>& other) noexcept
     {
-        std::ignore = other;
     }
 
     ~HostAllocator() override = default;
@@ -142,26 +141,23 @@ public:
         return ptr;
     }
 
-    void deallocate(T* p, std::size_t n) noexcept override
+    void deallocate(T* p, [[maybe_unused]] std::size_t n) noexcept override
     {
-        std::ignore = n;
         std::free(p);
     }
 };
 
 template <typename T, typename U>
-bool operator==(const HostAllocator<T>& lhs, const HostAllocator<U>& rhs) noexcept
+bool operator==([[maybe_unused]] const HostAllocator<T>& lhs,
+                [[maybe_unused]] const HostAllocator<U>& rhs) noexcept
 {
-    std::ignore = lhs;
-    std::ignore = rhs;
     return true;
 }
 
 template <typename T, typename U>
-bool operator!=(const HostAllocator<T>& lhs, const HostAllocator<U>& rhs) noexcept
+bool operator!=([[maybe_unused]] const HostAllocator<T>& lhs,
+                [[maybe_unused]] const HostAllocator<U>& rhs) noexcept
 {
-    std::ignore = lhs;
-    std::ignore = rhs;
     return false;
 }
 
@@ -188,9 +184,8 @@ public:
     PinnedHostAllocator(const PinnedHostAllocator&) noexcept = default;
 
     template <typename U>
-    PinnedHostAllocator(const PinnedHostAllocator<U>& other) noexcept
+    PinnedHostAllocator([[maybe_unused]] const PinnedHostAllocator<U>& other) noexcept
     {
-        std::ignore = other;
     }
 
     ~PinnedHostAllocator() override = default;
@@ -211,26 +206,23 @@ public:
         return static_cast<T*>(ptr);
     }
 
-    void deallocate(T* p, std::size_t n) noexcept override
+    void deallocate(T* p, [[maybe_unused]] std::size_t n) noexcept override
     {
-        std::ignore = n;
         std::ignore = hipHostFree(p);
     }
 };
 
 template <typename T, typename U>
-bool operator==(const PinnedHostAllocator<T>& lhs, const PinnedHostAllocator<U>& rhs) noexcept
+bool operator==([[maybe_unused]] const PinnedHostAllocator<T>& lhs,
+                [[maybe_unused]] const PinnedHostAllocator<U>& rhs) noexcept
 {
-    std::ignore = lhs;
-    std::ignore = rhs;
     return true;
 }
 
 template <typename T, typename U>
-bool operator!=(const PinnedHostAllocator<T>& lhs, const PinnedHostAllocator<U>& rhs) noexcept
+bool operator!=([[maybe_unused]] const PinnedHostAllocator<T>& lhs,
+                [[maybe_unused]] const PinnedHostAllocator<U>& rhs) noexcept
 {
-    std::ignore = lhs;
-    std::ignore = rhs;
     return false;
 }
 
@@ -257,9 +249,8 @@ public:
     DeviceAllocator(const DeviceAllocator&) noexcept = default;
 
     template <typename U>
-    DeviceAllocator(const DeviceAllocator<U>& other) noexcept
+    DeviceAllocator([[maybe_unused]] const DeviceAllocator<U>& other) noexcept
     {
-        std::ignore = other;
     }
 
     ~DeviceAllocator() override = default;
@@ -280,9 +271,8 @@ public:
         return static_cast<T*>(ptr);
     }
 
-    void deallocate(T* p, std::size_t n) noexcept override
+    void deallocate(T* p, [[maybe_unused]] std::size_t n) noexcept override
     {
-        std::ignore = n;
         std::ignore = hipFree(p);
     }
 
@@ -292,18 +282,16 @@ public:
 };
 
 template <typename T, typename U>
-bool operator==(const DeviceAllocator<T>& lhs, const DeviceAllocator<U>& rhs) noexcept
+bool operator==([[maybe_unused]] const DeviceAllocator<T>& lhs,
+                [[maybe_unused]] const DeviceAllocator<U>& rhs) noexcept
 {
-    std::ignore = lhs;
-    std::ignore = rhs;
     return true;
 }
 
 template <typename T, typename U>
-bool operator!=(const DeviceAllocator<T>& lhs, const DeviceAllocator<U>& rhs) noexcept
+bool operator!=([[maybe_unused]] const DeviceAllocator<T>& lhs,
+                [[maybe_unused]] const DeviceAllocator<U>& rhs) noexcept
 {
-    std::ignore = lhs;
-    std::ignore = rhs;
     return false;
 }
 

--- a/sdk/include/hipdnn_sdk/utilities/MigratableMemory.hpp
+++ b/sdk/include/hipdnn_sdk/utilities/MigratableMemory.hpp
@@ -236,10 +236,8 @@ private:
         }
     }
 
-    static void logOnError(hipError_t err, const char* msg)
+    static void logOnError(hipError_t err, [[maybe_unused]] const char* msg)
     {
-        std::ignore = msg;
-
         if(err != hipSuccess)
         {
             HIPDNN_LOG_ERROR("{}: HIP error: {}", msg, hipGetErrorString(err));


### PR DESCRIPTION
## Proposed changes
- Transitioned away from using `std::ignore` and swapped to `[[maybe_unused]]`
- Did a brief regex search for commented-out function / method args, didn't find any

## Checklist

- [x] I have added automated tests relevant to the introduced functionality
- [x] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [x] I have ran the tests, and they are all passing locally
- [x] I have ran the tests with ASAN, and they are all passing locally
- [x] I have added relevant documentation for the changes
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] I have ran `make format` & `make check_format` to ensure the changes have been formatted
