### PR TITLE
Swap types to follow naming rules for the frontend

### DIFF
--- a/frontend/include/hipdnn_frontend/Error.hpp
+++ b/frontend/include/hipdnn_frontend/Error.hpp
@@ -28,17 +28,17 @@ enum class ErrorCode
 
 typedef ErrorCode error_code_t; // NOLINT(readability-identifier-naming)
 
-struct ErrorObject
+struct Error
 {
     ErrorCode code;
     std::string err_msg; // NOLINT(readability-identifier-naming)
 
-    ErrorObject()
+    Error()
         : code(ErrorCode::OK)
     {
     }
 
-    ErrorObject(ErrorCode errorCode, std::string message)
+    Error(ErrorCode errorCode, std::string message)
         : code(errorCode)
         , err_msg(std::move(message))
     {
@@ -71,18 +71,18 @@ struct ErrorObject
     {
         return code != otherCode;
     }
-    bool operator==(const ErrorObject& other) const
+    bool operator==(const Error& other) const
     {
         return code == other.code;
     }
-    bool operator!=(const ErrorObject& other) const
+    bool operator!=(const Error& other) const
     {
         return code != other.code;
     }
 };
 
-typedef ErrorObject error_object; // NOLINT(readability-identifier-naming)
-typedef ErrorObject error_t; // NOLINT(readability-identifier-naming)
+typedef Error error_object; // NOLINT(readability-identifier-naming)
+typedef Error error_t; // NOLINT(readability-identifier-naming)
 
 #define HIPDNN_RETURN_IF_NE(x, y, error_status, message) \
     if(x != y)                                           \

--- a/frontend/include/hipdnn_frontend/Error.hpp
+++ b/frontend/include/hipdnn_frontend/Error.hpp
@@ -18,7 +18,7 @@
 
 namespace hipdnn_frontend
 {
-enum class error_code_t // NOLINT(readability-identifier-naming)
+enum class ErrorCode
 {
     OK,
     INVALID_VALUE,
@@ -26,18 +26,20 @@ enum class error_code_t // NOLINT(readability-identifier-naming)
     ATTRIBUTE_NOT_SET
 };
 
-typedef struct error_object // NOLINT(readability-identifier-naming)
-{
-    error_code_t code;
-    std::string err_msg;
+typedef ErrorCode error_code_t; // NOLINT(readability-identifier-naming)
 
-    error_object()
-        : code(error_code_t::OK)
+struct ErrorObject
+{
+    ErrorCode code;
+    std::string err_msg; // NOLINT(readability-identifier-naming)
+
+    ErrorObject()
+        : code(ErrorCode::OK)
     {
     }
-    // NOLINTNEXTLINE(readability-identifier-naming)
-    error_object(error_code_t error_code, std::string message)
-        : code(error_code)
+
+    ErrorObject(ErrorCode errorCode, std::string message)
+        : code(errorCode)
         , err_msg(std::move(message))
     {
     }
@@ -47,37 +49,40 @@ typedef struct error_object // NOLINT(readability-identifier-naming)
         return err_msg;
     }
 
-    error_code_t get_code() const // NOLINT(readability-identifier-naming)
+    ErrorCode get_code() const // NOLINT(readability-identifier-naming)
     {
         return code;
     }
 
     bool is_good() const // NOLINT(readability-identifier-naming)
     {
-        return code == error_code_t::OK;
+        return code == ErrorCode::OK;
     }
     bool is_bad() const // NOLINT(readability-identifier-naming)
     {
-        return code != error_code_t::OK;
+        return code != ErrorCode::OK;
     }
 
-    bool operator==(error_code_t otherCode) const
+    bool operator==(ErrorCode otherCode) const
     {
         return code == otherCode;
     }
-    bool operator!=(error_code_t otherCode) const
+    bool operator!=(ErrorCode otherCode) const
     {
         return code != otherCode;
     }
-    bool operator==(const error_object& other) const
+    bool operator==(const ErrorObject& other) const
     {
         return code == other.code;
     }
-    bool operator!=(const error_object& other) const
+    bool operator!=(const ErrorObject& other) const
     {
         return code != other.code;
     }
-} error_t;
+};
+
+typedef ErrorObject error_object; // NOLINT(readability-identifier-naming)
+typedef ErrorObject error_t; // NOLINT(readability-identifier-naming)
 
 #define HIPDNN_RETURN_IF_NE(x, y, error_status, message) \
     if(x != y)                                           \

--- a/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/frontend/include/hipdnn_frontend/Graph.hpp
@@ -29,7 +29,7 @@ namespace graph
                                                              backend_err_msg.size());   \
         std::string full_error_msg                                                      \
             = std::string(error_message) + " Backend error: " + backend_err_msg.data(); \
-        return error_t(error_code_t::HIPDNN_BACKEND_ERROR, full_error_msg);             \
+        return ErrorObject(ErrorCode::HIPDNN_BACKEND_ERROR, full_error_msg);            \
     }
 
 class Graph : public INode
@@ -47,7 +47,7 @@ private:
         return tensor;
     }
 
-    error_t initializeHeuristicDescriptor(std::vector<HeurMode_t> const& modes)
+    ErrorObject initializeHeuristicDescriptor(std::vector<HeuristicMode> const& modes)
     {
         _engineHeuristicDesc
             = std::make_unique<ScopedHipdnnBackendDescriptor>(HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR);
@@ -81,10 +81,10 @@ private:
         RETURN_ON_BACKEND_FAILURE(hipdnnBackend()->backendFinalize(_engineHeuristicDesc->get()),
                                   "Failed to finalize engine heuristic descriptor");
 
-        return {error_code_t::OK, ""};
+        return {ErrorCode::OK, ""};
     }
 
-    error_t initializeEngineConfig()
+    ErrorObject initializeEngineConfig()
     {
         int64_t availableEngineCount = 0;
         RETURN_ON_BACKEND_FAILURE(
@@ -98,7 +98,7 @@ private:
 
         if(availableEngineCount == 0)
         {
-            return {error_code_t::HIPDNN_BACKEND_ERROR,
+            return {ErrorCode::HIPDNN_BACKEND_ERROR,
                     "No engine configurations available for the graph."};
         }
 
@@ -112,7 +112,7 @@ private:
 
             if(engineCfgDesc == nullptr || !engineCfgDesc->valid())
             {
-                return {error_code_t::HIPDNN_BACKEND_ERROR,
+                return {ErrorCode::HIPDNN_BACKEND_ERROR,
                         "Failed to create engine configuration descriptor."};
             }
             engineConfigs.push_back(std::move(engineCfgDesc));
@@ -131,7 +131,7 @@ private:
 
         if(count == 0)
         {
-            return {error_code_t::HIPDNN_BACKEND_ERROR,
+            return {ErrorCode::HIPDNN_BACKEND_ERROR,
                     "No engine configurations retrieved from the heuristic desc."};
         }
 
@@ -140,7 +140,7 @@ private:
         _engineConfigDesc = std::move(engineConfigs[0]);
         engineConfigs.erase(engineConfigs.begin(), engineConfigs.begin() + 1);
 
-        return {error_code_t::OK, ""};
+        return {ErrorCode::OK, ""};
     }
 
 public:
@@ -149,12 +149,13 @@ public:
     {
     }
 
-    error_t validate()
+    ErrorObject validate()
     {
         return validateSubtree();
     }
 
-    error_t build_operation_graph(hipdnnHandle_t handle) // NOLINT(readability-identifier-naming)
+    ErrorObject
+        build_operation_graph(hipdnnHandle_t handle) // NOLINT(readability-identifier-naming)
     {
         std::unordered_set<int64_t> usedTensorUids;
         gatherHipdnnTensorIdsSubtree(usedTensorUids);
@@ -199,7 +200,7 @@ public:
 
         if(!_graphDesc->valid())
         {
-            return {error_code_t::HIPDNN_BACKEND_ERROR,
+            return {ErrorCode::HIPDNN_BACKEND_ERROR,
                     "Failed to create backend graph descriptor for the graph."};
         }
 
@@ -214,28 +215,21 @@ public:
         RETURN_ON_BACKEND_FAILURE(hipdnnBackend()->backendFinalize(_graphDesc->get()),
                                   "Failed to finalize backend descriptor for the graph");
 
-        return {error_code_t::OK, ""};
+        return {ErrorCode::OK, ""};
     }
 
     // NOLINTNEXTLINE(readability-identifier-naming)
-    error_t create_execution_plans(hipdnnHandle_t,
-                                   std::vector<HeurMode_t> const& modes = {HeurMode_t::FALLBACK})
-    {
-        // Handle no longer needed.
-        return create_execution_plans(modes);
-    }
-
-    // NOLINTNEXTLINE(readability-identifier-naming)
-    error_t create_execution_plans(std::vector<HeurMode_t> const& modes = {HeurMode_t::FALLBACK})
+    ErrorObject create_execution_plans(std::vector<HeuristicMode> const& modes
+                                       = {HeuristicMode::FALLBACK})
     {
         if(!_graphDesc || !_graphDesc->valid())
         {
-            return {error_code_t::HIPDNN_BACKEND_ERROR,
+            return {ErrorCode::HIPDNN_BACKEND_ERROR,
                     "Graph has not been built, build the operation graph first. Cannot create "
                     "execution plan."};
         }
 
-        error_t status = initializeHeuristicDescriptor(modes);
+        ErrorObject status = initializeHeuristicDescriptor(modes);
         HIPDNN_CHECK_ERROR(status);
 
         status = initializeEngineConfig();
@@ -246,25 +240,25 @@ public:
 
         if(!_executionPlanDesc->valid())
         {
-            return {error_code_t::HIPDNN_BACKEND_ERROR,
+            return {ErrorCode::HIPDNN_BACKEND_ERROR,
                     "Failed to create backend execution descriptor."};
         }
 
-        return {error_code_t::OK, ""};
+        return {ErrorCode::OK, ""};
     }
 
-    error_t check_support() // NOLINT(readability-identifier-naming)
+    ErrorObject check_support() // NOLINT(readability-identifier-naming)
     {
         if(!_executionPlanDesc || !_executionPlanDesc->valid())
         {
-            return {error_code_t::HIPDNN_BACKEND_ERROR,
+            return {ErrorCode::HIPDNN_BACKEND_ERROR,
                     "Execution plan descriptor is not created or invalid."};
         }
 
-        return {error_code_t::OK, ""};
+        return {ErrorCode::OK, ""};
     }
 
-    error_t build_plans() // NOLINT(readability-identifier-naming)
+    ErrorObject build_plans() // NOLINT(readability-identifier-naming)
     {
         RETURN_ON_BACKEND_FAILURE(hipdnnBackend()->backendFinalize(_engineConfigDesc->get()),
                                   "Failed to finalize engine config descriptor");
@@ -280,11 +274,11 @@ public:
         RETURN_ON_BACKEND_FAILURE(hipdnnBackend()->backendFinalize(_executionPlanDesc->get()),
                                   "Failed to finalize execution plan descriptor");
 
-        return {error_code_t::OK, ""};
+        return {ErrorCode::OK, ""};
     }
 
     // NOLINTNEXTLINE(readability-identifier-naming)
-    error_t get_workspace_size(int64_t& workspaceSize) const
+    ErrorObject get_workspace_size(int64_t& workspaceSize) const
     {
         RETURN_ON_BACKEND_FAILURE(
             hipdnnBackend()->backendGetAttribute(_executionPlanDesc->get(),
@@ -295,12 +289,12 @@ public:
                                                  &workspaceSize),
             "Failed to get engine configurations from the execution plan descriptor.");
 
-        return {error_code_t::OK, ""};
+        return {ErrorCode::OK, ""};
     }
 
-    error_t execute(hipdnnHandle_t handle,
-                    std::unordered_map<std::shared_ptr<TensorAttributes>, void*>& tensorLookup,
-                    void* workspace) const
+    ErrorObject execute(hipdnnHandle_t handle,
+                        std::unordered_map<std::shared_ptr<TensorAttributes>, void*>& tensorLookup,
+                        void* workspace) const
     {
 
         std::unordered_map<int64_t, void*> variantPack;
@@ -312,7 +306,7 @@ public:
             }
             else
             {
-                return {error_code_t::INVALID_VALUE,
+                return {ErrorCode::INVALID_VALUE,
                         "Tensor in tensor lookup is null or does not have a valid uid."};
             }
         }
@@ -320,16 +314,15 @@ public:
         return execute(handle, variantPack, workspace);
     }
 
-    error_t execute(hipdnnHandle_t handle,
-                    std::unordered_map<int64_t, void*>& variantPack,
-                    void* workspace) const
+    ErrorObject execute(hipdnnHandle_t handle,
+                        std::unordered_map<int64_t, void*>& variantPack,
+                        void* workspace) const
     {
         auto variantPackDesc = std::make_unique<ScopedHipdnnBackendDescriptor>(
             HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR);
         if(!variantPackDesc || !variantPackDesc->valid())
         {
-            return {error_code_t::HIPDNN_BACKEND_ERROR,
-                    "Failed to create variant pack descriptor."};
+            return {ErrorCode::HIPDNN_BACKEND_ERROR, "Failed to create variant pack descriptor."};
         }
 
         //split variant_pack into vector of keys and vector of values
@@ -374,7 +367,7 @@ public:
                                       handle, _executionPlanDesc->get(), variantPackDesc->get()),
                                   "Execute failed.");
 
-        return {error_code_t::OK, ""};
+        return {ErrorCode::OK, ""};
     }
 
     const std::string& get_name() const // NOLINT(readability-identifier-naming)
@@ -382,15 +375,15 @@ public:
         return graph_attributes.get_name();
     }
 
-    DataType_t get_compute_data_type() const // NOLINT(readability-identifier-naming)
+    DataType get_compute_data_type() const // NOLINT(readability-identifier-naming)
     {
         return graph_attributes.get_compute_data_type();
     }
-    DataType_t get_intermediate_data_type() const // NOLINT(readability-identifier-naming)
+    DataType get_intermediate_data_type() const // NOLINT(readability-identifier-naming)
     {
         return graph_attributes.get_intermediate_data_type();
     }
-    DataType_t get_io_data_type() const // NOLINT(readability-identifier-naming)
+    DataType get_io_data_type() const // NOLINT(readability-identifier-naming)
     {
         return graph_attributes.get_io_data_type();
     }
@@ -401,18 +394,18 @@ public:
         graph_attributes.set_name(name);
         return *this;
     }
-    Graph& set_compute_data_type(DataType_t computeType) // NOLINT(readability-identifier-naming)
+    Graph& set_compute_data_type(DataType computeType) // NOLINT(readability-identifier-naming)
     {
         graph_attributes.set_compute_data_type(computeType);
         return *this;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
-    Graph& set_intermediate_data_type(DataType_t intermediateType)
+    Graph& set_intermediate_data_type(DataType intermediateType)
     {
         graph_attributes.set_intermediate_data_type(intermediateType);
         return *this;
     }
-    Graph& set_io_data_type(DataType_t ioType) // NOLINT(readability-identifier-naming)
+    Graph& set_io_data_type(DataType ioType) // NOLINT(readability-identifier-naming)
     {
         graph_attributes.set_io_data_type(ioType);
         return *this;

--- a/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/frontend/include/hipdnn_frontend/Graph.hpp
@@ -29,7 +29,7 @@ namespace graph
                                                              backend_err_msg.size());   \
         std::string full_error_msg                                                      \
             = std::string(error_message) + " Backend error: " + backend_err_msg.data(); \
-        return ErrorObject(ErrorCode::HIPDNN_BACKEND_ERROR, full_error_msg);            \
+        return Error(ErrorCode::HIPDNN_BACKEND_ERROR, full_error_msg);                  \
     }
 
 class Graph : public INode
@@ -47,7 +47,7 @@ private:
         return tensor;
     }
 
-    ErrorObject initializeHeuristicDescriptor(std::vector<HeuristicMode> const& modes)
+    Error initializeHeuristicDescriptor(std::vector<HeuristicMode> const& modes)
     {
         _engineHeuristicDesc
             = std::make_unique<ScopedHipdnnBackendDescriptor>(HIPDNN_BACKEND_ENGINEHEUR_DESCRIPTOR);
@@ -84,7 +84,7 @@ private:
         return {ErrorCode::OK, ""};
     }
 
-    ErrorObject initializeEngineConfig()
+    Error initializeEngineConfig()
     {
         int64_t availableEngineCount = 0;
         RETURN_ON_BACKEND_FAILURE(
@@ -149,13 +149,12 @@ public:
     {
     }
 
-    ErrorObject validate()
+    Error validate()
     {
         return validateSubtree();
     }
 
-    ErrorObject
-        build_operation_graph(hipdnnHandle_t handle) // NOLINT(readability-identifier-naming)
+    Error build_operation_graph(hipdnnHandle_t handle) // NOLINT(readability-identifier-naming)
     {
         std::unordered_set<int64_t> usedTensorUids;
         gatherHipdnnTensorIdsSubtree(usedTensorUids);
@@ -219,8 +218,8 @@ public:
     }
 
     // NOLINTNEXTLINE(readability-identifier-naming)
-    ErrorObject create_execution_plans(std::vector<HeuristicMode> const& modes
-                                       = {HeuristicMode::FALLBACK})
+    Error create_execution_plans(std::vector<HeuristicMode> const& modes
+                                 = {HeuristicMode::FALLBACK})
     {
         if(!_graphDesc || !_graphDesc->valid())
         {
@@ -229,7 +228,7 @@ public:
                     "execution plan."};
         }
 
-        ErrorObject status = initializeHeuristicDescriptor(modes);
+        Error status = initializeHeuristicDescriptor(modes);
         HIPDNN_CHECK_ERROR(status);
 
         status = initializeEngineConfig();
@@ -247,7 +246,7 @@ public:
         return {ErrorCode::OK, ""};
     }
 
-    ErrorObject check_support() // NOLINT(readability-identifier-naming)
+    Error check_support() // NOLINT(readability-identifier-naming)
     {
         if(!_executionPlanDesc || !_executionPlanDesc->valid())
         {
@@ -258,7 +257,7 @@ public:
         return {ErrorCode::OK, ""};
     }
 
-    ErrorObject build_plans() // NOLINT(readability-identifier-naming)
+    Error build_plans() // NOLINT(readability-identifier-naming)
     {
         RETURN_ON_BACKEND_FAILURE(hipdnnBackend()->backendFinalize(_engineConfigDesc->get()),
                                   "Failed to finalize engine config descriptor");
@@ -278,7 +277,7 @@ public:
     }
 
     // NOLINTNEXTLINE(readability-identifier-naming)
-    ErrorObject get_workspace_size(int64_t& workspaceSize) const
+    Error get_workspace_size(int64_t& workspaceSize) const
     {
         RETURN_ON_BACKEND_FAILURE(
             hipdnnBackend()->backendGetAttribute(_executionPlanDesc->get(),
@@ -292,9 +291,9 @@ public:
         return {ErrorCode::OK, ""};
     }
 
-    ErrorObject execute(hipdnnHandle_t handle,
-                        std::unordered_map<std::shared_ptr<TensorAttributes>, void*>& tensorLookup,
-                        void* workspace) const
+    Error execute(hipdnnHandle_t handle,
+                  std::unordered_map<std::shared_ptr<TensorAttributes>, void*>& tensorLookup,
+                  void* workspace) const
     {
 
         std::unordered_map<int64_t, void*> variantPack;
@@ -314,9 +313,9 @@ public:
         return execute(handle, variantPack, workspace);
     }
 
-    ErrorObject execute(hipdnnHandle_t handle,
-                        std::unordered_map<int64_t, void*>& variantPack,
-                        void* workspace) const
+    Error execute(hipdnnHandle_t handle,
+                  std::unordered_map<int64_t, void*>& variantPack,
+                  void* workspace) const
     {
         auto variantPackDesc = std::make_unique<ScopedHipdnnBackendDescriptor>(
             HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR);

--- a/frontend/include/hipdnn_frontend/Types.hpp
+++ b/frontend/include/hipdnn_frontend/Types.hpp
@@ -12,20 +12,22 @@
 namespace hipdnn_frontend
 {
 
-enum class ConvolutionMode_t // NOLINT(readability-identifier-naming)
+enum class ConvolutionMode
 {
     NOT_SET = 0,
     CROSS_CORRELATION = 1,
     CONVOLUTION = 2
 };
+typedef ConvolutionMode ConvolutionMode_t; // NOLINT(readability-identifier-naming)
 
-enum class PointwiseMode_t // NOLINT(readability-identifier-naming)
+enum class PointwiseMode
 {
     NOT_SET = 0,
     RELU_FWD = 1,
 };
+typedef PointwiseMode PointwiseMode_t; // NOLINT(readability-identifier-naming)
 
-enum class DataType_t // NOLINT(readability-identifier-naming)
+enum class DataType
 {
     NOT_SET = 0,
     FLOAT = 1,
@@ -35,96 +37,97 @@ enum class DataType_t // NOLINT(readability-identifier-naming)
     UINT8 = 5,
     INT32 = 6,
 };
+typedef DataType DataType_t; // NOLINT(readability-identifier-naming)
 
-enum class HeurMode_t // NOLINT(readability-identifier-naming)
+enum class HeuristicMode
 {
     FALLBACK,
 };
+typedef HeuristicMode HeurMode_t; // NOLINT(readability-identifier-naming)
 
 template <typename T>
-DataType_t getDataTypeEnumFromType()
+DataType getDataTypeEnumFromType()
 {
     if constexpr(std::is_same_v<T, float>)
     {
-        return DataType_t::FLOAT;
+        return DataType::FLOAT;
     }
     else if constexpr(std::is_same_v<T, half>)
     {
-        return DataType_t::HALF;
+        return DataType::HALF;
     }
     else if constexpr(std::is_same_v<T, hip_bfloat16>)
     {
-        return DataType_t::BFLOAT16;
+        return DataType::BFLOAT16;
     }
     else if constexpr(std::is_same_v<T, double>)
     {
-        return DataType_t::DOUBLE;
+        return DataType::DOUBLE;
     }
     else if constexpr(std::is_same_v<T, uint8_t>)
     {
-        return DataType_t::UINT8;
+        return DataType::UINT8;
     }
     else if constexpr(std::is_same_v<T, int32_t>)
     {
-        return DataType_t::INT32;
+        return DataType::INT32;
     }
     else
     {
-        return DataType_t::NOT_SET;
+        return DataType::NOT_SET;
     }
 }
 
-[[maybe_unused]] static hipdnn_sdk::data_objects::ConvMode toSdkType(const ConvolutionMode_t& type)
+[[maybe_unused]] static hipdnn_sdk::data_objects::ConvMode toSdkType(const ConvolutionMode& type)
 {
     switch(type)
     {
-    case ConvolutionMode_t::CROSS_CORRELATION:
+    case ConvolutionMode::CROSS_CORRELATION:
         return hipdnn_sdk::data_objects::ConvMode::ConvMode_CROSS_CORRELATION;
-    case ConvolutionMode_t::CONVOLUTION:
+    case ConvolutionMode::CONVOLUTION:
         return hipdnn_sdk::data_objects::ConvMode::ConvMode_CONVOLUTION;
     default:
         return hipdnn_sdk::data_objects::ConvMode::ConvMode_UNSET;
     }
 }
 
-[[maybe_unused]] static hipdnn_sdk::data_objects::DataType toSdkType(const DataType_t& type)
+[[maybe_unused]] static hipdnn_sdk::data_objects::DataType toSdkType(const DataType& type)
 {
     switch(type)
     {
-    case DataType_t::FLOAT:
+    case DataType::FLOAT:
         return hipdnn_sdk::data_objects::DataType::DataType_FLOAT;
-    case DataType_t::HALF:
+    case DataType::HALF:
         return hipdnn_sdk::data_objects::DataType::DataType_HALF;
-    case DataType_t::BFLOAT16:
+    case DataType::BFLOAT16:
         return hipdnn_sdk::data_objects::DataType::DataType_BFLOAT16;
-    case DataType_t::DOUBLE:
+    case DataType::DOUBLE:
         return hipdnn_sdk::data_objects::DataType::DataType_DOUBLE;
-    case DataType_t::UINT8:
+    case DataType::UINT8:
         return hipdnn_sdk::data_objects::DataType::DataType_UINT8;
-    case DataType_t::INT32:
+    case DataType::INT32:
         return hipdnn_sdk::data_objects::DataType::DataType_INT32;
     default:
         return hipdnn_sdk::data_objects::DataType::DataType_UNSET;
     }
 }
 
-[[maybe_unused]] static hipdnn_sdk::data_objects::PointwiseMode
-    toSdkType(const PointwiseMode_t& type)
+[[maybe_unused]] static hipdnn_sdk::data_objects::PointwiseMode toSdkType(const PointwiseMode& type)
 {
     switch(type)
     {
-    case PointwiseMode_t::RELU_FWD:
+    case PointwiseMode::RELU_FWD:
         return hipdnn_sdk::data_objects::PointwiseMode::PointwiseMode_RELU_FWD;
     default:
         return hipdnn_sdk::data_objects::PointwiseMode::PointwiseMode_UNSET;
     }
 }
 
-[[maybe_unused]] static hipdnnBackendHeurMode_t toBackendType(const HeurMode_t& type)
+[[maybe_unused]] static hipdnnBackendHeurMode_t toBackendType(const HeuristicMode& type)
 {
     switch(type)
     {
-    case HeurMode_t::FALLBACK:
+    case HeuristicMode::FALLBACK:
         return hipdnnBackendHeurMode_t::HIPDNN_HEUR_MODE_FALLBACK;
     default:
         return hipdnnBackendHeurMode_t::HIPDNN_HEUR_MODE_FALLBACK;
@@ -132,28 +135,28 @@ DataType_t getDataTypeEnumFromType()
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-[[maybe_unused]] static const char* to_string(const DataType_t& type)
+[[maybe_unused]] static const char* to_string(const DataType& type)
 {
     switch(type)
     {
-    case DataType_t::FLOAT:
+    case DataType::FLOAT:
         return "fp32";
-    case DataType_t::HALF:
+    case DataType::HALF:
         return "fp16";
-    case DataType_t::BFLOAT16:
+    case DataType::BFLOAT16:
         return "bf16";
-    case DataType_t::DOUBLE:
+    case DataType::DOUBLE:
         return "fp64";
-    case DataType_t::UINT8:
+    case DataType::UINT8:
         return "uint8";
-    case DataType_t::INT32:
+    case DataType::INT32:
         return "int32";
     default:
         return "unknown";
     }
 }
 
-[[maybe_unused]] static std::ostream& operator<<(std::ostream& os, const DataType_t& type)
+[[maybe_unused]] static std::ostream& operator<<(std::ostream& os, const DataType& type)
 {
     return os << to_string(type);
 }

--- a/frontend/include/hipdnn_frontend/Utilities.hpp
+++ b/frontend/include/hipdnn_frontend/Utilities.hpp
@@ -21,8 +21,8 @@ namespace graph
 // For example:
 // input_shapes = {{1, 2}, {1, 2}, {1, 2, 5}} -> common_shape = {1, 2, 5}
 // input_shapes = {{1, 2, 3}, {1, 2, 4}, {1, 2}} -> error
-inline ErrorObject findCommonShape(const std::vector<std::vector<int64_t>>& inputShapes,
-                                   std::vector<int64_t>& commonShape)
+inline Error findCommonShape(const std::vector<std::vector<int64_t>>& inputShapes,
+                             std::vector<int64_t>& commonShape)
 {
     if(inputShapes.empty())
     {

--- a/frontend/include/hipdnn_frontend/Utilities.hpp
+++ b/frontend/include/hipdnn_frontend/Utilities.hpp
@@ -21,12 +21,12 @@ namespace graph
 // For example:
 // input_shapes = {{1, 2}, {1, 2}, {1, 2, 5}} -> common_shape = {1, 2, 5}
 // input_shapes = {{1, 2, 3}, {1, 2, 4}, {1, 2}} -> error
-inline error_t findCommonShape(const std::vector<std::vector<int64_t>>& inputShapes,
-                               std::vector<int64_t>& commonShape)
+inline ErrorObject findCommonShape(const std::vector<std::vector<int64_t>>& inputShapes,
+                                   std::vector<int64_t>& commonShape)
 {
     if(inputShapes.empty())
     {
-        return {error_code_t::INVALID_VALUE, "Input shapes cannot be empty"};
+        return {ErrorCode::INVALID_VALUE, "Input shapes cannot be empty"};
     }
 
     size_t dims = std::ranges::max_element(
@@ -45,7 +45,7 @@ inline error_t findCommonShape(const std::vector<std::vector<int64_t>>& inputSha
         {
             if(commonShape[j] != current[j] && commonShape[j] != 1 && current[j] != 1)
             {
-                return {error_code_t::INVALID_VALUE, "Incompatible shapes"};
+                return {ErrorCode::INVALID_VALUE, "Incompatible shapes"};
             }
 
             commonShape[j] = std::max(commonShape[j], current[j]);
@@ -61,7 +61,7 @@ template <class T,
           class DeviceAlloc = hipdnn_sdk::utilities::DeviceAllocator<T>>
 inline TensorAttributes
     makeTensorAttributes(const std::string& name,
-                         DataType_t dataType,
+                         DataType dataType,
                          const hipdnn_sdk::utilities::Tensor<T, HostAlloc, DeviceAlloc>& tensor)
 {
     return TensorAttributes()

--- a/frontend/include/hipdnn_frontend/attributes/Attributes.hpp
+++ b/frontend/include/hipdnn_frontend/attributes/Attributes.hpp
@@ -43,7 +43,7 @@ public:
     }
 
     // NOLINTNEXTLINE(readability-identifier-naming)
-    error_t fill_from_context(const GraphAttributes& graphAttributes)
+    ErrorObject fill_from_context(const GraphAttributes& graphAttributes)
     {
         for(auto& [_, tensor] : self().inputs)
         {

--- a/frontend/include/hipdnn_frontend/attributes/Attributes.hpp
+++ b/frontend/include/hipdnn_frontend/attributes/Attributes.hpp
@@ -43,7 +43,7 @@ public:
     }
 
     // NOLINTNEXTLINE(readability-identifier-naming)
-    ErrorObject fill_from_context(const GraphAttributes& graphAttributes)
+    Error fill_from_context(const GraphAttributes& graphAttributes)
     {
         for(auto& [_, tensor] : self().inputs)
         {

--- a/frontend/include/hipdnn_frontend/attributes/BatchnormAttributes.hpp
+++ b/frontend/include/hipdnn_frontend/attributes/BatchnormAttributes.hpp
@@ -16,7 +16,7 @@ namespace graph
 class BatchnormAttributes : public Attributes<BatchnormAttributes>
 {
 public:
-    enum class input_names // NOLINT(readability-identifier-naming)
+    enum class InputNames
     {
         X = 0,
         SCALE = 1,
@@ -26,8 +26,9 @@ public:
         MOMENTUM = 5,
         EPSILON = 6
     };
+    typedef InputNames input_names; // NOLINT(readability-identifier-naming)
 
-    enum class output_names // NOLINT(readability-identifier-naming)
+    enum class OutputNames
     {
         Y = 0,
         MEAN = 1,
@@ -35,30 +36,31 @@ public:
         NEXT_RUNNING_MEAN = 3,
         NEXT_RUNNING_VARIANCE = 4
     };
+    typedef OutputNames output_names; // NOLINT(readability-identifier-naming)
 
-    std::unordered_map<input_names, std::shared_ptr<TensorAttributes>> inputs;
-    std::unordered_map<output_names, std::shared_ptr<TensorAttributes>> outputs;
+    std::unordered_map<InputNames, std::shared_ptr<TensorAttributes>> inputs;
+    std::unordered_map<OutputNames, std::shared_ptr<TensorAttributes>> outputs;
     std::vector<std::shared_ptr<TensorAttributes>> peer_stats;
 
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_x() const
     {
-        return getInput(input_names::X);
+        return getInput(InputNames::X);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_scale() const
     {
-        return getInput(input_names::SCALE);
+        return getInput(InputNames::SCALE);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_bias() const
     {
-        return getInput(input_names::BIAS);
+        return getInput(InputNames::BIAS);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_epsilon() const
     {
-        return getInput(input_names::EPSILON);
+        return getInput(InputNames::EPSILON);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     const std::vector<std::shared_ptr<TensorAttributes>>& get_peer_stats() const
@@ -68,82 +70,82 @@ public:
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_prev_running_mean() const
     {
-        return getInput(input_names::PREV_RUNNING_MEAN);
+        return getInput(InputNames::PREV_RUNNING_MEAN);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_prev_running_variance() const
     {
-        return getInput(input_names::PREV_RUNNING_VARIANCE);
+        return getInput(InputNames::PREV_RUNNING_VARIANCE);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_momentum() const
     {
-        return getInput(input_names::MOMENTUM);
+        return getInput(InputNames::MOMENTUM);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_y() const
     {
-        return getOutput(output_names::Y);
+        return getOutput(OutputNames::Y);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_mean() const
     {
-        return getOutput(output_names::MEAN);
+        return getOutput(OutputNames::MEAN);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_inv_variance() const
     {
-        return getOutput(output_names::INV_VARIANCE);
+        return getOutput(OutputNames::INV_VARIANCE);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_next_running_mean() const
     {
-        return getOutput(output_names::NEXT_RUNNING_MEAN);
+        return getOutput(OutputNames::NEXT_RUNNING_MEAN);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_next_running_variance() const
     {
-        return getOutput(output_names::NEXT_RUNNING_VARIANCE);
+        return getOutput(OutputNames::NEXT_RUNNING_VARIANCE);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_x(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::X, value);
+        return setInput(InputNames::X, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_x(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::X, std::move(value));
+        return setInput(InputNames::X, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_scale(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::SCALE, value);
+        return setInput(InputNames::SCALE, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_scale(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::SCALE, std::move(value));
+        return setInput(InputNames::SCALE, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_bias(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::BIAS, value);
+        return setInput(InputNames::BIAS, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_bias(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::BIAS, std::move(value));
+        return setInput(InputNames::BIAS, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_epsilon(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::EPSILON, value);
+        return setInput(InputNames::EPSILON, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_epsilon(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::EPSILON, std::move(value));
+        return setInput(InputNames::EPSILON, std::move(value));
     }
 
     // NOLINTNEXTLINE(readability-identifier-naming)
@@ -161,82 +163,82 @@ public:
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_prev_running_mean(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::PREV_RUNNING_MEAN, value);
+        return setInput(InputNames::PREV_RUNNING_MEAN, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_prev_running_mean(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::PREV_RUNNING_MEAN, std::move(value));
+        return setInput(InputNames::PREV_RUNNING_MEAN, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_prev_running_variance(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::PREV_RUNNING_VARIANCE, value);
+        return setInput(InputNames::PREV_RUNNING_VARIANCE, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_prev_running_variance(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::PREV_RUNNING_VARIANCE, std::move(value));
+        return setInput(InputNames::PREV_RUNNING_VARIANCE, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_momentum(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::MOMENTUM, value);
+        return setInput(InputNames::MOMENTUM, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_momentum(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::MOMENTUM, std::move(value));
+        return setInput(InputNames::MOMENTUM, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_y(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setOutput(output_names::Y, value);
+        return setOutput(OutputNames::Y, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_y(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setOutput(output_names::Y, std::move(value));
+        return setOutput(OutputNames::Y, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_mean(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setOutput(output_names::MEAN, value);
+        return setOutput(OutputNames::MEAN, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_mean(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setOutput(output_names::MEAN, std::move(value));
+        return setOutput(OutputNames::MEAN, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_inv_variance(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setOutput(output_names::INV_VARIANCE, value);
+        return setOutput(OutputNames::INV_VARIANCE, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_inv_variance(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setOutput(output_names::INV_VARIANCE, std::move(value));
+        return setOutput(OutputNames::INV_VARIANCE, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_next_running_mean(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setOutput(output_names::NEXT_RUNNING_MEAN, value);
+        return setOutput(OutputNames::NEXT_RUNNING_MEAN, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_next_running_mean(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setOutput(output_names::NEXT_RUNNING_MEAN, std::move(value));
+        return setOutput(OutputNames::NEXT_RUNNING_MEAN, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_next_running_variance(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setOutput(output_names::NEXT_RUNNING_VARIANCE, value);
+        return setOutput(OutputNames::NEXT_RUNNING_VARIANCE, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormAttributes& set_next_running_variance(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setOutput(output_names::NEXT_RUNNING_VARIANCE, std::move(value));
+        return setOutput(OutputNames::NEXT_RUNNING_VARIANCE, std::move(value));
     }
     // NOLINTBEGIN(readability-identifier-naming)
     BatchnormAttributes&
@@ -301,7 +303,7 @@ public:
     }
 
 private:
-    std::shared_ptr<TensorAttributes> getInput(input_names name) const
+    std::shared_ptr<TensorAttributes> getInput(InputNames name) const
     {
         auto it = inputs.find(name);
         if(it != inputs.end())
@@ -311,7 +313,7 @@ private:
         return nullptr;
     }
 
-    std::shared_ptr<TensorAttributes> getOutput(output_names name) const
+    std::shared_ptr<TensorAttributes> getOutput(OutputNames name) const
     {
         auto it = outputs.find(name);
         if(it != outputs.end())
@@ -321,24 +323,23 @@ private:
         return nullptr;
     }
 
-    BatchnormAttributes& setInput(input_names name, const std::shared_ptr<TensorAttributes>& value)
+    BatchnormAttributes& setInput(InputNames name, const std::shared_ptr<TensorAttributes>& value)
     {
         inputs[name] = value;
         return *this;
     }
-    BatchnormAttributes& setInput(input_names name, std::shared_ptr<TensorAttributes>&& value)
+    BatchnormAttributes& setInput(InputNames name, std::shared_ptr<TensorAttributes>&& value)
     {
         inputs[name] = std::move(value);
         return *this;
     }
 
-    BatchnormAttributes& setOutput(output_names name,
-                                   const std::shared_ptr<TensorAttributes>& value)
+    BatchnormAttributes& setOutput(OutputNames name, const std::shared_ptr<TensorAttributes>& value)
     {
         outputs[name] = value;
         return *this;
     }
-    BatchnormAttributes& setOutput(output_names name, std::shared_ptr<TensorAttributes>&& value)
+    BatchnormAttributes& setOutput(OutputNames name, std::shared_ptr<TensorAttributes>&& value)
     {
         outputs[name] = std::move(value);
         return *this;

--- a/frontend/include/hipdnn_frontend/attributes/BatchnormBackwardAttributes.hpp
+++ b/frontend/include/hipdnn_frontend/attributes/BatchnormBackwardAttributes.hpp
@@ -15,7 +15,7 @@ namespace graph
 class BatchnormBackwardAttributes : public Attributes<BatchnormBackwardAttributes>
 {
 public:
-    enum class input_names // NOLINT(readability-identifier-naming)
+    enum class InputNames
     {
         DY = 0,
         X = 1,
@@ -23,57 +23,59 @@ public:
         MEAN = 3,
         INV_VARIANCE = 4
     };
+    typedef InputNames input_names; // NOLINT(readability-identifier-naming)
 
-    enum class output_names // NOLINT(readability-identifier-naming)
+    enum class OutputNames
     {
         DX = 0,
         DSCALE = 1,
         DBIAS = 2
     };
+    typedef OutputNames output_names; // NOLINT(readability-identifier-naming)
 
-    std::unordered_map<input_names, std::shared_ptr<TensorAttributes>> inputs;
-    std::unordered_map<output_names, std::shared_ptr<TensorAttributes>> outputs;
+    std::unordered_map<InputNames, std::shared_ptr<TensorAttributes>> inputs;
+    std::unordered_map<OutputNames, std::shared_ptr<TensorAttributes>> outputs;
     std::vector<std::shared_ptr<TensorAttributes>> peer_stats;
 
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_dy() const
     {
-        return getInput(input_names::DY);
+        return getInput(InputNames::DY);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_x() const
     {
-        return getInput(input_names::X);
+        return getInput(InputNames::X);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_scale() const
     {
-        return getInput(input_names::SCALE);
+        return getInput(InputNames::SCALE);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_mean() const
     {
-        return getInput(input_names::MEAN);
+        return getInput(InputNames::MEAN);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_inv_variance() const
     {
-        return getInput(input_names::INV_VARIANCE);
+        return getInput(InputNames::INV_VARIANCE);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_dx() const
     {
-        return getOutput(output_names::DX);
+        return getOutput(OutputNames::DX);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_dscale() const
     {
-        return getOutput(output_names::DSCALE);
+        return getOutput(OutputNames::DSCALE);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_dbias() const
     {
-        return getOutput(output_names::DBIAS);
+        return getOutput(OutputNames::DBIAS);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     const std::vector<std::shared_ptr<TensorAttributes>>& get_peer_stats() const
@@ -84,82 +86,82 @@ public:
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_dy(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::DY, value);
+        return setInput(InputNames::DY, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_dy(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::DY, std::move(value));
+        return setInput(InputNames::DY, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_x(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::X, value);
+        return setInput(InputNames::X, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_x(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::X, std::move(value));
+        return setInput(InputNames::X, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_scale(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::SCALE, value);
+        return setInput(InputNames::SCALE, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_scale(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::SCALE, std::move(value));
+        return setInput(InputNames::SCALE, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_mean(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::MEAN, value);
+        return setInput(InputNames::MEAN, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_mean(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::MEAN, std::move(value));
+        return setInput(InputNames::MEAN, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_inv_variance(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::INV_VARIANCE, value);
+        return setInput(InputNames::INV_VARIANCE, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_inv_variance(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::INV_VARIANCE, std::move(value));
+        return setInput(InputNames::INV_VARIANCE, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_dx(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setOutput(output_names::DX, value);
+        return setOutput(OutputNames::DX, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_dx(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setOutput(output_names::DX, std::move(value));
+        return setOutput(OutputNames::DX, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_dscale(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setOutput(output_names::DSCALE, value);
+        return setOutput(OutputNames::DSCALE, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_dscale(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setOutput(output_names::DSCALE, std::move(value));
+        return setOutput(OutputNames::DSCALE, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_dbias(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setOutput(output_names::DBIAS, value);
+        return setOutput(OutputNames::DBIAS, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormBackwardAttributes& set_dbias(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setOutput(output_names::DBIAS, std::move(value));
+        return setOutput(OutputNames::DBIAS, std::move(value));
     }
     BatchnormBackwardAttributes&
         set_peer_stats(const std::vector<std::shared_ptr<TensorAttributes>>& value) // NOLINT
@@ -217,7 +219,7 @@ public:
     }
 
 private:
-    std::shared_ptr<TensorAttributes> getInput(input_names name) const
+    std::shared_ptr<TensorAttributes> getInput(InputNames name) const
     {
         auto it = inputs.find(name);
         if(it != inputs.end())
@@ -227,7 +229,7 @@ private:
         return nullptr;
     }
 
-    std::shared_ptr<TensorAttributes> getOutput(output_names name) const
+    std::shared_ptr<TensorAttributes> getOutput(OutputNames name) const
     {
         auto it = outputs.find(name);
         if(it != outputs.end())
@@ -237,26 +239,26 @@ private:
         return nullptr;
     }
 
-    BatchnormBackwardAttributes& setInput(input_names name,
+    BatchnormBackwardAttributes& setInput(InputNames name,
                                           const std::shared_ptr<TensorAttributes>& value)
     {
         inputs[name] = value;
         return *this;
     }
-    BatchnormBackwardAttributes& setInput(input_names name,
+    BatchnormBackwardAttributes& setInput(InputNames name,
                                           std::shared_ptr<TensorAttributes>&& value)
     {
         inputs[name] = std::move(value);
         return *this;
     }
 
-    BatchnormBackwardAttributes& setOutput(output_names name,
+    BatchnormBackwardAttributes& setOutput(OutputNames name,
                                            const std::shared_ptr<TensorAttributes>& value)
     {
         outputs[name] = value;
         return *this;
     }
-    BatchnormBackwardAttributes& setOutput(output_names name,
+    BatchnormBackwardAttributes& setOutput(OutputNames name,
                                            std::shared_ptr<TensorAttributes>&& value)
     {
         outputs[name] = std::move(value);

--- a/frontend/include/hipdnn_frontend/attributes/BatchnormInferenceAttributes.hpp
+++ b/frontend/include/hipdnn_frontend/attributes/BatchnormInferenceAttributes.hpp
@@ -15,7 +15,7 @@ namespace graph
 class BatchnormInferenceAttributes : public Attributes<BatchnormInferenceAttributes>
 {
 public:
-    enum class input_names // NOLINT(readability-identifier-naming)
+    enum class InputNames
     {
         X = 0,
         MEAN = 1,
@@ -23,105 +23,107 @@ public:
         SCALE = 3,
         BIAS = 4
     };
+    typedef InputNames input_names; // NOLINT(readability-identifier-naming)
 
-    enum class output_names // NOLINT(readability-identifier-naming)
+    enum class OutputNames
     {
         Y = 0
     };
+    typedef OutputNames output_names; // NOLINT(readability-identifier-naming)
 
-    std::unordered_map<input_names, std::shared_ptr<TensorAttributes>> inputs;
-    std::unordered_map<output_names, std::shared_ptr<TensorAttributes>> outputs;
+    std::unordered_map<InputNames, std::shared_ptr<TensorAttributes>> inputs;
+    std::unordered_map<OutputNames, std::shared_ptr<TensorAttributes>> outputs;
 
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_x() const
     {
-        return getInput(input_names::X);
+        return getInput(InputNames::X);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_mean() const
     {
-        return getInput(input_names::MEAN);
+        return getInput(InputNames::MEAN);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_inv_variance() const
     {
-        return getInput(input_names::INV_VARIANCE);
+        return getInput(InputNames::INV_VARIANCE);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_scale() const
     {
-        return getInput(input_names::SCALE);
+        return getInput(InputNames::SCALE);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_bias() const
     {
-        return getInput(input_names::BIAS);
+        return getInput(InputNames::BIAS);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_y() const
     {
-        return getOutput(output_names::Y);
+        return getOutput(OutputNames::Y);
     }
 
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormInferenceAttributes& set_x(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::X, value);
+        return setInput(InputNames::X, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormInferenceAttributes& set_x(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::X, std::move(value));
+        return setInput(InputNames::X, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormInferenceAttributes& set_mean(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::MEAN, value);
+        return setInput(InputNames::MEAN, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormInferenceAttributes& set_mean(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::MEAN, std::move(value));
+        return setInput(InputNames::MEAN, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormInferenceAttributes& set_inv_variance(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::INV_VARIANCE, value);
+        return setInput(InputNames::INV_VARIANCE, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormInferenceAttributes& set_inv_variance(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::INV_VARIANCE, std::move(value));
+        return setInput(InputNames::INV_VARIANCE, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormInferenceAttributes& set_scale(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::SCALE, value);
+        return setInput(InputNames::SCALE, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormInferenceAttributes& set_scale(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::SCALE, std::move(value));
+        return setInput(InputNames::SCALE, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormInferenceAttributes& set_bias(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::BIAS, value);
+        return setInput(InputNames::BIAS, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormInferenceAttributes& set_bias(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::BIAS, std::move(value));
+        return setInput(InputNames::BIAS, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormInferenceAttributes& set_y(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setOutput(output_names::Y, value);
+        return setOutput(OutputNames::Y, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     BatchnormInferenceAttributes& set_y(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setOutput(output_names::Y, std::move(value));
+        return setOutput(OutputNames::Y, std::move(value));
     }
 
     flatbuffers::Offset<hipdnn_sdk::data_objects::BatchnormInferenceAttributes>
@@ -142,7 +144,7 @@ public:
     }
 
 private:
-    std::shared_ptr<TensorAttributes> getInput(input_names name) const
+    std::shared_ptr<TensorAttributes> getInput(InputNames name) const
     {
         auto it = inputs.find(name);
         if(it != inputs.end())
@@ -152,7 +154,7 @@ private:
         return nullptr;
     }
 
-    std::shared_ptr<TensorAttributes> getOutput(output_names name) const
+    std::shared_ptr<TensorAttributes> getOutput(OutputNames name) const
     {
         auto it = outputs.find(name);
         if(it != outputs.end())
@@ -162,26 +164,26 @@ private:
         return nullptr;
     }
 
-    BatchnormInferenceAttributes& setInput(input_names name,
+    BatchnormInferenceAttributes& setInput(InputNames name,
                                            const std::shared_ptr<TensorAttributes>& value)
     {
         inputs[name] = value;
         return *this;
     }
-    BatchnormInferenceAttributes& setInput(input_names name,
+    BatchnormInferenceAttributes& setInput(InputNames name,
                                            std::shared_ptr<TensorAttributes>&& value)
     {
         inputs[name] = std::move(value);
         return *this;
     }
 
-    BatchnormInferenceAttributes& setOutput(output_names name,
+    BatchnormInferenceAttributes& setOutput(OutputNames name,
                                             const std::shared_ptr<TensorAttributes>& value)
     {
         outputs[name] = value;
         return *this;
     }
-    BatchnormInferenceAttributes& setOutput(output_names name,
+    BatchnormInferenceAttributes& setOutput(OutputNames name,
                                             std::shared_ptr<TensorAttributes>&& value)
     {
         outputs[name] = std::move(value);

--- a/frontend/include/hipdnn_frontend/attributes/ConvolutionFpropAttributes.hpp
+++ b/frontend/include/hipdnn_frontend/attributes/ConvolutionFpropAttributes.hpp
@@ -17,74 +17,76 @@ namespace graph
 class ConvFpropAttributes : public Attributes<ConvFpropAttributes>
 {
 public:
-    enum class input_names // NOLINT(readability-identifier-naming)
+    enum class InputNames
     {
         X = 0, // Input tensor
         W = 1 // Weights/filter tensor
     };
+    typedef InputNames input_names; // NOLINT(readability-identifier-naming)
 
-    enum class output_names // NOLINT(readability-identifier-naming)
+    enum class OutputNames
     {
         Y = 0 // Output tensor
     };
+    typedef OutputNames output_names; // NOLINT(readability-identifier-naming)
 
-    std::unordered_map<input_names, std::shared_ptr<TensorAttributes>> inputs;
-    std::unordered_map<output_names, std::shared_ptr<TensorAttributes>> outputs;
+    std::unordered_map<InputNames, std::shared_ptr<TensorAttributes>> inputs;
+    std::unordered_map<OutputNames, std::shared_ptr<TensorAttributes>> outputs;
 
     // Convolution parameters
     std::vector<int64_t> pre_padding;
     std::vector<int64_t> post_padding;
     std::vector<int64_t> stride;
     std::vector<int64_t> dilation;
-    ConvolutionMode_t math_mode = ConvolutionMode_t::CROSS_CORRELATION;
+    ConvolutionMode math_mode = ConvolutionMode::CROSS_CORRELATION;
 
     // Getters for tensors
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_x() const
     {
-        return getInput(input_names::X);
+        return getInput(InputNames::X);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_w() const
     {
-        return getInput(input_names::W);
+        return getInput(InputNames::W);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_y() const
     {
-        return getOutput(output_names::Y);
+        return getOutput(OutputNames::Y);
     }
 
     // Setters for tensor
     // NOLINTNEXTLINE(readability-identifier-naming)
     ConvFpropAttributes& set_x(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::X, std::move(value));
+        return setInput(InputNames::X, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     ConvFpropAttributes& set_x(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::X, value);
+        return setInput(InputNames::X, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     ConvFpropAttributes& set_w(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setInput(input_names::W, std::move(value));
+        return setInput(InputNames::W, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     ConvFpropAttributes& set_w(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setInput(input_names::W, value);
+        return setInput(InputNames::W, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     ConvFpropAttributes& set_y(std::shared_ptr<TensorAttributes>&& value)
     {
-        return setOutput(output_names::Y, std::move(value));
+        return setOutput(OutputNames::Y, std::move(value));
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     ConvFpropAttributes& set_y(const std::shared_ptr<TensorAttributes>& value)
     {
-        return setOutput(output_names::Y, value);
+        return setOutput(OutputNames::Y, value);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     ConvFpropAttributes& set_padding(std::vector<int64_t> padding)
@@ -151,7 +153,7 @@ public:
     }
 
     // NOLINTNEXTLINE(readability-identifier-naming)
-    ConvFpropAttributes& set_convolution_mode(ConvolutionMode_t mode)
+    ConvFpropAttributes& set_convolution_mode(ConvolutionMode mode)
     {
         math_mode = mode;
         return *this;
@@ -179,7 +181,7 @@ public:
         return dilation;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
-    ConvolutionMode_t get_convolution_mode() const
+    ConvolutionMode get_convolution_mode() const
     {
         return math_mode;
     }
@@ -199,7 +201,7 @@ public:
     }
 
 private:
-    std::shared_ptr<TensorAttributes> getInput(input_names name) const
+    std::shared_ptr<TensorAttributes> getInput(InputNames name) const
     {
         auto it = inputs.find(name);
         if(it != inputs.end())
@@ -209,7 +211,7 @@ private:
         return nullptr;
     }
 
-    std::shared_ptr<TensorAttributes> getOutput(output_names name) const
+    std::shared_ptr<TensorAttributes> getOutput(OutputNames name) const
     {
         auto it = outputs.find(name);
         if(it != outputs.end())
@@ -219,26 +221,25 @@ private:
         return nullptr;
     }
 
-    ConvFpropAttributes& setInput(input_names name, const std::shared_ptr<TensorAttributes>& value)
+    ConvFpropAttributes& setInput(InputNames name, const std::shared_ptr<TensorAttributes>& value)
     {
         inputs[name] = value;
         return *this;
     }
 
-    ConvFpropAttributes& setInput(input_names name, std::shared_ptr<TensorAttributes>&& value)
+    ConvFpropAttributes& setInput(InputNames name, std::shared_ptr<TensorAttributes>&& value)
     {
         inputs[name] = std::move(value);
         return *this;
     }
 
-    ConvFpropAttributes& setOutput(output_names name,
-                                   const std::shared_ptr<TensorAttributes>& value)
+    ConvFpropAttributes& setOutput(OutputNames name, const std::shared_ptr<TensorAttributes>& value)
     {
         outputs[name] = value;
         return *this;
     }
 
-    ConvFpropAttributes& setOutput(output_names name, std::shared_ptr<TensorAttributes>&& value)
+    ConvFpropAttributes& setOutput(OutputNames name, std::shared_ptr<TensorAttributes>&& value)
     {
         outputs[name] = std::move(value);
         return *this;

--- a/frontend/include/hipdnn_frontend/attributes/GraphAttributes.hpp
+++ b/frontend/include/hipdnn_frontend/attributes/GraphAttributes.hpp
@@ -20,34 +20,34 @@ public:
         return _name;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
-    DataType_t get_compute_data_type() const
+    DataType get_compute_data_type() const
     {
         return _computeType;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
-    DataType_t get_intermediate_data_type() const
+    DataType get_intermediate_data_type() const
     {
         return _intermediateType;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
-    DataType_t get_io_data_type() const
+    DataType get_io_data_type() const
     {
         return _ioType;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
-    GraphAttributes& set_compute_data_type(DataType_t computeType)
+    GraphAttributes& set_compute_data_type(DataType computeType)
     {
         _computeType = computeType;
         return *this;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
-    GraphAttributes& set_intermediate_data_type(DataType_t intermediateType)
+    GraphAttributes& set_intermediate_data_type(DataType intermediateType)
     {
         _intermediateType = intermediateType;
         return *this;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
-    GraphAttributes& set_io_data_type(DataType_t ioType)
+    GraphAttributes& set_io_data_type(DataType ioType)
     {
         _ioType = ioType;
         return *this;
@@ -62,11 +62,11 @@ public:
     // NOLINTNEXTLINE(readability-identifier-naming)
     GraphAttributes& fill_missing_properties(const GraphAttributes& other)
     {
-        if(_computeType == DataType_t::NOT_SET)
+        if(_computeType == DataType::NOT_SET)
             _computeType = other._computeType;
-        if(_intermediateType == DataType_t::NOT_SET)
+        if(_intermediateType == DataType::NOT_SET)
             _intermediateType = other._intermediateType;
-        if(_ioType == DataType_t::NOT_SET)
+        if(_ioType == DataType::NOT_SET)
             _ioType = other._ioType;
         if(_name.empty())
             _name = other._name;
@@ -75,9 +75,9 @@ public:
 
 private:
     std::string _name;
-    DataType_t _computeType = DataType_t::NOT_SET;
-    DataType_t _intermediateType = DataType_t::NOT_SET;
-    DataType_t _ioType = DataType_t::NOT_SET;
+    DataType _computeType = DataType::NOT_SET;
+    DataType _intermediateType = DataType::NOT_SET;
+    DataType _ioType = DataType::NOT_SET;
 };
 typedef GraphAttributes Context;
 }

--- a/frontend/include/hipdnn_frontend/attributes/PointwiseAttributes.hpp
+++ b/frontend/include/hipdnn_frontend/attributes/PointwiseAttributes.hpp
@@ -18,7 +18,7 @@ class PointwiseAttributes : public Attributes<PointwiseAttributes>
 {
 public:
     // NOLINTNEXTLINE(readability-identifier-naming)
-    PointwiseMode_t get_mode() const
+    PointwiseMode get_mode() const
     {
         return _mode;
     }
@@ -45,26 +45,26 @@ public:
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_input_0() const
     {
-        return getInput(input_names::IN_0);
+        return getInput(InputNames::IN_0);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_input_1() const
     {
-        return getInput(input_names::IN_1);
+        return getInput(InputNames::IN_1);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_input_2() const
     {
-        return getInput(input_names::IN_2);
+        return getInput(InputNames::IN_2);
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     std::shared_ptr<TensorAttributes> get_output_0() const
     {
-        return getOutput(output_names::OUT_0);
+        return getOutput(OutputNames::OUT_0);
     }
 
     // NOLINTNEXTLINE(readability-identifier-naming)
-    PointwiseAttributes& set_mode(PointwiseMode_t mode)
+    PointwiseAttributes& set_mode(PointwiseMode mode)
     {
         _mode = mode;
         return *this;
@@ -96,64 +96,68 @@ public:
     // NOLINTNEXTLINE(readability-identifier-naming)
     PointwiseAttributes& set_input_0(const std::shared_ptr<TensorAttributes>& input0)
     {
-        inputs[input_names::IN_0] = input0;
+        inputs[InputNames::IN_0] = input0;
         return *this;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     PointwiseAttributes& set_input_0(std::shared_ptr<TensorAttributes>&& input0)
     {
-        inputs[input_names::IN_0] = std::move(input0);
+        inputs[InputNames::IN_0] = std::move(input0);
         return *this;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     PointwiseAttributes& set_input_1(const std::shared_ptr<TensorAttributes>& input1)
     {
-        inputs[input_names::IN_1] = input1;
+        inputs[InputNames::IN_1] = input1;
         return *this;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     PointwiseAttributes& set_input_1(std::shared_ptr<TensorAttributes>&& input1)
     {
-        inputs[input_names::IN_1] = std::move(input1);
+        inputs[InputNames::IN_1] = std::move(input1);
         return *this;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     PointwiseAttributes& set_input_2(const std::shared_ptr<TensorAttributes>& input2)
     {
-        inputs[input_names::IN_2] = input2;
+        inputs[InputNames::IN_2] = input2;
         return *this;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     PointwiseAttributes& set_input_2(std::shared_ptr<TensorAttributes>&& input2)
     {
-        inputs[input_names::IN_2] = std::move(input2);
+        inputs[InputNames::IN_2] = std::move(input2);
         return *this;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     PointwiseAttributes& set_output_0(const std::shared_ptr<TensorAttributes>& output0)
     {
-        outputs[output_names::OUT_0] = output0;
+        outputs[OutputNames::OUT_0] = output0;
         return *this;
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     PointwiseAttributes& set_output_0(std::shared_ptr<TensorAttributes>&& output0)
     {
-        outputs[output_names::OUT_0] = std::move(output0);
+        outputs[OutputNames::OUT_0] = std::move(output0);
         return *this;
     }
 
-    enum class input_names // NOLINT(readability-identifier-naming)
+    enum class InputNames
     {
         IN_0 = 0,
         IN_1 = 1,
         IN_2 = 2,
     };
-    enum class output_names // NOLINT(readability-identifier-naming)
+    typedef InputNames input_names; // NOLINT(readability-identifier-naming)
+
+    enum class OutputNames
     {
         OUT_0 = 0,
     };
-    std::unordered_map<input_names, std::shared_ptr<TensorAttributes>> inputs;
-    std::unordered_map<output_names, std::shared_ptr<TensorAttributes>> outputs;
+    typedef OutputNames output_names; // NOLINT(readability-identifier-naming)
+
+    std::unordered_map<InputNames, std::shared_ptr<TensorAttributes>> inputs;
+    std::unordered_map<OutputNames, std::shared_ptr<TensorAttributes>> outputs;
 
     flatbuffers::Offset<hipdnn_sdk::data_objects::PointwiseAttributes>
         pack_attributes(flatbuffers::FlatBufferBuilder& builder) const // NOLINT
@@ -177,7 +181,7 @@ public:
     }
 
 private:
-    std::shared_ptr<TensorAttributes> getInput(input_names name) const
+    std::shared_ptr<TensorAttributes> getInput(InputNames name) const
     {
         auto it = inputs.find(name);
         if(it != inputs.end())
@@ -186,7 +190,7 @@ private:
         }
         return nullptr;
     }
-    std::shared_ptr<TensorAttributes> getOutput(output_names name) const
+    std::shared_ptr<TensorAttributes> getOutput(OutputNames name) const
     {
         auto it = outputs.find(name);
         if(it != outputs.end())
@@ -195,7 +199,7 @@ private:
         }
         return nullptr;
     }
-    PointwiseMode_t _mode = PointwiseMode_t::NOT_SET;
+    PointwiseMode _mode = PointwiseMode::NOT_SET;
     std::optional<float> _reluLowerClip = std::nullopt;
     std::optional<float> _reluUpperClip = std::nullopt;
     std::optional<float> _reluLowerSlope = std::nullopt;

--- a/frontend/include/hipdnn_frontend/attributes/TensorAttributes.hpp
+++ b/frontend/include/hipdnn_frontend/attributes/TensorAttributes.hpp
@@ -82,7 +82,7 @@ public:
         return _name;
     }
 
-    DataType_t get_data_type() const // NOLINT(readability-identifier-naming)
+    DataType get_data_type() const // NOLINT(readability-identifier-naming)
     {
         return _dataType;
     }
@@ -130,7 +130,7 @@ public:
         return *this;
     }
 
-    TensorAttributes& set_data_type(DataType_t dataType) // NOLINT(readability-identifier-naming)
+    TensorAttributes& set_data_type(DataType dataType) // NOLINT(readability-identifier-naming)
     {
         _dataType = dataType;
         return *this;
@@ -171,7 +171,7 @@ public:
     // NOLINTNEXTLINE(readability-identifier-naming)
     TensorAttributes& fill_from_context(const GraphAttributes& graphAttributes)
     {
-        if(_dataType == DataType_t::NOT_SET)
+        if(_dataType == DataType::NOT_SET)
         {
             if(_isVirtual)
             {
@@ -265,7 +265,7 @@ private:
     int64_t _uid = 0;
     bool _uidSet = false;
     std::string _name;
-    DataType_t _dataType = DataType_t::NOT_SET;
+    DataType _dataType = DataType::NOT_SET;
     std::vector<int64_t> _stride;
     std::vector<int64_t> _dim;
     bool _isVirtual = false;

--- a/frontend/include/hipdnn_frontend/node/BatchnormBackwardNode.hpp
+++ b/frontend/include/hipdnn_frontend/node/BatchnormBackwardNode.hpp
@@ -25,7 +25,7 @@ public:
     {
     }
 
-    ErrorObject pre_validate_node() const override
+    Error pre_validate_node() const override
     {
         if(!attributes.get_dy())
         {
@@ -61,7 +61,7 @@ public:
         return {};
     }
 
-    ErrorObject infer_properties_node() override
+    Error infer_properties_node() override
     {
         auto x = attributes.get_x();
         auto dx = attributes.get_dx();
@@ -137,7 +137,7 @@ public:
         }
     }
 
-    ErrorObject populate_hipdnn_tensor_ids(
+    Error populate_hipdnn_tensor_ids(
         std::unordered_map<int64_t, std::shared_ptr<TensorAttributes>>& tensorLookup,
         int64_t& currentTensorId,
         std::unordered_set<int64_t>& usedIds) const override

--- a/frontend/include/hipdnn_frontend/node/BatchnormBackwardNode.hpp
+++ b/frontend/include/hipdnn_frontend/node/BatchnormBackwardNode.hpp
@@ -25,43 +25,43 @@ public:
     {
     }
 
-    error_t pre_validate_node() const override
+    ErrorObject pre_validate_node() const override
     {
         if(!attributes.get_dy())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormBackwardNode missing dy for pre-validation"};
         }
         if(!attributes.get_x())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormBackwardNode missing x for pre-validation"};
         }
         if(!attributes.get_scale())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormBackwardNode missing scale for pre-validation"};
         }
         if(!attributes.get_dx())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormBackwardNode missing dx for pre-validation"};
         }
         if(!attributes.get_dscale())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormBackwardNode missing dscale for pre-validation"};
         }
         if(!attributes.get_dbias())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormBackwardNode missing dbias for pre-validation"};
         }
 
         return {};
     }
 
-    error_t infer_properties_node() override
+    ErrorObject infer_properties_node() override
     {
         auto x = attributes.get_x();
         auto dx = attributes.get_dx();
@@ -70,22 +70,22 @@ public:
 
         if(!x)
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormBackwardNode missing x for setting properties"};
         }
         if(!dx)
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormBackwardNode missing dx for setting properties"};
         }
         if(!dscale)
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormBackwardNode missing dscale for setting properties"};
         }
         if(!dbias)
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormBackwardNode missing dbias for setting properties"};
         }
 
@@ -137,7 +137,7 @@ public:
         }
     }
 
-    error_t populate_hipdnn_tensor_ids(
+    ErrorObject populate_hipdnn_tensor_ids(
         std::unordered_map<int64_t, std::shared_ptr<TensorAttributes>>& tensorLookup,
         int64_t& currentTensorId,
         std::unordered_set<int64_t>& usedIds) const override

--- a/frontend/include/hipdnn_frontend/node/BatchnormInferenceNode.hpp
+++ b/frontend/include/hipdnn_frontend/node/BatchnormInferenceNode.hpp
@@ -22,46 +22,46 @@ public:
     {
     }
 
-    error_t pre_validate_node() const override
+    ErrorObject pre_validate_node() const override
     {
         if(!attributes.get_x())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormInferenceNode missing x for pre-validation"};
         }
         if(!attributes.get_scale())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormInferenceNode missing scale for pre-validation"};
         }
         if(!attributes.get_bias())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormInferenceNode missing bias for pre-validation"};
         }
         if(!attributes.get_y())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormInferenceNode missing y for pre-validation"};
         }
 
         return {};
     }
 
-    error_t infer_properties_node() override
+    ErrorObject infer_properties_node() override
     {
         auto x = attributes.get_x();
         auto y = attributes.get_y();
 
         if(!x)
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormInferenceNode missing x for setting properties"};
         }
 
         if(!y)
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormInferenceNode missing y for setting properties"};
         }
 

--- a/frontend/include/hipdnn_frontend/node/BatchnormInferenceNode.hpp
+++ b/frontend/include/hipdnn_frontend/node/BatchnormInferenceNode.hpp
@@ -22,7 +22,7 @@ public:
     {
     }
 
-    ErrorObject pre_validate_node() const override
+    Error pre_validate_node() const override
     {
         if(!attributes.get_x())
         {
@@ -48,7 +48,7 @@ public:
         return {};
     }
 
-    ErrorObject infer_properties_node() override
+    Error infer_properties_node() override
     {
         auto x = attributes.get_x();
         auto y = attributes.get_y();

--- a/frontend/include/hipdnn_frontend/node/BatchnormNode.hpp
+++ b/frontend/include/hipdnn_frontend/node/BatchnormNode.hpp
@@ -23,7 +23,7 @@ public:
     {
     }
 
-    ErrorObject pre_validate_node() const override
+    Error pre_validate_node() const override
     {
         if(!attributes.get_x())
         {
@@ -50,7 +50,7 @@ public:
         return {};
     }
 
-    ErrorObject infer_properties_node() override
+    Error infer_properties_node() override
     {
         auto x = attributes.get_x();
         auto y = attributes.get_y();
@@ -135,7 +135,7 @@ public:
         }
     }
 
-    ErrorObject populate_hipdnn_tensor_ids(
+    Error populate_hipdnn_tensor_ids(
         std::unordered_map<int64_t, std::shared_ptr<TensorAttributes>>& tensorLookup,
         int64_t& currentTensorId,
         std::unordered_set<int64_t>& usedIds) const override

--- a/frontend/include/hipdnn_frontend/node/BatchnormNode.hpp
+++ b/frontend/include/hipdnn_frontend/node/BatchnormNode.hpp
@@ -23,50 +23,46 @@ public:
     {
     }
 
-    error_t pre_validate_node() const override
+    ErrorObject pre_validate_node() const override
     {
         if(!attributes.get_x())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET, "BatchnormNode missing x for pre-validation"};
+            return {ErrorCode::ATTRIBUTE_NOT_SET, "BatchnormNode missing x for pre-validation"};
         }
         if(!attributes.get_scale())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
-                    "BatchnormNode missing scale for pre-validation"};
+            return {ErrorCode::ATTRIBUTE_NOT_SET, "BatchnormNode missing scale for pre-validation"};
         }
         if(!attributes.get_bias())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
-                    "BatchnormNode missing bias for pre-validation"};
+            return {ErrorCode::ATTRIBUTE_NOT_SET, "BatchnormNode missing bias for pre-validation"};
         }
         if(!attributes.get_y())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET, "BatchnormNode missing y for pre-validation"};
+            return {ErrorCode::ATTRIBUTE_NOT_SET, "BatchnormNode missing y for pre-validation"};
         }
         if(!attributes.get_epsilon())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormNode missing epsilon for pre-validation"};
         }
 
         return {};
     }
 
-    error_t infer_properties_node() override
+    ErrorObject infer_properties_node() override
     {
         auto x = attributes.get_x();
         auto y = attributes.get_y();
 
         if(!x)
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
-                    "BatchnormNode missing x for setting properties"};
+            return {ErrorCode::ATTRIBUTE_NOT_SET, "BatchnormNode missing x for setting properties"};
         }
 
         if(!y)
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
-                    "BatchnormNode missing y for setting properties"};
+            return {ErrorCode::ATTRIBUTE_NOT_SET, "BatchnormNode missing y for setting properties"};
         }
 
         HIPDNN_CHECK_ERROR(attributes.fill_from_context(graph_attributes));
@@ -139,7 +135,7 @@ public:
         }
     }
 
-    error_t populate_hipdnn_tensor_ids(
+    ErrorObject populate_hipdnn_tensor_ids(
         std::unordered_map<int64_t, std::shared_ptr<TensorAttributes>>& tensorLookup,
         int64_t& currentTensorId,
         std::unordered_set<int64_t>& usedIds) const override

--- a/frontend/include/hipdnn_frontend/node/ConvolutionFpropNode.hpp
+++ b/frontend/include/hipdnn_frontend/node/ConvolutionFpropNode.hpp
@@ -23,7 +23,7 @@ public:
     {
     }
 
-    ErrorObject pre_validate_node() const override
+    Error pre_validate_node() const override
     {
         // Validate tensor pointers
         HIPDNN_RETURN_IF_FALSE(attributes.get_x(),
@@ -212,7 +212,7 @@ public:
         return {};
     }
 
-    ErrorObject infer_properties_node() override
+    Error infer_properties_node() override
     {
         auto x = attributes.get_x();
         auto w = attributes.get_w();

--- a/frontend/include/hipdnn_frontend/node/ConvolutionFpropNode.hpp
+++ b/frontend/include/hipdnn_frontend/node/ConvolutionFpropNode.hpp
@@ -23,36 +23,36 @@ public:
     {
     }
 
-    error_t pre_validate_node() const override
+    ErrorObject pre_validate_node() const override
     {
         // Validate tensor pointers
         HIPDNN_RETURN_IF_FALSE(attributes.get_x(),
-                               error_code_t::ATTRIBUTE_NOT_SET,
+                               ErrorCode::ATTRIBUTE_NOT_SET,
                                "ConvolutionFpropNode missing x (input) for pre-validation");
 
         HIPDNN_RETURN_IF_FALSE(attributes.get_w(),
-                               error_code_t::ATTRIBUTE_NOT_SET,
+                               ErrorCode::ATTRIBUTE_NOT_SET,
                                "ConvolutionFpropNode missing w (weights) for pre-validation");
 
         HIPDNN_RETURN_IF_FALSE(attributes.get_y(),
-                               error_code_t::ATTRIBUTE_NOT_SET,
+                               ErrorCode::ATTRIBUTE_NOT_SET,
                                "ConvolutionFpropNode missing y (output) for pre-validation");
 
         // Validate convolution parameters
         HIPDNN_RETURN_IF_TRUE(attributes.get_pre_padding().empty(),
-                              error_code_t::ATTRIBUTE_NOT_SET,
+                              ErrorCode::ATTRIBUTE_NOT_SET,
                               "ConvolutionFpropNode missing pre_padding for pre-validation");
 
         HIPDNN_RETURN_IF_TRUE(attributes.get_post_padding().empty(),
-                              error_code_t::ATTRIBUTE_NOT_SET,
+                              ErrorCode::ATTRIBUTE_NOT_SET,
                               "ConvolutionFpropNode missing post_padding for pre-validation");
 
         HIPDNN_RETURN_IF_TRUE(attributes.get_stride().empty(),
-                              error_code_t::ATTRIBUTE_NOT_SET,
+                              ErrorCode::ATTRIBUTE_NOT_SET,
                               "ConvolutionFpropNode missing stride for pre-validation");
 
         HIPDNN_RETURN_IF_TRUE(attributes.get_dilation().empty(),
-                              error_code_t::ATTRIBUTE_NOT_SET,
+                              ErrorCode::ATTRIBUTE_NOT_SET,
                               "ConvolutionFpropNode missing dilation for pre-validation");
 
         // Get tensor references
@@ -65,13 +65,13 @@ public:
 
         HIPDNN_RETURN_IF_FALSE(
             x->validate_dims_and_strides_set_and_positive(),
-            error_code_t::INVALID_VALUE,
+            ErrorCode::INVALID_VALUE,
             "ConvolutionFpropNode: Input tensor dimensions and strides must be set and positive");
 
         HIPDNN_RETURN_IF_LT(
             xDims.size(),
             3,
-            error_code_t::INVALID_VALUE,
+            ErrorCode::INVALID_VALUE,
             "ConvolutionFpropNode: Input tensor must have at least 3 dimensions (N, C, spatial)");
 
         // Validate weight tensor dimensions and strides
@@ -79,13 +79,13 @@ public:
 
         HIPDNN_RETURN_IF_FALSE(
             w->validate_dims_and_strides_set_and_positive(),
-            error_code_t::INVALID_VALUE,
+            ErrorCode::INVALID_VALUE,
             "ConvolutionFpropNode: Weight tensor dimensions and strides must be set and positive");
 
         HIPDNN_RETURN_IF_NE(
             wDims.size(),
             xDims.size(),
-            error_code_t::INVALID_VALUE,
+            ErrorCode::INVALID_VALUE,
             "ConvolutionFpropNode: Weight tensor dimension count must match input tensor "
             "dimension count");
 
@@ -95,7 +95,7 @@ public:
         HIPDNN_RETURN_IF_NE(
             xDims[1] % wDims[1],
             0,
-            error_code_t::INVALID_VALUE,
+            ErrorCode::INVALID_VALUE,
             "ConvolutionFpropNode: Input tensor channels must match weight tensor input "
             "channels or be divisible by them for grouped convolution");
 
@@ -105,7 +105,7 @@ public:
         HIPDNN_RETURN_IF_NE(
             wDims[0] % groupCount,
             0,
-            error_code_t::INVALID_VALUE,
+            ErrorCode::INVALID_VALUE,
             "ConvolutionFpropNode: Weight tensor output channels must be divisible by "
             "the number of groups");
 
@@ -118,34 +118,34 @@ public:
             HIPDNN_RETURN_IF_NE(
                 yDims.size(),
                 xDims.size(),
-                error_code_t::INVALID_VALUE,
+                ErrorCode::INVALID_VALUE,
                 "ConvolutionFpropNode: Output tensor dimension count must match input tensor "
                 "dimension count");
 
             // Validate batch size matches
             HIPDNN_RETURN_IF_NE(yDims[0],
                                 xDims[0],
-                                error_code_t::INVALID_VALUE,
+                                ErrorCode::INVALID_VALUE,
                                 "ConvolutionFpropNode: Output tensor batch size must match input "
                                 "tensor batch size");
 
             // Validate output channels match weight output channels
             HIPDNN_RETURN_IF_NE(yDims[1],
                                 wDims[0],
-                                error_code_t::INVALID_VALUE,
+                                ErrorCode::INVALID_VALUE,
                                 "ConvolutionFpropNode: Output tensor channels must match weight "
                                 "tensor output channels");
 
             HIPDNN_RETURN_IF_FALSE(
                 y->validate_dims_set_and_positive(),
-                error_code_t::INVALID_VALUE,
+                ErrorCode::INVALID_VALUE,
                 "ConvolutionFpropNode: Output tensor dimensions must be set and positive");
         }
 
         if(!yStrides.empty())
         {
             HIPDNN_RETURN_IF_FALSE(y->validate_dims_and_strides_set_and_positive(),
-                                   error_code_t::INVALID_VALUE,
+                                   ErrorCode::INVALID_VALUE,
                                    "ConvolutionFpropNode: Output tensor dimensions and strides "
                                    "must be set and positive");
         }
@@ -160,25 +160,25 @@ public:
         HIPDNN_RETURN_IF_NE(
             prePadding.size(),
             spatialDims,
-            error_code_t::INVALID_VALUE,
+            ErrorCode::INVALID_VALUE,
             "ConvolutionFpropNode: pre_padding parameter count must match spatial dimension count");
 
         HIPDNN_RETURN_IF_NE(postPadding.size(),
                             spatialDims,
-                            error_code_t::INVALID_VALUE,
+                            ErrorCode::INVALID_VALUE,
                             "ConvolutionFpropNode: post_padding parameter count must match spatial "
                             "dimension count");
 
         HIPDNN_RETURN_IF_NE(
             stride.size(),
             spatialDims,
-            error_code_t::INVALID_VALUE,
+            ErrorCode::INVALID_VALUE,
             "ConvolutionFpropNode: stride parameter count must match spatial dimension count");
 
         HIPDNN_RETURN_IF_NE(
             dilation.size(),
             spatialDims,
-            error_code_t::INVALID_VALUE,
+            ErrorCode::INVALID_VALUE,
             "ConvolutionFpropNode: dilation parameter count must match spatial dimension count");
 
         // Check spatial parameters for each dimension
@@ -190,46 +190,44 @@ public:
             auto dilationVal = dilation[i];
 
             // Validate parameters
-            HIPDNN_RETURN_IF_LT(strideVal,
-                                1,
-                                error_code_t::INVALID_VALUE,
-                                "ConvolutionFpropNode: Stride must be > 0");
+            HIPDNN_RETURN_IF_LT(
+                strideVal, 1, ErrorCode::INVALID_VALUE, "ConvolutionFpropNode: Stride must be > 0");
 
             HIPDNN_RETURN_IF_LT(dilationVal,
                                 1,
-                                error_code_t::INVALID_VALUE,
+                                ErrorCode::INVALID_VALUE,
                                 "ConvolutionFpropNode: Dilation must > 0");
 
             HIPDNN_RETURN_IF_LT(prePad,
                                 0,
-                                error_code_t::INVALID_VALUE,
+                                ErrorCode::INVALID_VALUE,
                                 "ConvolutionFpropNode: Pre-padding must be non-negative");
 
             HIPDNN_RETURN_IF_LT(postPad,
                                 0,
-                                error_code_t::INVALID_VALUE,
+                                ErrorCode::INVALID_VALUE,
                                 "ConvolutionFpropNode: Post-padding must be non-negative");
         }
 
         return {};
     }
 
-    error_t infer_properties_node() override
+    ErrorObject infer_properties_node() override
     {
         auto x = attributes.get_x();
         auto w = attributes.get_w();
         auto y = attributes.get_y();
 
         HIPDNN_RETURN_IF_FALSE(x,
-                               error_code_t::ATTRIBUTE_NOT_SET,
+                               ErrorCode::ATTRIBUTE_NOT_SET,
                                "ConvolutionFpropNode missing x for setting properties");
 
         HIPDNN_RETURN_IF_FALSE(w,
-                               error_code_t::ATTRIBUTE_NOT_SET,
+                               ErrorCode::ATTRIBUTE_NOT_SET,
                                "ConvolutionFpropNode missing w for setting properties");
 
         HIPDNN_RETURN_IF_FALSE(y,
-                               error_code_t::ATTRIBUTE_NOT_SET,
+                               ErrorCode::ATTRIBUTE_NOT_SET,
                                "ConvolutionFpropNode missing y for setting properties");
 
         HIPDNN_CHECK_ERROR(attributes.fill_from_context(graph_attributes));
@@ -261,7 +259,7 @@ public:
                 HIPDNN_RETURN_IF_TRUE(
                     spatialIdx >= prePadding.size() || spatialIdx >= postPadding.size()
                         || spatialIdx >= stride.size() || spatialIdx >= dilation.size(),
-                    error_code_t::INVALID_VALUE,
+                    ErrorCode::INVALID_VALUE,
                     "ConvolutionFpropNode: Insufficient padding/stride/dilation parameters for "
                     "spatial "
                     "dimensions");
@@ -280,22 +278,22 @@ public:
                 // Validate parameters
                 HIPDNN_RETURN_IF_LT(strideVal,
                                     1,
-                                    error_code_t::INVALID_VALUE,
+                                    ErrorCode::INVALID_VALUE,
                                     "ConvolutionFpropNode: Stride must be positive");
 
                 HIPDNN_RETURN_IF_LT(dilationVal,
                                     1,
-                                    error_code_t::INVALID_VALUE,
+                                    ErrorCode::INVALID_VALUE,
                                     "ConvolutionFpropNode: Dilation must be positive");
 
                 HIPDNN_RETURN_IF_LT(prePad,
                                     0,
-                                    error_code_t::INVALID_VALUE,
+                                    ErrorCode::INVALID_VALUE,
                                     "ConvolutionFpropNode: Pre-padding must be non-negative");
 
                 HIPDNN_RETURN_IF_LT(postPad,
                                     0,
-                                    error_code_t::INVALID_VALUE,
+                                    ErrorCode::INVALID_VALUE,
                                     "ConvolutionFpropNode: Post-padding must be non-negative");
 
                 // Calculate dilated kernel size
@@ -306,7 +304,7 @@ public:
                 HIPDNN_RETURN_IF_LT(
                     numerator,
                     0,
-                    error_code_t::INVALID_VALUE,
+                    ErrorCode::INVALID_VALUE,
                     "ConvolutionFpropNode: Invalid convolution parameters result in negative "
                     "output size");
 
@@ -325,18 +323,18 @@ public:
 
             HIPDNN_RETURN_IF_TRUE(
                 xStrides.empty(),
-                error_code_t::ATTRIBUTE_NOT_SET,
+                ErrorCode::ATTRIBUTE_NOT_SET,
                 "ConvolutionFpropNode: Cannot infer output strides - missing input strides");
 
             HIPDNN_RETURN_IF_TRUE(
                 yDimsFinal.empty(),
-                error_code_t::ATTRIBUTE_NOT_SET,
+                ErrorCode::ATTRIBUTE_NOT_SET,
                 "ConvolutionFpropNode: Cannot infer output strides - missing output dimensions");
 
             HIPDNN_RETURN_IF_NE(
                 xStrides.size(),
                 yDimsFinal.size(),
-                error_code_t::ATTRIBUTE_NOT_SET,
+                ErrorCode::ATTRIBUTE_NOT_SET,
                 "ConvolutionFpropNode: Stride dimension mismatch between input and output tensors");
 
             // All validations passed - perform stride generation

--- a/frontend/include/hipdnn_frontend/node/Node.hpp
+++ b/frontend/include/hipdnn_frontend/node/Node.hpp
@@ -25,19 +25,19 @@ public:
     }
     virtual ~INode() = default;
 
-    virtual ErrorObject pre_validate_node() const // NOLINT(readability-identifier-naming)
+    virtual Error pre_validate_node() const // NOLINT(readability-identifier-naming)
     {
         return {};
     }
-    virtual ErrorObject infer_properties_node() // NOLINT(readability-identifier-naming)
+    virtual Error infer_properties_node() // NOLINT(readability-identifier-naming)
     {
         return {};
     }
-    virtual ErrorObject post_validate_node() const // NOLINT(readability-identifier-naming)
+    virtual Error post_validate_node() const // NOLINT(readability-identifier-naming)
     {
         return {};
     }
-    virtual ErrorObject populate_hipdnn_tensor_ids( // NOLINT(readability-identifier-naming)
+    virtual Error populate_hipdnn_tensor_ids( // NOLINT(readability-identifier-naming)
         [[maybe_unused]] std::unordered_map<int64_t, std::shared_ptr<TensorAttributes>>&
             tensorLookup,
         [[maybe_unused]] int64_t& currentTensorId,
@@ -58,7 +58,7 @@ public:
 protected:
     std::vector<std::shared_ptr<INode>> _sub_nodes;
 
-    ErrorObject validateSubtree()
+    Error validateSubtree()
     {
         HIPDNN_CHECK_ERROR(pre_validate_node());
         HIPDNN_CHECK_ERROR(infer_properties_node());
@@ -79,7 +79,7 @@ protected:
         }
     }
 
-    ErrorObject populateHipdnnTensorIdsSubtree(
+    Error populateHipdnnTensorIdsSubtree(
         std::unordered_map<int64_t, std::shared_ptr<TensorAttributes>>& tensorLookup,
         int64_t& currentTensorId,
         std::unordered_set<int64_t>& usedIds)
@@ -143,7 +143,7 @@ public:
     }
 
     // NOLINT(readability-identifier-naming)
-    ErrorObject populate_hipdnn_tensor_ids(
+    Error populate_hipdnn_tensor_ids(
         std::unordered_map<int64_t, std::shared_ptr<TensorAttributes>>& tensorLookup,
         int64_t& currentTensorId,
         std::unordered_set<int64_t>& usedIds) const override

--- a/frontend/include/hipdnn_frontend/node/Node.hpp
+++ b/frontend/include/hipdnn_frontend/node/Node.hpp
@@ -25,19 +25,19 @@ public:
     }
     virtual ~INode() = default;
 
-    virtual error_t pre_validate_node() const // NOLINT(readability-identifier-naming)
+    virtual ErrorObject pre_validate_node() const // NOLINT(readability-identifier-naming)
     {
         return {};
     }
-    virtual error_t infer_properties_node() // NOLINT(readability-identifier-naming)
+    virtual ErrorObject infer_properties_node() // NOLINT(readability-identifier-naming)
     {
         return {};
     }
-    virtual error_t post_validate_node() const // NOLINT(readability-identifier-naming)
+    virtual ErrorObject post_validate_node() const // NOLINT(readability-identifier-naming)
     {
         return {};
     }
-    virtual error_t populate_hipdnn_tensor_ids( // NOLINT(readability-identifier-naming)
+    virtual ErrorObject populate_hipdnn_tensor_ids( // NOLINT(readability-identifier-naming)
         [[maybe_unused]] std::unordered_map<int64_t, std::shared_ptr<TensorAttributes>>&
             tensorLookup,
         [[maybe_unused]] int64_t& currentTensorId,
@@ -58,7 +58,7 @@ public:
 protected:
     std::vector<std::shared_ptr<INode>> _sub_nodes;
 
-    error_t validateSubtree()
+    ErrorObject validateSubtree()
     {
         HIPDNN_CHECK_ERROR(pre_validate_node());
         HIPDNN_CHECK_ERROR(infer_properties_node());
@@ -79,7 +79,7 @@ protected:
         }
     }
 
-    error_t populateHipdnnTensorIdsSubtree(
+    ErrorObject populateHipdnnTensorIdsSubtree(
         std::unordered_map<int64_t, std::shared_ptr<TensorAttributes>>& tensorLookup,
         int64_t& currentTensorId,
         std::unordered_set<int64_t>& usedIds)
@@ -143,7 +143,7 @@ public:
     }
 
     // NOLINT(readability-identifier-naming)
-    error_t populate_hipdnn_tensor_ids(
+    ErrorObject populate_hipdnn_tensor_ids(
         std::unordered_map<int64_t, std::shared_ptr<TensorAttributes>>& tensorLookup,
         int64_t& currentTensorId,
         std::unordered_set<int64_t>& usedIds) const override

--- a/frontend/include/hipdnn_frontend/node/PointwiseNode.hpp
+++ b/frontend/include/hipdnn_frontend/node/PointwiseNode.hpp
@@ -22,40 +22,38 @@ public:
     {
     }
 
-    error_t pre_validate_node() const override
+    ErrorObject pre_validate_node() const override
     {
         if(!attributes.get_input_0())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
-                    "PointwiseNode missing IN_0 for pre-validation"};
+            return {ErrorCode::ATTRIBUTE_NOT_SET, "PointwiseNode missing IN_0 for pre-validation"};
         }
         if(!attributes.get_output_0())
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
-                    "PointwiseNode missing OUT_0 for pre-validation"};
+            return {ErrorCode::ATTRIBUTE_NOT_SET, "PointwiseNode missing OUT_0 for pre-validation"};
         }
-        if(attributes.get_mode() == PointwiseMode_t::NOT_SET)
+        if(attributes.get_mode() == PointwiseMode::NOT_SET)
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "PointwiseNode missing operation for pre-validation"};
         }
 
         return {};
     }
 
-    error_t infer_properties_node() override
+    ErrorObject infer_properties_node() override
     {
         auto in0 = attributes.get_input_0();
         if(!in0)
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "PointwiseNode missing input for setting properties"};
         }
 
         auto out = attributes.get_output_0();
         if(!out)
         {
-            return {error_code_t::ATTRIBUTE_NOT_SET,
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "PointwiseNode missing output for setting properties"};
         }
 
@@ -98,7 +96,7 @@ public:
 
             if(out->get_stride().empty())
             {
-                return {error_code_t::ATTRIBUTE_NOT_SET, "PointwiseNode output missing stride"};
+                return {ErrorCode::ATTRIBUTE_NOT_SET, "PointwiseNode output missing stride"};
             }
         }
 

--- a/frontend/include/hipdnn_frontend/node/PointwiseNode.hpp
+++ b/frontend/include/hipdnn_frontend/node/PointwiseNode.hpp
@@ -22,7 +22,7 @@ public:
     {
     }
 
-    ErrorObject pre_validate_node() const override
+    Error pre_validate_node() const override
     {
         if(!attributes.get_input_0())
         {
@@ -41,7 +41,7 @@ public:
         return {};
     }
 
-    ErrorObject infer_properties_node() override
+    Error infer_properties_node() override
     {
         auto in0 = attributes.get_input_0();
         if(!in0)

--- a/frontend/tests/TestBatchnormAttributes.cpp
+++ b/frontend/tests/TestBatchnormAttributes.cpp
@@ -29,98 +29,98 @@ TEST(TestBatchnormAttributes, CreateBatchnormAttributes)
     auto xTensor = batchnormAttributes.get_x();
     xTensor->set_uid(1)
         .set_name("XTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto yTensor = batchnormAttributes.get_y();
     yTensor->set_uid(2)
         .set_name("YTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto scaleTensor = batchnormAttributes.get_scale();
     scaleTensor->set_uid(3)
         .set_name("ScaleTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto biasTensor = batchnormAttributes.get_bias();
     biasTensor->set_uid(4)
         .set_name("BiasTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto prevMeanTensor = batchnormAttributes.get_prev_running_mean();
     prevMeanTensor->set_uid(5)
         .set_name("PrevMeanTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto prevVarianceTensor = batchnormAttributes.get_prev_running_variance();
     prevVarianceTensor->set_uid(6)
         .set_name("PrevVarianceTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto momentumTensor = batchnormAttributes.get_momentum();
     momentumTensor->set_uid(7)
         .set_name("MomentumTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto meanTensor = batchnormAttributes.get_mean();
     meanTensor->set_uid(8)
         .set_name("MeanTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto invVarianceTensor = batchnormAttributes.get_inv_variance();
     invVarianceTensor->set_uid(9)
         .set_name("InvVarianceTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto nextMeanTensor = batchnormAttributes.get_next_running_mean();
     nextMeanTensor->set_uid(10)
         .set_name("NextMeanTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto nextVarianceTensor = batchnormAttributes.get_next_running_variance();
     nextVarianceTensor->set_uid(11)
         .set_name("NextVarianceTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto epsilonTensor = batchnormAttributes.get_epsilon();
     epsilonTensor->set_uid(14)
         .set_name("EpsilonTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1})
         .set_stride({1});
 
     auto peerStat1 = std::make_shared<hipdnn_frontend::graph::TensorAttributes>();
     peerStat1->set_uid(12)
         .set_name("PeerStat1")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2})
         .set_stride({3, 4});
 
     auto peerStat2 = std::make_shared<hipdnn_frontend::graph::TensorAttributes>();
     peerStat2->set_uid(13)
         .set_name("PeerStat2")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({5, 6})
         .set_stride({7, 8});
 
@@ -131,85 +131,85 @@ TEST(TestBatchnormAttributes, CreateBatchnormAttributes)
 
     EXPECT_EQ(peerStats[0]->get_uid(), 12);
     EXPECT_EQ(peerStats[0]->get_name(), "PeerStat1");
-    EXPECT_EQ(peerStats[0]->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(peerStats[0]->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(peerStats[0]->get_dim(), (std::vector<int64_t>{1, 2}));
     EXPECT_EQ(peerStats[0]->get_stride(), (std::vector<int64_t>{3, 4}));
 
     EXPECT_EQ(peerStats[1]->get_uid(), 13);
     EXPECT_EQ(peerStats[1]->get_name(), "PeerStat2");
-    EXPECT_EQ(peerStats[1]->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(peerStats[1]->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(peerStats[1]->get_dim(), (std::vector<int64_t>{5, 6}));
     EXPECT_EQ(peerStats[1]->get_stride(), (std::vector<int64_t>{7, 8}));
 
     EXPECT_EQ(xTensor->get_uid(), 1);
     EXPECT_EQ(xTensor->get_name(), "XTensor");
-    EXPECT_EQ(xTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(xTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(xTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(xTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(yTensor->get_uid(), 2);
     EXPECT_EQ(yTensor->get_name(), "YTensor");
-    EXPECT_EQ(yTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(yTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(yTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(yTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(scaleTensor->get_uid(), 3);
     EXPECT_EQ(scaleTensor->get_name(), "ScaleTensor");
-    EXPECT_EQ(scaleTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(scaleTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(scaleTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(scaleTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(biasTensor->get_uid(), 4);
     EXPECT_EQ(biasTensor->get_name(), "BiasTensor");
-    EXPECT_EQ(biasTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(biasTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(biasTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(biasTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(prevMeanTensor->get_uid(), 5);
     EXPECT_EQ(prevMeanTensor->get_name(), "PrevMeanTensor");
-    EXPECT_EQ(prevMeanTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(prevMeanTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(prevMeanTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(prevMeanTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(prevVarianceTensor->get_uid(), 6);
     EXPECT_EQ(prevVarianceTensor->get_name(), "PrevVarianceTensor");
-    EXPECT_EQ(prevVarianceTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(prevVarianceTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(prevVarianceTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(prevVarianceTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(momentumTensor->get_uid(), 7);
     EXPECT_EQ(momentumTensor->get_name(), "MomentumTensor");
-    EXPECT_EQ(momentumTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(momentumTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(momentumTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(momentumTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(meanTensor->get_uid(), 8);
     EXPECT_EQ(meanTensor->get_name(), "MeanTensor");
-    EXPECT_EQ(meanTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(meanTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(meanTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(meanTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(invVarianceTensor->get_uid(), 9);
     EXPECT_EQ(invVarianceTensor->get_name(), "InvVarianceTensor");
-    EXPECT_EQ(invVarianceTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(invVarianceTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(invVarianceTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(invVarianceTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(nextMeanTensor->get_uid(), 10);
     EXPECT_EQ(nextMeanTensor->get_name(), "NextMeanTensor");
-    EXPECT_EQ(nextMeanTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(nextMeanTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(nextMeanTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(nextMeanTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(nextVarianceTensor->get_uid(), 11);
     EXPECT_EQ(nextVarianceTensor->get_name(), "NextVarianceTensor");
-    EXPECT_EQ(nextVarianceTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(nextVarianceTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(nextVarianceTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(nextVarianceTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(epsilonTensor->get_uid(), 14);
     EXPECT_EQ(epsilonTensor->get_name(), "EpsilonTensor");
-    EXPECT_EQ(epsilonTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(epsilonTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(epsilonTensor->get_dim(), (std::vector<int64_t>{1}));
     EXPECT_EQ(epsilonTensor->get_stride(), (std::vector<int64_t>{1}));
 }

--- a/frontend/tests/TestBatchnormBackwardAttributes.cpp
+++ b/frontend/tests/TestBatchnormBackwardAttributes.cpp
@@ -20,70 +20,70 @@ TEST(TestBatchnormBackwardAttributes, CreateBatchnormBackwardAttributes)
     auto dyTensor = batchnormAttributes.get_dy();
     dyTensor->set_uid(1)
         .set_name("DyTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto xTensor = batchnormAttributes.get_x();
     xTensor->set_uid(2)
         .set_name("XTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto scaleTensor = batchnormAttributes.get_scale();
     scaleTensor->set_uid(3)
         .set_name("ScaleTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto meanTensor = batchnormAttributes.get_mean();
     meanTensor->set_uid(4)
         .set_name("MeanTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto invVarianceTensor = batchnormAttributes.get_inv_variance();
     invVarianceTensor->set_uid(5)
         .set_name("InvVarianceTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto dxTensor = batchnormAttributes.get_dx();
     dxTensor->set_uid(6)
         .set_name("DxTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto dscaleTensor = batchnormAttributes.get_dscale();
     dscaleTensor->set_uid(7)
         .set_name("DscaleTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto dbiasTensor = batchnormAttributes.get_dbias();
     dbiasTensor->set_uid(8)
         .set_name("DbiasTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto peerStat1 = std::make_shared<hipdnn_frontend::graph::TensorAttributes>();
     peerStat1->set_uid(9)
         .set_name("PeerStat1")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2})
         .set_stride({3, 4});
 
     auto peerStat2 = std::make_shared<hipdnn_frontend::graph::TensorAttributes>();
     peerStat2->set_uid(10)
         .set_name("PeerStat2")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({5, 6})
         .set_stride({7, 8});
 
@@ -91,49 +91,49 @@ TEST(TestBatchnormBackwardAttributes, CreateBatchnormBackwardAttributes)
 
     EXPECT_EQ(dyTensor->get_uid(), 1);
     EXPECT_EQ(dyTensor->get_name(), "DyTensor");
-    EXPECT_EQ(dyTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(dyTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(dyTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(dyTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(xTensor->get_uid(), 2);
     EXPECT_EQ(xTensor->get_name(), "XTensor");
-    EXPECT_EQ(xTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(xTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(xTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(xTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(scaleTensor->get_uid(), 3);
     EXPECT_EQ(scaleTensor->get_name(), "ScaleTensor");
-    EXPECT_EQ(scaleTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(scaleTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(scaleTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(scaleTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(meanTensor->get_uid(), 4);
     EXPECT_EQ(meanTensor->get_name(), "MeanTensor");
-    EXPECT_EQ(meanTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(meanTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(meanTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(meanTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(invVarianceTensor->get_uid(), 5);
     EXPECT_EQ(invVarianceTensor->get_name(), "InvVarianceTensor");
-    EXPECT_EQ(invVarianceTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(invVarianceTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(invVarianceTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(invVarianceTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(dxTensor->get_uid(), 6);
     EXPECT_EQ(dxTensor->get_name(), "DxTensor");
-    EXPECT_EQ(dxTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(dxTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(dxTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(dxTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(dscaleTensor->get_uid(), 7);
     EXPECT_EQ(dscaleTensor->get_name(), "DscaleTensor");
-    EXPECT_EQ(dscaleTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(dscaleTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(dscaleTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(dscaleTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(dbiasTensor->get_uid(), 8);
     EXPECT_EQ(dbiasTensor->get_name(), "DbiasTensor");
-    EXPECT_EQ(dbiasTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(dbiasTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(dbiasTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(dbiasTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
@@ -142,13 +142,13 @@ TEST(TestBatchnormBackwardAttributes, CreateBatchnormBackwardAttributes)
 
     EXPECT_EQ(peerStats[0]->get_uid(), 9);
     EXPECT_EQ(peerStats[0]->get_name(), "PeerStat1");
-    EXPECT_EQ(peerStats[0]->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(peerStats[0]->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(peerStats[0]->get_dim(), (std::vector<int64_t>{1, 2}));
     EXPECT_EQ(peerStats[0]->get_stride(), (std::vector<int64_t>{3, 4}));
 
     EXPECT_EQ(peerStats[1]->get_uid(), 10);
     EXPECT_EQ(peerStats[1]->get_name(), "PeerStat2");
-    EXPECT_EQ(peerStats[1]->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(peerStats[1]->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(peerStats[1]->get_dim(), (std::vector<int64_t>{5, 6}));
     EXPECT_EQ(peerStats[1]->get_stride(), (std::vector<int64_t>{7, 8}));
 }

--- a/frontend/tests/TestBatchnormBackwardNode.cpp
+++ b/frontend/tests/TestBatchnormBackwardNode.cpp
@@ -22,7 +22,7 @@ TEST(TestBatchnormBackwardNode, PreValidateNode)
     BatchnormBackwardNode node(std::move(batchnormAttributes), graphAttributes);
 
     auto error = node.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 }
 
 TEST(TestBatchnormBackwardNode, PreValidateNodeMissingValues)
@@ -33,49 +33,49 @@ TEST(TestBatchnormBackwardNode, PreValidateNodeMissingValues)
     BatchnormBackwardNode node(std::move(batchnormAttributes), graphAttributes);
 
     auto error = node.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_dy(std::make_shared<TensorAttributes>());
     auto batchnormAttributesCopy = batchnormAttributes;
     BatchnormBackwardNode nodeWithDy(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithDy.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_x(std::make_shared<TensorAttributes>());
     batchnormAttributesCopy = batchnormAttributes;
     BatchnormBackwardNode nodeWithX(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithX.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_scale(std::make_shared<TensorAttributes>());
     batchnormAttributesCopy = batchnormAttributes;
     BatchnormBackwardNode nodeWithScale(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithScale.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_dx(std::make_shared<TensorAttributes>());
     batchnormAttributesCopy = batchnormAttributes;
     BatchnormBackwardNode nodeWithDx(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithDx.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_dscale(std::make_shared<TensorAttributes>());
     batchnormAttributesCopy = batchnormAttributes;
     BatchnormBackwardNode nodeWithDscale(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithDscale.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_dbias(std::make_shared<TensorAttributes>());
     batchnormAttributesCopy = batchnormAttributes;
     BatchnormBackwardNode nodeWithAllValues(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithAllValues.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 }
 
 TEST(TestBatchnormBackwardNode, InferPropertiesNode)
@@ -93,7 +93,7 @@ TEST(TestBatchnormBackwardNode, InferPropertiesNode)
     auto xTensor = batchnormAttributes.get_x();
     xTensor->set_uid(1)
         .set_name("InputTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
@@ -110,7 +110,7 @@ TEST(TestBatchnormBackwardNode, InferPropertiesNode)
     BatchnormBackwardNode node(std::move(batchnormAttributes), graphAttributes);
 
     auto error = node.infer_properties_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 
     EXPECT_EQ(dxTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(dxTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
@@ -177,7 +177,7 @@ TEST(TestBatchnormBackwardNode, PopulateHipdnnTensorIds)
     int64_t currentTensorId = 1;
 
     auto error = node.populate_hipdnn_tensor_ids(tensorLookup, currentTensorId, usedIds);
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 
     // Collect all tensor attributes from input map, output map, and peer_stats vector
     std::vector<std::shared_ptr<TensorAttributes>> tensors;
@@ -221,7 +221,7 @@ TEST(TestBatchnormBackwardNode, PackNode)
     auto dyTensor = std::make_shared<TensorAttributes>();
     dyTensor->set_uid(1)
         .set_name("DyTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({4, 3, 2, 1});
     batchnormAttributes.set_dy(dyTensor);
@@ -229,7 +229,7 @@ TEST(TestBatchnormBackwardNode, PackNode)
     auto xTensor = std::make_shared<TensorAttributes>();
     xTensor->set_uid(2)
         .set_name("XTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({4, 3, 2, 1});
     batchnormAttributes.set_x(xTensor);
@@ -237,7 +237,7 @@ TEST(TestBatchnormBackwardNode, PackNode)
     auto scaleTensor = std::make_shared<TensorAttributes>();
     scaleTensor->set_uid(3)
         .set_name("ScaleTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_scale(scaleTensor);
@@ -245,7 +245,7 @@ TEST(TestBatchnormBackwardNode, PackNode)
     auto meanTensor = std::make_shared<TensorAttributes>();
     meanTensor->set_uid(4)
         .set_name("MeanTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_mean(meanTensor);
@@ -253,7 +253,7 @@ TEST(TestBatchnormBackwardNode, PackNode)
     auto invVarianceTensor = std::make_shared<TensorAttributes>();
     invVarianceTensor->set_uid(5)
         .set_name("InvVarianceTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_inv_variance(invVarianceTensor);
@@ -261,7 +261,7 @@ TEST(TestBatchnormBackwardNode, PackNode)
     auto dxTensor = std::make_shared<TensorAttributes>();
     dxTensor->set_uid(6)
         .set_name("DxTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({4, 3, 2, 1});
     batchnormAttributes.set_dx(dxTensor);
@@ -269,7 +269,7 @@ TEST(TestBatchnormBackwardNode, PackNode)
     auto dscaleTensor = std::make_shared<TensorAttributes>();
     dscaleTensor->set_uid(7)
         .set_name("DscaleTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_dscale(dscaleTensor);
@@ -277,7 +277,7 @@ TEST(TestBatchnormBackwardNode, PackNode)
     auto dbiasTensor = std::make_shared<TensorAttributes>();
     dbiasTensor->set_uid(8)
         .set_name("DbiasTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_dbias(dbiasTensor);
@@ -320,7 +320,7 @@ TEST(TestBatchnormBackwardNode, PackNodeWithoutMeanAndInvVariance)
     auto dyTensor = std::make_shared<TensorAttributes>();
     dyTensor->set_uid(1)
         .set_name("DyTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({4, 3, 2, 1});
     batchnormAttributes.set_dy(dyTensor);
@@ -328,7 +328,7 @@ TEST(TestBatchnormBackwardNode, PackNodeWithoutMeanAndInvVariance)
     auto xTensor = std::make_shared<TensorAttributes>();
     xTensor->set_uid(2)
         .set_name("XTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({4, 3, 2, 1});
     batchnormAttributes.set_x(xTensor);
@@ -336,7 +336,7 @@ TEST(TestBatchnormBackwardNode, PackNodeWithoutMeanAndInvVariance)
     auto scaleTensor = std::make_shared<TensorAttributes>();
     scaleTensor->set_uid(3)
         .set_name("ScaleTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_scale(scaleTensor);
@@ -344,7 +344,7 @@ TEST(TestBatchnormBackwardNode, PackNodeWithoutMeanAndInvVariance)
     auto dxTensor = std::make_shared<TensorAttributes>();
     dxTensor->set_uid(4)
         .set_name("DxTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({4, 3, 2, 1});
     batchnormAttributes.set_dx(dxTensor);
@@ -352,7 +352,7 @@ TEST(TestBatchnormBackwardNode, PackNodeWithoutMeanAndInvVariance)
     auto dscaleTensor = std::make_shared<TensorAttributes>();
     dscaleTensor->set_uid(5)
         .set_name("DscaleTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_dscale(dscaleTensor);
@@ -360,7 +360,7 @@ TEST(TestBatchnormBackwardNode, PackNodeWithoutMeanAndInvVariance)
     auto dbiasTensor = std::make_shared<TensorAttributes>();
     dbiasTensor->set_uid(6)
         .set_name("DbiasTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_dbias(dbiasTensor);

--- a/frontend/tests/TestBatchnormInferenceAttributes.cpp
+++ b/frontend/tests/TestBatchnormInferenceAttributes.cpp
@@ -18,78 +18,78 @@ TEST(TestBatchnormInferenceAttributes, CreateBatchnormInferenceAttributes)
     auto inputTensor = batchnormAttributes.get_x();
     inputTensor->set_uid(1)
         .set_name("InputTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto outputTensor = batchnormAttributes.get_y();
     outputTensor->set_uid(2)
         .set_name("OutputTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto meanTensor = batchnormAttributes.get_mean();
     meanTensor->set_uid(3)
         .set_name("MeanTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto varianceTensor = batchnormAttributes.get_inv_variance();
     varianceTensor->set_uid(4)
         .set_name("VarianceTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto scaleTensor = batchnormAttributes.get_scale();
     scaleTensor->set_uid(5)
         .set_name("ScaleTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto biasTensor = batchnormAttributes.get_bias();
     biasTensor->set_uid(6)
         .set_name("BiasTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     EXPECT_EQ(inputTensor->get_uid(), 1);
     EXPECT_EQ(inputTensor->get_name(), "InputTensor");
-    EXPECT_EQ(inputTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(inputTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(inputTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(inputTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(outputTensor->get_uid(), 2);
     EXPECT_EQ(outputTensor->get_name(), "OutputTensor");
-    EXPECT_EQ(outputTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(outputTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(outputTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(outputTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(meanTensor->get_uid(), 3);
     EXPECT_EQ(meanTensor->get_name(), "MeanTensor");
-    EXPECT_EQ(meanTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(meanTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(meanTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(meanTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(varianceTensor->get_uid(), 4);
     EXPECT_EQ(varianceTensor->get_name(), "VarianceTensor");
-    EXPECT_EQ(varianceTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(varianceTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(varianceTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(varianceTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(scaleTensor->get_uid(), 5);
     EXPECT_EQ(scaleTensor->get_name(), "ScaleTensor");
-    EXPECT_EQ(scaleTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(scaleTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(scaleTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(scaleTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(biasTensor->get_uid(), 6);
     EXPECT_EQ(biasTensor->get_name(), "BiasTensor");
-    EXPECT_EQ(biasTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(biasTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(biasTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(biasTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 }

--- a/frontend/tests/TestBatchnormInferenceNode.cpp
+++ b/frontend/tests/TestBatchnormInferenceNode.cpp
@@ -19,7 +19,7 @@ TEST(TestBatchnormInferenceNode, BatchnormInferenceNodeProperties)
     auto inputTensor = batchnormAttributes.get_x();
     inputTensor->set_uid(1)
         .set_name("InputTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
@@ -30,7 +30,7 @@ TEST(TestBatchnormInferenceNode, BatchnormInferenceNodeProperties)
     BatchnormInferenceNode node(std::move(batchnormAttributes), graphAttributes);
     auto error = node.infer_properties_node();
 
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
     EXPECT_EQ(outputTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(outputTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 }
@@ -47,7 +47,7 @@ TEST(TestBatchnormInferenceNode, PreValidateNode)
     BatchnormInferenceNode node(std::move(batchnormAttributes), graphAttributes);
 
     auto error = node.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 }
 
 TEST(TestBatchnormInferenceNode, PreValidateNodeMissingValues)
@@ -58,35 +58,35 @@ TEST(TestBatchnormInferenceNode, PreValidateNodeMissingValues)
     BatchnormInferenceNode node(std::move(batchnormAttributes), graphAttributes);
 
     auto error = node.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_x(std::make_shared<TensorAttributes>());
     auto batchnormAttributesCopy = batchnormAttributes;
     BatchnormInferenceNode nodeWithX(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithX.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_y(std::make_shared<TensorAttributes>());
     batchnormAttributesCopy = batchnormAttributes;
     BatchnormInferenceNode nodeWithY(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithY.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_scale(std::make_shared<TensorAttributes>());
     batchnormAttributesCopy = batchnormAttributes;
     BatchnormInferenceNode nodeWithScale(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithScale.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_bias(std::make_shared<TensorAttributes>());
     batchnormAttributesCopy = batchnormAttributes;
     BatchnormInferenceNode nodeWithAllValues(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithAllValues.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 }
 
 TEST(TestBatchnormInferenceNode, InferPropertiesNode)
@@ -102,7 +102,7 @@ TEST(TestBatchnormInferenceNode, InferPropertiesNode)
     auto inputTensor = batchnormAttributes.get_x();
     inputTensor->set_uid(1)
         .set_name("InputTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
@@ -113,7 +113,7 @@ TEST(TestBatchnormInferenceNode, InferPropertiesNode)
     BatchnormInferenceNode node(std::move(batchnormAttributes), graphAttributes);
 
     auto error = node.infer_properties_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 
     EXPECT_EQ(outputTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(outputTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
@@ -127,7 +127,7 @@ TEST(TestBatchnormInferenceNode, PackNode)
     auto xTensor = std::make_shared<TensorAttributes>();
     xTensor->set_uid(1)
         .set_name("XTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({4, 3, 2, 1});
     batchnormAttributes.set_x(xTensor);
@@ -135,7 +135,7 @@ TEST(TestBatchnormInferenceNode, PackNode)
     auto yTensor = std::make_shared<TensorAttributes>();
     yTensor->set_uid(2)
         .set_name("YTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({4, 3, 2, 1});
     batchnormAttributes.set_y(yTensor);
@@ -143,7 +143,7 @@ TEST(TestBatchnormInferenceNode, PackNode)
     auto meanTensor = std::make_shared<TensorAttributes>();
     meanTensor->set_uid(3)
         .set_name("MeanTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_mean(meanTensor);
@@ -151,7 +151,7 @@ TEST(TestBatchnormInferenceNode, PackNode)
     auto invVarianceTensor = std::make_shared<TensorAttributes>();
     invVarianceTensor->set_uid(4)
         .set_name("InvVarianceTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_inv_variance(invVarianceTensor);
@@ -159,7 +159,7 @@ TEST(TestBatchnormInferenceNode, PackNode)
     auto scaleTensor = std::make_shared<TensorAttributes>();
     scaleTensor->set_uid(5)
         .set_name("ScaleTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_scale(scaleTensor);
@@ -167,7 +167,7 @@ TEST(TestBatchnormInferenceNode, PackNode)
     auto biasTensor = std::make_shared<TensorAttributes>();
     biasTensor->set_uid(6)
         .set_name("BiasTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_bias(biasTensor);
@@ -206,7 +206,7 @@ TEST(TestBatchnormInferenceNode, PackNodeWithoutMeanAndInvVariance)
     auto xTensor = std::make_shared<TensorAttributes>();
     xTensor->set_uid(1)
         .set_name("XTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({4, 3, 2, 1});
     batchnormAttributes.set_x(xTensor);
@@ -214,7 +214,7 @@ TEST(TestBatchnormInferenceNode, PackNodeWithoutMeanAndInvVariance)
     auto yTensor = std::make_shared<TensorAttributes>();
     yTensor->set_uid(2)
         .set_name("YTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({4, 3, 2, 1});
     batchnormAttributes.set_y(yTensor);
@@ -222,7 +222,7 @@ TEST(TestBatchnormInferenceNode, PackNodeWithoutMeanAndInvVariance)
     auto scaleTensor = std::make_shared<TensorAttributes>();
     scaleTensor->set_uid(3)
         .set_name("ScaleTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_scale(scaleTensor);
@@ -230,7 +230,7 @@ TEST(TestBatchnormInferenceNode, PackNodeWithoutMeanAndInvVariance)
     auto biasTensor = std::make_shared<TensorAttributes>();
     biasTensor->set_uid(4)
         .set_name("BiasTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_bias(biasTensor);

--- a/frontend/tests/TestBatchnormNode.cpp
+++ b/frontend/tests/TestBatchnormNode.cpp
@@ -21,7 +21,7 @@ TEST(TestBatchnormNode, PreValidateNode)
     BatchnormNode node(std::move(batchnormAttributes), graphAttributes);
 
     auto error = node.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 }
 
 TEST(TestBatchnormNode, PreValidateNodeMissingValues)
@@ -32,42 +32,42 @@ TEST(TestBatchnormNode, PreValidateNodeMissingValues)
     BatchnormNode node(std::move(batchnormAttributes), graphAttributes);
 
     auto error = node.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_x(std::make_shared<TensorAttributes>());
     auto batchnormAttributesCopy = batchnormAttributes;
     BatchnormNode nodeWithX(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithX.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_y(std::make_shared<TensorAttributes>());
     batchnormAttributesCopy = batchnormAttributes;
     BatchnormNode nodeWithY(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithY.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_scale(std::make_shared<TensorAttributes>());
     batchnormAttributesCopy = batchnormAttributes;
     BatchnormNode nodeWithScale(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithScale.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_bias(std::make_shared<TensorAttributes>());
     batchnormAttributesCopy = batchnormAttributes;
     BatchnormNode nodeWithBias(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithBias.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_epsilon(std::make_shared<TensorAttributes>());
     batchnormAttributesCopy = batchnormAttributes;
     BatchnormNode nodeWithAllValues(std::move(batchnormAttributesCopy), graphAttributes);
 
     error = nodeWithAllValues.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 }
 
 TEST(TestBatchnormNode, InferPropertiesNode)
@@ -82,7 +82,7 @@ TEST(TestBatchnormNode, InferPropertiesNode)
     auto inputTensor = batchnormAttributes.get_x();
     inputTensor->set_uid(1)
         .set_name("InputTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
@@ -93,7 +93,7 @@ TEST(TestBatchnormNode, InferPropertiesNode)
     BatchnormNode node(std::move(batchnormAttributes), graphAttributes);
 
     auto error = node.infer_properties_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 
     EXPECT_EQ(outputTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(outputTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
@@ -117,7 +117,7 @@ TEST(TestBatchnormNode, InferPropertiesNodeWithStats)
     auto inputTensor = batchnormAttributes.get_x();
     inputTensor->set_uid(1)
         .set_name("InputTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
@@ -140,7 +140,7 @@ TEST(TestBatchnormNode, InferPropertiesNodeWithStats)
     BatchnormNode node(std::move(batchnormAttributes), graphAttributes);
 
     auto error = node.infer_properties_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 
     EXPECT_EQ(outputTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(outputTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
@@ -159,7 +159,7 @@ TEST(TestBatchnormNode, PackNode)
     auto xTensor = std::make_shared<TensorAttributes>();
     xTensor->set_uid(1)
         .set_name("XTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({4, 3, 2, 1});
     batchnormAttributes.set_x(xTensor);
@@ -167,7 +167,7 @@ TEST(TestBatchnormNode, PackNode)
     auto yTensor = std::make_shared<TensorAttributes>();
     yTensor->set_uid(2)
         .set_name("YTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({4, 3, 2, 1});
     batchnormAttributes.set_y(yTensor);
@@ -175,7 +175,7 @@ TEST(TestBatchnormNode, PackNode)
     auto scaleTensor = std::make_shared<TensorAttributes>();
     scaleTensor->set_uid(3)
         .set_name("ScaleTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_scale(scaleTensor);
@@ -183,7 +183,7 @@ TEST(TestBatchnormNode, PackNode)
     auto biasTensor = std::make_shared<TensorAttributes>();
     biasTensor->set_uid(4)
         .set_name("BiasTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 1, 1})
         .set_stride({2, 1, 1, 1});
     batchnormAttributes.set_bias(biasTensor);
@@ -191,7 +191,7 @@ TEST(TestBatchnormNode, PackNode)
     auto epsilonTensor = std::make_shared<TensorAttributes>();
     epsilonTensor->set_uid(5)
         .set_name("EpsilonTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1})
         .set_stride({1});
     batchnormAttributes.set_epsilon(epsilonTensor);
@@ -289,7 +289,7 @@ TEST(TestBatchnormNode, PopulateHipdnnTensorIds)
     int64_t currentTensorId = 1;
 
     auto error = node.populate_hipdnn_tensor_ids(tensorLookup, currentTensorId, usedIds);
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 
     std::vector<std::shared_ptr<TensorAttributes>> tensors;
     tensors.reserve(node.attributes.inputs.size() + node.attributes.outputs.size()

--- a/frontend/tests/TestConvolutionFwdAttributes.cpp
+++ b/frontend/tests/TestConvolutionFwdAttributes.cpp
@@ -17,13 +17,13 @@ TEST(TestConvolutionFwdAttributes, CreateConvolutionFwdAttributes)
     convAttributes.set_post_padding({1, 1});
     convAttributes.set_stride({1, 1});
     convAttributes.set_dilation({1, 1});
-    convAttributes.set_convolution_mode(hipdnn_frontend::ConvolutionMode_t::CROSS_CORRELATION);
+    convAttributes.set_convolution_mode(hipdnn_frontend::ConvolutionMode::CROSS_CORRELATION);
 
     // Configure input tensor
     auto xTensor = convAttributes.get_x();
     xTensor->set_uid(1)
         .set_name("InputTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 3, 32, 32}) // NCHW format
         .set_stride({3072, 1024, 32, 1});
 
@@ -31,7 +31,7 @@ TEST(TestConvolutionFwdAttributes, CreateConvolutionFwdAttributes)
     auto wTensor = convAttributes.get_w();
     wTensor->set_uid(2)
         .set_name("WeightsTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({64, 3, 3, 3}) // KCHW format
         .set_stride({27, 9, 3, 1});
 
@@ -39,26 +39,26 @@ TEST(TestConvolutionFwdAttributes, CreateConvolutionFwdAttributes)
     auto yTensor = convAttributes.get_y();
     yTensor->set_uid(3)
         .set_name("OutputTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 64, 32, 32}) // NCHW format
         .set_stride({65536, 1024, 32, 1});
 
     // Verify tensor attributes
     EXPECT_EQ(xTensor->get_uid(), 1);
     EXPECT_EQ(xTensor->get_name(), "InputTensor");
-    EXPECT_EQ(xTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(xTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(xTensor->get_dim(), (std::vector<int64_t>{1, 3, 32, 32}));
     EXPECT_EQ(xTensor->get_stride(), (std::vector<int64_t>{3072, 1024, 32, 1}));
 
     EXPECT_EQ(wTensor->get_uid(), 2);
     EXPECT_EQ(wTensor->get_name(), "WeightsTensor");
-    EXPECT_EQ(wTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(wTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(wTensor->get_dim(), (std::vector<int64_t>{64, 3, 3, 3}));
     EXPECT_EQ(wTensor->get_stride(), (std::vector<int64_t>{27, 9, 3, 1}));
 
     EXPECT_EQ(yTensor->get_uid(), 3);
     EXPECT_EQ(yTensor->get_name(), "OutputTensor");
-    EXPECT_EQ(yTensor->get_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(yTensor->get_data_type(), hipdnn_frontend::DataType::FLOAT);
     EXPECT_EQ(yTensor->get_dim(), (std::vector<int64_t>{1, 64, 32, 32}));
     EXPECT_EQ(yTensor->get_stride(), (std::vector<int64_t>{65536, 1024, 32, 1}));
 
@@ -68,7 +68,7 @@ TEST(TestConvolutionFwdAttributes, CreateConvolutionFwdAttributes)
     EXPECT_EQ(convAttributes.get_stride(), (std::vector<int64_t>{1, 1}));
     EXPECT_EQ(convAttributes.get_dilation(), (std::vector<int64_t>{1, 1}));
     EXPECT_EQ(convAttributes.get_convolution_mode(),
-              hipdnn_frontend::ConvolutionMode_t::CROSS_CORRELATION);
+              hipdnn_frontend::ConvolutionMode::CROSS_CORRELATION);
 }
 
 TEST(TestConvolutionFwdAttributes, PackAttributes)
@@ -93,7 +93,7 @@ TEST(TestConvolutionFwdAttributes, PackAttributes)
     convAttributes.set_post_padding({2, 2});
     convAttributes.set_stride({2, 2});
     convAttributes.set_dilation({1, 1});
-    convAttributes.set_convolution_mode(hipdnn_frontend::ConvolutionMode_t::CROSS_CORRELATION);
+    convAttributes.set_convolution_mode(hipdnn_frontend::ConvolutionMode::CROSS_CORRELATION);
 
     // Pack attributes
     flatbuffers::FlatBufferBuilder builder;
@@ -135,7 +135,7 @@ TEST(TestConvolutionFwdAttributes, DefaultValues)
 
     // Check default convolution mode
     EXPECT_EQ(convAttributes.get_convolution_mode(),
-              hipdnn_frontend::ConvolutionMode_t::CROSS_CORRELATION);
+              hipdnn_frontend::ConvolutionMode::CROSS_CORRELATION);
 
     // Check that parameters are empty by default
     EXPECT_TRUE(convAttributes.get_pre_padding().empty());
@@ -208,7 +208,7 @@ TEST(TestConvolutionFwdAttributes, SetXMove)
     auto xTensor = std::make_shared<hipdnn_frontend::graph::TensorAttributes>();
     xTensor->set_uid(10)
         .set_name("MovedInputTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_dim({1, 3, 224, 224})
         .set_stride({150528, 50176, 224, 1});
 
@@ -232,7 +232,7 @@ TEST(TestConvolutionFwdAttributes, SetWMove)
     auto wTensor = std::make_shared<hipdnn_frontend::graph::TensorAttributes>();
     wTensor->set_uid(20)
         .set_name("MovedWeightTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::HALF)
+        .set_data_type(hipdnn_frontend::DataType::HALF)
         .set_dim({128, 64, 5, 5})
         .set_stride({1600, 25, 5, 1});
 
@@ -256,7 +256,7 @@ TEST(TestConvolutionFwdAttributes, SetYWithMove)
     auto yTensor = std::make_shared<hipdnn_frontend::graph::TensorAttributes>();
     yTensor->set_uid(30)
         .set_name("MovedOutputTensor")
-        .set_data_type(hipdnn_frontend::DataType_t::BFLOAT16)
+        .set_data_type(hipdnn_frontend::DataType::BFLOAT16)
         .set_dim({1, 128, 112, 112})
         .set_stride({1605632, 12544, 112, 1});
 

--- a/frontend/tests/TestError.cpp
+++ b/frontend/tests/TestError.cpp
@@ -6,8 +6,8 @@
 
 TEST(TestError, DefaultConstructor)
 {
-    hipdnn_frontend::error_t error;
-    EXPECT_EQ(error.get_code(), hipdnn_frontend::error_code_t::OK);
+    hipdnn_frontend::ErrorObject error;
+    EXPECT_EQ(error.get_code(), hipdnn_frontend::ErrorCode::OK);
     EXPECT_TRUE(error.is_good());
     EXPECT_FALSE(error.is_bad());
     EXPECT_EQ(error.get_message(), "");
@@ -15,9 +15,9 @@ TEST(TestError, DefaultConstructor)
 
 TEST(TestError, ParameterizedConstructor)
 {
-    hipdnn_frontend::error_t error(hipdnn_frontend::error_code_t::INVALID_VALUE,
-                                   "Invalid value provided");
-    EXPECT_EQ(error.get_code(), hipdnn_frontend::error_code_t::INVALID_VALUE);
+    hipdnn_frontend::ErrorObject error(hipdnn_frontend::ErrorCode::INVALID_VALUE,
+                                       "Invalid value provided");
+    EXPECT_EQ(error.get_code(), hipdnn_frontend::ErrorCode::INVALID_VALUE);
     EXPECT_FALSE(error.is_good());
     EXPECT_TRUE(error.is_bad());
     EXPECT_EQ(error.get_message(), "Invalid value provided");
@@ -25,9 +25,9 @@ TEST(TestError, ParameterizedConstructor)
 
 TEST(TestError, EqualityOperators)
 {
-    hipdnn_frontend::error_t error1(hipdnn_frontend::error_code_t::INVALID_VALUE, "Error 1");
-    hipdnn_frontend::error_t error2(hipdnn_frontend::error_code_t::INVALID_VALUE, "Error 2");
-    hipdnn_frontend::error_t error3(hipdnn_frontend::error_code_t::ATTRIBUTE_NOT_SET, "Error 3");
+    hipdnn_frontend::ErrorObject error1(hipdnn_frontend::ErrorCode::INVALID_VALUE, "Error 1");
+    hipdnn_frontend::ErrorObject error2(hipdnn_frontend::ErrorCode::INVALID_VALUE, "Error 2");
+    hipdnn_frontend::ErrorObject error3(hipdnn_frontend::ErrorCode::ATTRIBUTE_NOT_SET, "Error 3");
 
     EXPECT_TRUE(error1 == error2);
     EXPECT_FALSE(error1 == error3);
@@ -37,32 +37,32 @@ TEST(TestError, EqualityOperators)
 
 TEST(TestError, CodeEqualityOperators)
 {
-    hipdnn_frontend::error_t error(hipdnn_frontend::error_code_t::INVALID_VALUE,
-                                   "Invalid value provided");
+    hipdnn_frontend::ErrorObject error(hipdnn_frontend::ErrorCode::INVALID_VALUE,
+                                       "Invalid value provided");
 
-    EXPECT_TRUE(error == hipdnn_frontend::error_code_t::INVALID_VALUE);
-    EXPECT_FALSE(error == hipdnn_frontend::error_code_t::ATTRIBUTE_NOT_SET);
-    EXPECT_TRUE(error != hipdnn_frontend::error_code_t::ATTRIBUTE_NOT_SET);
-    EXPECT_FALSE(error != hipdnn_frontend::error_code_t::INVALID_VALUE);
+    EXPECT_TRUE(error == hipdnn_frontend::ErrorCode::INVALID_VALUE);
+    EXPECT_FALSE(error == hipdnn_frontend::ErrorCode::ATTRIBUTE_NOT_SET);
+    EXPECT_TRUE(error != hipdnn_frontend::ErrorCode::ATTRIBUTE_NOT_SET);
+    EXPECT_FALSE(error != hipdnn_frontend::ErrorCode::INVALID_VALUE);
 }
 
 TEST(TestError, CheckHipdnnErrorMacro)
 {
-    auto successFunction = []() -> hipdnn_frontend::error_t {
-        return {hipdnn_frontend::error_code_t::OK, "Success"};
+    auto successFunction = []() -> hipdnn_frontend::ErrorObject {
+        return {hipdnn_frontend::ErrorCode::OK, "Success"};
     };
 
-    auto failureFunction = []() -> hipdnn_frontend::error_t {
-        return {hipdnn_frontend::error_code_t::INVALID_VALUE, "Failure"};
+    auto failureFunction = []() -> hipdnn_frontend::ErrorObject {
+        return {hipdnn_frontend::ErrorCode::INVALID_VALUE, "Failure"};
     };
 
-    auto testFunction = [&]() -> hipdnn_frontend::error_t {
+    auto testFunction = [&]() -> hipdnn_frontend::ErrorObject {
         HIPDNN_CHECK_ERROR(successFunction());
         HIPDNN_CHECK_ERROR(failureFunction());
-        return {hipdnn_frontend::error_code_t::OK, "Should not reach here"};
+        return {hipdnn_frontend::ErrorCode::OK, "Should not reach here"};
     };
 
-    hipdnn_frontend::error_t result = testFunction();
-    EXPECT_EQ(result.get_code(), hipdnn_frontend::error_code_t::INVALID_VALUE);
+    hipdnn_frontend::ErrorObject result = testFunction();
+    EXPECT_EQ(result.get_code(), hipdnn_frontend::ErrorCode::INVALID_VALUE);
     EXPECT_EQ(result.get_message(), "Failure");
 }

--- a/frontend/tests/TestError.cpp
+++ b/frontend/tests/TestError.cpp
@@ -6,7 +6,7 @@
 
 TEST(TestError, DefaultConstructor)
 {
-    hipdnn_frontend::ErrorObject error;
+    hipdnn_frontend::Error error;
     EXPECT_EQ(error.get_code(), hipdnn_frontend::ErrorCode::OK);
     EXPECT_TRUE(error.is_good());
     EXPECT_FALSE(error.is_bad());
@@ -15,8 +15,8 @@ TEST(TestError, DefaultConstructor)
 
 TEST(TestError, ParameterizedConstructor)
 {
-    hipdnn_frontend::ErrorObject error(hipdnn_frontend::ErrorCode::INVALID_VALUE,
-                                       "Invalid value provided");
+    hipdnn_frontend::Error error(hipdnn_frontend::ErrorCode::INVALID_VALUE,
+                                 "Invalid value provided");
     EXPECT_EQ(error.get_code(), hipdnn_frontend::ErrorCode::INVALID_VALUE);
     EXPECT_FALSE(error.is_good());
     EXPECT_TRUE(error.is_bad());
@@ -25,9 +25,9 @@ TEST(TestError, ParameterizedConstructor)
 
 TEST(TestError, EqualityOperators)
 {
-    hipdnn_frontend::ErrorObject error1(hipdnn_frontend::ErrorCode::INVALID_VALUE, "Error 1");
-    hipdnn_frontend::ErrorObject error2(hipdnn_frontend::ErrorCode::INVALID_VALUE, "Error 2");
-    hipdnn_frontend::ErrorObject error3(hipdnn_frontend::ErrorCode::ATTRIBUTE_NOT_SET, "Error 3");
+    hipdnn_frontend::Error error1(hipdnn_frontend::ErrorCode::INVALID_VALUE, "Error 1");
+    hipdnn_frontend::Error error2(hipdnn_frontend::ErrorCode::INVALID_VALUE, "Error 2");
+    hipdnn_frontend::Error error3(hipdnn_frontend::ErrorCode::ATTRIBUTE_NOT_SET, "Error 3");
 
     EXPECT_TRUE(error1 == error2);
     EXPECT_FALSE(error1 == error3);
@@ -37,8 +37,8 @@ TEST(TestError, EqualityOperators)
 
 TEST(TestError, CodeEqualityOperators)
 {
-    hipdnn_frontend::ErrorObject error(hipdnn_frontend::ErrorCode::INVALID_VALUE,
-                                       "Invalid value provided");
+    hipdnn_frontend::Error error(hipdnn_frontend::ErrorCode::INVALID_VALUE,
+                                 "Invalid value provided");
 
     EXPECT_TRUE(error == hipdnn_frontend::ErrorCode::INVALID_VALUE);
     EXPECT_FALSE(error == hipdnn_frontend::ErrorCode::ATTRIBUTE_NOT_SET);
@@ -48,21 +48,20 @@ TEST(TestError, CodeEqualityOperators)
 
 TEST(TestError, CheckHipdnnErrorMacro)
 {
-    auto successFunction = []() -> hipdnn_frontend::ErrorObject {
-        return {hipdnn_frontend::ErrorCode::OK, "Success"};
-    };
+    auto successFunction
+        = []() -> hipdnn_frontend::Error { return {hipdnn_frontend::ErrorCode::OK, "Success"}; };
 
-    auto failureFunction = []() -> hipdnn_frontend::ErrorObject {
+    auto failureFunction = []() -> hipdnn_frontend::Error {
         return {hipdnn_frontend::ErrorCode::INVALID_VALUE, "Failure"};
     };
 
-    auto testFunction = [&]() -> hipdnn_frontend::ErrorObject {
+    auto testFunction = [&]() -> hipdnn_frontend::Error {
         HIPDNN_CHECK_ERROR(successFunction());
         HIPDNN_CHECK_ERROR(failureFunction());
         return {hipdnn_frontend::ErrorCode::OK, "Should not reach here"};
     };
 
-    hipdnn_frontend::ErrorObject result = testFunction();
+    hipdnn_frontend::Error result = testFunction();
     EXPECT_EQ(result.get_code(), hipdnn_frontend::ErrorCode::INVALID_VALUE);
     EXPECT_EQ(result.get_message(), "Failure");
 }

--- a/frontend/tests/TestGraph.cpp
+++ b/frontend/tests/TestGraph.cpp
@@ -51,28 +51,28 @@ protected:
     static std::shared_ptr<TensorAttributes> createBasicBatchnormGraph(Graph& graph)
     {
         graph.set_name("SerializedGraphTest")
-            .set_compute_data_type(DataType_t::FLOAT)
-            .set_intermediate_data_type(DataType_t::HALF)
-            .set_io_data_type(DataType_t::FLOAT);
+            .set_compute_data_type(DataType::FLOAT)
+            .set_intermediate_data_type(DataType::HALF)
+            .set_io_data_type(DataType::FLOAT);
 
         auto x = std::make_shared<TensorAttributes>();
         x->set_uid(1)
             .set_name("X")
             .set_dim({1, 2, 3, 4})
             .set_stride({5, 6, 7, 8})
-            .set_data_type(DataType_t::FLOAT);
+            .set_data_type(DataType::FLOAT);
 
         auto mean = std::make_shared<TensorAttributes>();
-        mean->set_uid(2).set_name("Mean").set_data_type(DataType_t::FLOAT);
+        mean->set_uid(2).set_name("Mean").set_data_type(DataType::FLOAT);
 
         auto invVariance = std::make_shared<TensorAttributes>();
-        invVariance->set_uid(3).set_name("InvVariance").set_data_type(DataType_t::FLOAT);
+        invVariance->set_uid(3).set_name("InvVariance").set_data_type(DataType::FLOAT);
 
         auto scale = std::make_shared<TensorAttributes>();
-        scale->set_uid(4).set_name("Scale").set_data_type(DataType_t::FLOAT);
+        scale->set_uid(4).set_name("Scale").set_data_type(DataType::FLOAT);
 
         auto bias = std::make_shared<TensorAttributes>();
-        bias->set_uid(5).set_name("Bias").set_data_type(DataType_t::FLOAT);
+        bias->set_uid(5).set_name("Bias").set_data_type(DataType::FLOAT);
 
         BatchnormInferenceAttributes batchnormAttributes;
         batchnormAttributes.set_name("BatchnormNode");
@@ -86,14 +86,14 @@ TEST_F(TestGraph, SetAndGetAttributes)
     Graph graph;
 
     graph.set_name("TestGraph")
-        .set_compute_data_type(DataType_t::FLOAT)
-        .set_intermediate_data_type(DataType_t::HALF)
-        .set_io_data_type(DataType_t::FLOAT);
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::FLOAT);
 
     EXPECT_EQ(graph.get_name(), "TestGraph");
-    EXPECT_EQ(graph.get_compute_data_type(), DataType_t::FLOAT);
-    EXPECT_EQ(graph.get_intermediate_data_type(), DataType_t::HALF);
-    EXPECT_EQ(graph.get_io_data_type(), DataType_t::FLOAT);
+    EXPECT_EQ(graph.get_compute_data_type(), DataType::FLOAT);
+    EXPECT_EQ(graph.get_intermediate_data_type(), DataType::HALF);
+    EXPECT_EQ(graph.get_io_data_type(), DataType::FLOAT);
 
     auto validationResult = graph.validate();
     EXPECT_TRUE(validationResult.is_good()) << validationResult.get_message();
@@ -104,7 +104,7 @@ TEST_F(TestGraph, BatchnormNodeCreation)
     Graph graph;
 
     auto x = std::make_shared<TensorAttributes>();
-    x->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType_t::FLOAT);
+    x->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
 
     auto scale = std::make_shared<TensorAttributes>();
     auto bias = std::make_shared<TensorAttributes>();
@@ -140,8 +140,8 @@ TEST_F(TestGraph, BatchnormBackwardNodeCreation)
     auto x = std::make_shared<TensorAttributes>();
     auto scale = std::make_shared<TensorAttributes>();
 
-    dy->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType_t::FLOAT);
-    x->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType_t::FLOAT);
+    dy->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
+    x->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
 
     BatchnormBackwardAttributes attributes;
     attributes.set_name("BatchnormBackwardNode");
@@ -166,7 +166,7 @@ TEST_F(TestGraph, BatchnormInferenceNodeCreation)
     Graph graph;
 
     auto x = std::make_shared<TensorAttributes>();
-    x->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType_t::FLOAT);
+    x->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
 
     auto mean = std::make_shared<TensorAttributes>();
     auto invVariance = std::make_shared<TensorAttributes>();
@@ -190,11 +190,11 @@ TEST_F(TestGraph, PointwiseNodeCreationSingleInput)
     Graph graph;
 
     auto in0 = std::make_shared<TensorAttributes>();
-    in0->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType_t::FLOAT);
+    in0->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
 
     PointwiseAttributes attributes;
     attributes.set_name("PointwiseNode");
-    attributes.set_mode(PointwiseMode_t::RELU_FWD);
+    attributes.set_mode(PointwiseMode::RELU_FWD);
 
     auto out0 = graph.pointwise(in0, attributes);
 
@@ -212,12 +212,12 @@ TEST_F(TestGraph, PointwiseNodeCreationTwoInputs)
     auto in0 = std::make_shared<TensorAttributes>();
     auto in1 = std::make_shared<TensorAttributes>();
 
-    in0->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType_t::FLOAT);
-    in1->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType_t::FLOAT);
+    in0->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
+    in1->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
 
     PointwiseAttributes attributes;
     attributes.set_name("PointwiseNode");
-    attributes.set_mode(PointwiseMode_t::RELU_FWD);
+    attributes.set_mode(PointwiseMode::RELU_FWD);
 
     auto out0 = graph.pointwise(in0, in1, attributes);
 
@@ -236,13 +236,13 @@ TEST_F(TestGraph, PointwiseNodeCreationThreeInputs)
     auto in1 = std::make_shared<TensorAttributes>();
     auto in2 = std::make_shared<TensorAttributes>();
 
-    in0->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType_t::FLOAT);
-    in1->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType_t::FLOAT);
-    in2->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType_t::FLOAT);
+    in0->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
+    in1->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
+    in2->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
 
     PointwiseAttributes attributes;
     attributes.set_name("PointwiseNode");
-    attributes.set_mode(PointwiseMode_t::RELU_FWD);
+    attributes.set_mode(PointwiseMode::RELU_FWD);
 
     auto out0 = graph.pointwise(in0, in1, in2, attributes);
 
@@ -258,10 +258,10 @@ TEST_F(TestGraph, ConvolutionFwdNodeCreation)
     Graph graph;
 
     auto x = std::make_shared<TensorAttributes>();
-    x->set_dim({1, 3, 32, 32}).set_stride({3072, 1024, 32, 1}).set_data_type(DataType_t::FLOAT);
+    x->set_dim({1, 3, 32, 32}).set_stride({3072, 1024, 32, 1}).set_data_type(DataType::FLOAT);
 
     auto w = std::make_shared<TensorAttributes>();
-    w->set_dim({64, 3, 3, 3}).set_stride({27, 9, 3, 1}).set_data_type(DataType_t::FLOAT);
+    w->set_dim({64, 3, 3, 3}).set_stride({27, 9, 3, 1}).set_data_type(DataType::FLOAT);
 
     ConvFpropAttributes attributes;
     attributes.set_name("ConvolutionFpropNode");
@@ -296,28 +296,28 @@ TEST_F(TestGraph, BuildAndSerializeBatchnormInferenceGraph)
     Graph graph;
 
     graph.set_name("SerializedGraphTest")
-        .set_compute_data_type(DataType_t::FLOAT)
-        .set_intermediate_data_type(DataType_t::HALF)
-        .set_io_data_type(DataType_t::FLOAT);
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::FLOAT);
 
     auto x = std::make_shared<TensorAttributes>();
     x->set_uid(1)
         .set_name("X")
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8})
-        .set_data_type(DataType_t::FLOAT);
+        .set_data_type(DataType::FLOAT);
 
     auto mean = std::make_shared<TensorAttributes>();
-    mean->set_uid(2).set_name("Mean").set_data_type(DataType_t::FLOAT);
+    mean->set_uid(2).set_name("Mean").set_data_type(DataType::FLOAT);
 
     auto invVariance = std::make_shared<TensorAttributes>();
-    invVariance->set_uid(3).set_name("InvVariance").set_data_type(DataType_t::FLOAT);
+    invVariance->set_uid(3).set_name("InvVariance").set_data_type(DataType::FLOAT);
 
     auto scale = std::make_shared<TensorAttributes>();
-    scale->set_uid(4).set_name("Scale").set_data_type(DataType_t::FLOAT);
+    scale->set_uid(4).set_name("Scale").set_data_type(DataType::FLOAT);
 
     auto bias = std::make_shared<TensorAttributes>();
-    bias->set_uid(5).set_name("Bias").set_data_type(DataType_t::FLOAT);
+    bias->set_uid(5).set_name("Bias").set_data_type(DataType::FLOAT);
 
     BatchnormInferenceAttributes batchnormAttributes;
     batchnormAttributes.set_name("BatchnormNode");
@@ -373,36 +373,34 @@ TEST_F(TestGraph, BuildAndSerializeBatchnormGraph)
     Graph graph;
 
     graph.set_name("SerializedBatchnormGraph")
-        .set_compute_data_type(DataType_t::FLOAT)
-        .set_intermediate_data_type(DataType_t::HALF)
-        .set_io_data_type(DataType_t::FLOAT);
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::FLOAT);
 
     auto x = std::make_shared<TensorAttributes>();
     x->set_uid(1)
         .set_name("X")
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8})
-        .set_data_type(DataType_t::FLOAT);
+        .set_data_type(DataType::FLOAT);
 
     auto scale = std::make_shared<TensorAttributes>();
-    scale->set_uid(2).set_name("Scale").set_data_type(DataType_t::FLOAT);
+    scale->set_uid(2).set_name("Scale").set_data_type(DataType::FLOAT);
 
     auto bias = std::make_shared<TensorAttributes>();
-    bias->set_uid(3).set_name("Bias").set_data_type(DataType_t::FLOAT);
+    bias->set_uid(3).set_name("Bias").set_data_type(DataType::FLOAT);
 
     auto prevRunningMean = std::make_shared<TensorAttributes>();
-    prevRunningMean->set_uid(4).set_name("PrevRunningMean").set_data_type(DataType_t::FLOAT);
+    prevRunningMean->set_uid(4).set_name("PrevRunningMean").set_data_type(DataType::FLOAT);
 
     auto prevRunningVariance = std::make_shared<TensorAttributes>();
-    prevRunningVariance->set_uid(5)
-        .set_name("PrevRunningVariance")
-        .set_data_type(DataType_t::FLOAT);
+    prevRunningVariance->set_uid(5).set_name("PrevRunningVariance").set_data_type(DataType::FLOAT);
 
     auto momentum = std::make_shared<TensorAttributes>();
-    momentum->set_uid(6).set_name("Momentum").set_data_type(DataType_t::FLOAT);
+    momentum->set_uid(6).set_name("Momentum").set_data_type(DataType::FLOAT);
 
     auto epsilon = std::make_shared<TensorAttributes>();
-    epsilon->set_uid(7).set_name("Epsilon").set_data_type(DataType_t::FLOAT);
+    epsilon->set_uid(7).set_name("Epsilon").set_data_type(DataType::FLOAT);
 
     BatchnormAttributes batchnormAttributes;
     batchnormAttributes.set_name("BatchnormNode");
@@ -476,36 +474,34 @@ TEST_F(TestGraph, BuildAndSerializeBatchnormAndPointwiseGraph)
     Graph graph;
 
     graph.set_name("SerializedBatchnormAndPointwiseGraph")
-        .set_compute_data_type(DataType_t::FLOAT)
-        .set_intermediate_data_type(DataType_t::HALF)
-        .set_io_data_type(DataType_t::FLOAT);
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::FLOAT);
 
     auto x = std::make_shared<TensorAttributes>();
     x->set_uid(1)
         .set_name("X")
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8})
-        .set_data_type(DataType_t::FLOAT);
+        .set_data_type(DataType::FLOAT);
 
     auto scale = std::make_shared<TensorAttributes>();
-    scale->set_uid(2).set_name("Scale").set_data_type(DataType_t::FLOAT);
+    scale->set_uid(2).set_name("Scale").set_data_type(DataType::FLOAT);
 
     auto bias = std::make_shared<TensorAttributes>();
-    bias->set_uid(3).set_name("Bias").set_data_type(DataType_t::FLOAT);
+    bias->set_uid(3).set_name("Bias").set_data_type(DataType::FLOAT);
 
     auto prevRunningMean = std::make_shared<TensorAttributes>();
-    prevRunningMean->set_uid(4).set_name("PrevRunningMean").set_data_type(DataType_t::FLOAT);
+    prevRunningMean->set_uid(4).set_name("PrevRunningMean").set_data_type(DataType::FLOAT);
 
     auto prevRunningVariance = std::make_shared<TensorAttributes>();
-    prevRunningVariance->set_uid(5)
-        .set_name("PrevRunningVariance")
-        .set_data_type(DataType_t::FLOAT);
+    prevRunningVariance->set_uid(5).set_name("PrevRunningVariance").set_data_type(DataType::FLOAT);
 
     auto momentum = std::make_shared<TensorAttributes>();
-    momentum->set_uid(6).set_name("Momentum").set_data_type(DataType_t::FLOAT);
+    momentum->set_uid(6).set_name("Momentum").set_data_type(DataType::FLOAT);
 
     auto epsilon = std::make_shared<TensorAttributes>();
-    epsilon->set_uid(7).set_name("Epsilon").set_data_type(DataType_t::FLOAT);
+    epsilon->set_uid(7).set_name("Epsilon").set_data_type(DataType::FLOAT);
 
     BatchnormAttributes batchnormAttributes;
     batchnormAttributes.set_name("BatchnormNode");
@@ -517,7 +513,7 @@ TEST_F(TestGraph, BuildAndSerializeBatchnormAndPointwiseGraph)
 
     PointwiseAttributes pointwiseAttributes;
     pointwiseAttributes.set_name("PointwiseNode");
-    pointwiseAttributes.set_mode(PointwiseMode_t::RELU_FWD);
+    pointwiseAttributes.set_mode(PointwiseMode::RELU_FWD);
 
     auto out0 = graph.pointwise(y, pointwiseAttributes);
 
@@ -596,20 +592,20 @@ TEST_F(TestGraph, BuildAndSerializePointwiseGraph)
     Graph graph;
 
     graph.set_name("SerializedGraphTest")
-        .set_compute_data_type(DataType_t::FLOAT)
-        .set_intermediate_data_type(DataType_t::HALF)
-        .set_io_data_type(DataType_t::FLOAT);
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::FLOAT);
 
     auto in0 = std::make_shared<TensorAttributes>();
     in0->set_uid(1)
         .set_name("Input0")
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8})
-        .set_data_type(DataType_t::FLOAT);
+        .set_data_type(DataType::FLOAT);
 
     PointwiseAttributes pointwiseAttributes;
     pointwiseAttributes.set_name("PointwiseNode");
-    pointwiseAttributes.set_mode(PointwiseMode_t::RELU_FWD);
+    pointwiseAttributes.set_mode(PointwiseMode::RELU_FWD);
 
     auto out0 = graph.pointwise(in0, pointwiseAttributes);
 
@@ -655,28 +651,28 @@ TEST_F(TestGraph, BuildAndSerializePointwiseAndBatchnormInferenceGraph)
     Graph graph;
 
     graph.set_name("SerializedGraphTest")
-        .set_compute_data_type(DataType_t::FLOAT)
-        .set_intermediate_data_type(DataType_t::HALF)
-        .set_io_data_type(DataType_t::FLOAT);
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::FLOAT);
 
     auto x = std::make_shared<TensorAttributes>();
     x->set_uid(1)
         .set_name("X")
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8})
-        .set_data_type(DataType_t::FLOAT);
+        .set_data_type(DataType::FLOAT);
 
     auto mean = std::make_shared<TensorAttributes>();
-    mean->set_uid(2).set_name("Mean").set_data_type(DataType_t::FLOAT);
+    mean->set_uid(2).set_name("Mean").set_data_type(DataType::FLOAT);
 
     auto invVariance = std::make_shared<TensorAttributes>();
-    invVariance->set_uid(3).set_name("InvVariance").set_data_type(DataType_t::FLOAT);
+    invVariance->set_uid(3).set_name("InvVariance").set_data_type(DataType::FLOAT);
 
     auto scale = std::make_shared<TensorAttributes>();
-    scale->set_uid(4).set_name("Scale").set_data_type(DataType_t::FLOAT);
+    scale->set_uid(4).set_name("Scale").set_data_type(DataType::FLOAT);
 
     auto bias = std::make_shared<TensorAttributes>();
-    bias->set_uid(5).set_name("Bias").set_data_type(DataType_t::FLOAT);
+    bias->set_uid(5).set_name("Bias").set_data_type(DataType::FLOAT);
 
     BatchnormInferenceAttributes batchnormAttributes;
     batchnormAttributes.set_name("BatchnormNode");
@@ -685,7 +681,7 @@ TEST_F(TestGraph, BuildAndSerializePointwiseAndBatchnormInferenceGraph)
 
     PointwiseAttributes pointwiseAttributes;
     pointwiseAttributes.set_name("PointwiseNode");
-    pointwiseAttributes.set_mode(PointwiseMode_t::RELU_FWD);
+    pointwiseAttributes.set_mode(PointwiseMode::RELU_FWD);
 
     auto out0 = graph.pointwise(y, pointwiseAttributes);
 
@@ -749,32 +745,32 @@ TEST_F(TestGraph, BuildAndSerializeBatchnormBackwardGraph)
     Graph graph;
 
     graph.set_name("SerializedGraphTest")
-        .set_compute_data_type(DataType_t::FLOAT)
-        .set_intermediate_data_type(DataType_t::HALF)
-        .set_io_data_type(DataType_t::FLOAT);
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::FLOAT);
 
     auto dy = std::make_shared<TensorAttributes>();
     dy->set_uid(1)
         .set_name("Dy")
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8})
-        .set_data_type(DataType_t::FLOAT);
+        .set_data_type(DataType::FLOAT);
 
     auto x = std::make_shared<TensorAttributes>();
     x->set_uid(2)
         .set_name("X")
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8})
-        .set_data_type(DataType_t::FLOAT);
+        .set_data_type(DataType::FLOAT);
 
     auto scale = std::make_shared<TensorAttributes>();
-    scale->set_uid(3).set_name("Scale").set_data_type(DataType_t::FLOAT);
+    scale->set_uid(3).set_name("Scale").set_data_type(DataType::FLOAT);
 
     auto mean = std::make_shared<TensorAttributes>();
-    mean->set_uid(4).set_name("Mean").set_data_type(DataType_t::FLOAT);
+    mean->set_uid(4).set_name("Mean").set_data_type(DataType::FLOAT);
 
     auto invVariance = std::make_shared<TensorAttributes>();
-    invVariance->set_uid(5).set_name("InvVariance").set_data_type(DataType_t::FLOAT);
+    invVariance->set_uid(5).set_name("InvVariance").set_data_type(DataType::FLOAT);
 
     BatchnormBackwardAttributes batchnormAttributes;
     batchnormAttributes.set_name("BatchnormBackwardNode");
@@ -833,23 +829,23 @@ TEST_F(TestGraph, BuildAndSerializeConvolutionFwdGraph)
     Graph graph;
 
     graph.set_name("SerializedConvolutionGraph")
-        .set_compute_data_type(DataType_t::FLOAT)
-        .set_intermediate_data_type(DataType_t::HALF)
-        .set_io_data_type(DataType_t::FLOAT);
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::FLOAT);
 
     auto x = std::make_shared<TensorAttributes>();
     x->set_uid(1)
         .set_name("X")
         .set_dim({1, 3, 32, 32})
         .set_stride({3072, 1024, 32, 1})
-        .set_data_type(DataType_t::FLOAT);
+        .set_data_type(DataType::FLOAT);
 
     auto w = std::make_shared<TensorAttributes>();
     w->set_uid(2)
         .set_name("W")
         .set_dim({64, 3, 3, 3})
         .set_stride({27, 9, 3, 1})
-        .set_data_type(DataType_t::FLOAT);
+        .set_data_type(DataType::FLOAT);
 
     ConvFpropAttributes convolutionAttributes;
     convolutionAttributes.set_name("ConvolutionFpropNode");
@@ -906,20 +902,20 @@ TEST_F(TestGraph, BuildAndSerializePointwiseAndBatchnormBackwardGraph)
     Graph graph;
 
     graph.set_name("SerializedGraphTest")
-        .set_compute_data_type(DataType_t::FLOAT)
-        .set_intermediate_data_type(DataType_t::HALF)
-        .set_io_data_type(DataType_t::FLOAT);
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::FLOAT);
 
     auto xPointwise = std::make_shared<TensorAttributes>();
     xPointwise->set_uid(6)
         .set_name("X_Pointwise")
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8})
-        .set_data_type(DataType_t::FLOAT);
+        .set_data_type(DataType::FLOAT);
 
     PointwiseAttributes pointwiseAttributes;
     pointwiseAttributes.set_name("PointwiseNode");
-    pointwiseAttributes.set_mode(PointwiseMode_t::RELU_FWD);
+    pointwiseAttributes.set_mode(PointwiseMode::RELU_FWD);
 
     auto dy = graph.pointwise(xPointwise, pointwiseAttributes);
 
@@ -928,16 +924,16 @@ TEST_F(TestGraph, BuildAndSerializePointwiseAndBatchnormBackwardGraph)
         .set_name("X")
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8})
-        .set_data_type(DataType_t::FLOAT);
+        .set_data_type(DataType::FLOAT);
 
     auto scale = std::make_shared<TensorAttributes>();
-    scale->set_uid(2).set_name("Scale").set_data_type(DataType_t::FLOAT);
+    scale->set_uid(2).set_name("Scale").set_data_type(DataType::FLOAT);
 
     auto mean = std::make_shared<TensorAttributes>();
-    mean->set_uid(3).set_name("Mean").set_data_type(DataType_t::FLOAT);
+    mean->set_uid(3).set_name("Mean").set_data_type(DataType::FLOAT);
 
     auto invVariance = std::make_shared<TensorAttributes>();
-    invVariance->set_uid(4).set_name("InvVariance").set_data_type(DataType_t::FLOAT);
+    invVariance->set_uid(4).set_name("InvVariance").set_data_type(DataType::FLOAT);
 
     BatchnormBackwardAttributes batchnormAttributes;
     batchnormAttributes.set_name("BatchnormBackwardNode");
@@ -1009,11 +1005,11 @@ TEST_F(TestGraph, TensorGraphAttributes)
                                     .set_name("TestTensor")
                                     .set_uid(100)
                                     .set_stride({5, 6, 7, 8})
-                                    .set_data_type(DataType_t::FLOAT)
+                                    .set_data_type(DataType::FLOAT)
                                     .set_is_virtual(false)
                                     .set_dim({1, 2, 3, 4}));
 
-    EXPECT_EQ(tensor->get_data_type(), DataType_t::FLOAT);
+    EXPECT_EQ(tensor->get_data_type(), DataType::FLOAT);
     EXPECT_FALSE(tensor->get_is_virtual());
     EXPECT_EQ(tensor->get_dim(), std::vector<int64_t>({1, 2, 3, 4}));
     EXPECT_EQ(tensor->get_stride(), std::vector<int64_t>({5, 6, 7, 8}));
@@ -1030,11 +1026,11 @@ TEST_F(TestGraph, TensorLikeGraphAttributes)
                                     .set_dim({1, 2, 3, 4})
                                     .set_stride({5, 6, 7, 8})
                                     .set_is_virtual(false)
-                                    .set_data_type(DataType_t::FLOAT));
+                                    .set_data_type(DataType::FLOAT));
 
     auto tensorLike = Graph::tensor_like(tensor, "TensorLike");
 
-    EXPECT_EQ(tensorLike->get_data_type(), DataType_t::FLOAT);
+    EXPECT_EQ(tensorLike->get_data_type(), DataType::FLOAT);
     EXPECT_FALSE(tensorLike->get_is_virtual());
     EXPECT_EQ(tensorLike->get_dim(), std::vector<int64_t>({1, 2, 3, 4}));
     EXPECT_EQ(tensorLike->get_stride(), std::vector<int64_t>({5, 6, 7, 8}));
@@ -1084,7 +1080,7 @@ TEST_F(TestGraph, CreatingExecutionPlansFailsWithNoGraph)
 {
     Graph graph;
 
-    auto result = graph.create_execution_plans({HeurMode_t::FALLBACK});
+    auto result = graph.create_execution_plans({HeuristicMode::FALLBACK});
     EXPECT_FALSE(result.is_good());
     EXPECT_EQ(result.get_message(),
               "Graph has not been built, build the operation graph first. Cannot create "
@@ -1095,7 +1091,7 @@ TEST_F(TestGraph, CanSuccessfullyCreateExecutionPlans)
 {
     ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
-    const std::vector<HeurMode_t> heurModes = {HeurMode_t::FALLBACK};
+    const std::vector<HeuristicMode> heurModes = {HeuristicMode::FALLBACK};
     std::vector<hipdnnBackendHeurMode_t> backend_modes;
     for(const auto& mode : heurModes)
     {
@@ -1227,7 +1223,7 @@ TEST_F(TestGraph, CheckSupportSucceedsWhenExecutionPlanCreated)
 {
     ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
-    const std::vector<HeurMode_t> heurModes = {HeurMode_t::FALLBACK};
+    const std::vector<HeuristicMode> heurModes = {HeuristicMode::FALLBACK};
     auto tensorAttributes = createBasicBatchnormGraph(graph);
     graph.build_operation_graph(_handle);
 
@@ -1259,7 +1255,7 @@ TEST_F(TestGraph, EngineConfigAndExecutionPlanAreFinalizedAfterBuildPlans)
 {
     ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
-    const std::vector<HeurMode_t> heurModes = {HeurMode_t::FALLBACK};
+    const std::vector<HeuristicMode> heurModes = {HeuristicMode::FALLBACK};
     auto tensorAttributes = createBasicBatchnormGraph(graph);
 
     ON_CALL(*_mockBackend, backendCreateAndDeserializeGraphExt(_, _, _))
@@ -1337,7 +1333,7 @@ TEST_F(TestGraph, WorkspaceSizeIsRetrievedFromExecutionPlan)
 {
     ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
-    const std::vector<HeurMode_t> heurModes = {HeurMode_t::FALLBACK};
+    const std::vector<HeuristicMode> heurModes = {HeuristicMode::FALLBACK};
     auto tensorAttributes = createBasicBatchnormGraph(graph);
     graph.build_operation_graph(_handle);
 
@@ -1407,11 +1403,11 @@ TEST_F(TestGraph, ExecutePacksVariantPackAndPassesTheCorrectArguments)
         .set_name("InputTensor")
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8})
-        .set_data_type(DataType_t::FLOAT);
+        .set_data_type(DataType::FLOAT);
 
     PointwiseAttributes pointwiseAttributes;
     pointwiseAttributes.set_name("PointwiseNode");
-    pointwiseAttributes.set_mode(PointwiseMode_t::RELU_FWD);
+    pointwiseAttributes.set_mode(PointwiseMode::RELU_FWD);
     auto out_tensor = graph.pointwise(tensor, pointwiseAttributes);
 
     // build_operation_graph mocks
@@ -1626,7 +1622,7 @@ TEST_F(TestGraph, ExecutePacksVariantPackAndPassesTheCorrectArguments)
     auto buildResult = graph.build_operation_graph(_handle);
     EXPECT_TRUE(buildResult.is_good());
 
-    std::vector<HeurMode_t> heurModes = {HeurMode_t::FALLBACK};
+    std::vector<HeuristicMode> heurModes = {HeuristicMode::FALLBACK};
     auto planResult = graph.create_execution_plans(heurModes);
     EXPECT_TRUE(planResult.is_good());
 

--- a/frontend/tests/TestGraphAttributes.cpp
+++ b/frontend/tests/TestGraphAttributes.cpp
@@ -10,15 +10,15 @@ TEST(TestGraphAttributes, CreateGraphAttributes)
 
     // Set all properties
     graphAttributes.set_name("TestGraph")
-        .set_compute_data_type(hipdnn_frontend::DataType_t::FLOAT)
-        .set_intermediate_data_type(hipdnn_frontend::DataType_t::HALF)
-        .set_io_data_type(hipdnn_frontend::DataType_t::BFLOAT16);
+        .set_compute_data_type(hipdnn_frontend::DataType::FLOAT)
+        .set_intermediate_data_type(hipdnn_frontend::DataType::HALF)
+        .set_io_data_type(hipdnn_frontend::DataType::BFLOAT16);
 
     // Verify all properties
     EXPECT_EQ(graphAttributes.get_name(), "TestGraph");
-    EXPECT_EQ(graphAttributes.get_compute_data_type(), hipdnn_frontend::DataType_t::FLOAT);
-    EXPECT_EQ(graphAttributes.get_intermediate_data_type(), hipdnn_frontend::DataType_t::HALF);
-    EXPECT_EQ(graphAttributes.get_io_data_type(), hipdnn_frontend::DataType_t::BFLOAT16);
+    EXPECT_EQ(graphAttributes.get_compute_data_type(), hipdnn_frontend::DataType::FLOAT);
+    EXPECT_EQ(graphAttributes.get_intermediate_data_type(), hipdnn_frontend::DataType::HALF);
+    EXPECT_EQ(graphAttributes.get_io_data_type(), hipdnn_frontend::DataType::BFLOAT16);
 }
 
 TEST(TestGraphAttributes, DefaultValues)
@@ -27,9 +27,9 @@ TEST(TestGraphAttributes, DefaultValues)
 
     // Check default values
     EXPECT_EQ(graphAttributes.get_name(), "");
-    EXPECT_EQ(graphAttributes.get_compute_data_type(), hipdnn_frontend::DataType_t::NOT_SET);
-    EXPECT_EQ(graphAttributes.get_intermediate_data_type(), hipdnn_frontend::DataType_t::NOT_SET);
-    EXPECT_EQ(graphAttributes.get_io_data_type(), hipdnn_frontend::DataType_t::NOT_SET);
+    EXPECT_EQ(graphAttributes.get_compute_data_type(), hipdnn_frontend::DataType::NOT_SET);
+    EXPECT_EQ(graphAttributes.get_intermediate_data_type(), hipdnn_frontend::DataType::NOT_SET);
+    EXPECT_EQ(graphAttributes.get_io_data_type(), hipdnn_frontend::DataType::NOT_SET);
 }
 
 TEST(TestGraphAttributes, SetName)
@@ -53,24 +53,24 @@ TEST(TestGraphAttributes, SetComputeDataType)
 {
     hipdnn_frontend::graph::GraphAttributes graphAttributes;
 
-    graphAttributes.set_compute_data_type(hipdnn_frontend::DataType_t::FLOAT);
-    EXPECT_EQ(graphAttributes.get_compute_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    graphAttributes.set_compute_data_type(hipdnn_frontend::DataType::FLOAT);
+    EXPECT_EQ(graphAttributes.get_compute_data_type(), hipdnn_frontend::DataType::FLOAT);
 }
 
 TEST(TestGraphAttributes, SetIntermediateDataType)
 {
     hipdnn_frontend::graph::GraphAttributes graphAttributes;
 
-    graphAttributes.set_intermediate_data_type(hipdnn_frontend::DataType_t::FLOAT);
-    EXPECT_EQ(graphAttributes.get_intermediate_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    graphAttributes.set_intermediate_data_type(hipdnn_frontend::DataType::FLOAT);
+    EXPECT_EQ(graphAttributes.get_intermediate_data_type(), hipdnn_frontend::DataType::FLOAT);
 }
 
 TEST(TestGraphAttributes, SetIoDataType)
 {
     hipdnn_frontend::graph::GraphAttributes graphAttributes;
 
-    graphAttributes.set_io_data_type(hipdnn_frontend::DataType_t::HALF);
-    EXPECT_EQ(graphAttributes.get_io_data_type(), hipdnn_frontend::DataType_t::HALF);
+    graphAttributes.set_io_data_type(hipdnn_frontend::DataType::HALF);
+    EXPECT_EQ(graphAttributes.get_io_data_type(), hipdnn_frontend::DataType::HALF);
 }
 
 TEST(TestGraphAttributes, MethodChaining)
@@ -79,9 +79,9 @@ TEST(TestGraphAttributes, MethodChaining)
 
     // Test that all setters return reference to self for chaining
     auto& ref1 = graphAttributes.set_name("ChainedGraph");
-    auto& ref2 = ref1.set_compute_data_type(hipdnn_frontend::DataType_t::FLOAT);
-    auto& ref3 = ref2.set_intermediate_data_type(hipdnn_frontend::DataType_t::HALF);
-    auto& ref4 = ref3.set_io_data_type(hipdnn_frontend::DataType_t::BFLOAT16);
+    auto& ref2 = ref1.set_compute_data_type(hipdnn_frontend::DataType::FLOAT);
+    auto& ref3 = ref2.set_intermediate_data_type(hipdnn_frontend::DataType::HALF);
+    auto& ref4 = ref3.set_io_data_type(hipdnn_frontend::DataType::BFLOAT16);
 
     // All references should point to the same object
     EXPECT_EQ(&graphAttributes, &ref1);
@@ -91,9 +91,9 @@ TEST(TestGraphAttributes, MethodChaining)
 
     // Verify all values were set correctly
     EXPECT_EQ(graphAttributes.get_name(), "ChainedGraph");
-    EXPECT_EQ(graphAttributes.get_compute_data_type(), hipdnn_frontend::DataType_t::FLOAT);
-    EXPECT_EQ(graphAttributes.get_intermediate_data_type(), hipdnn_frontend::DataType_t::HALF);
-    EXPECT_EQ(graphAttributes.get_io_data_type(), hipdnn_frontend::DataType_t::BFLOAT16);
+    EXPECT_EQ(graphAttributes.get_compute_data_type(), hipdnn_frontend::DataType::FLOAT);
+    EXPECT_EQ(graphAttributes.get_intermediate_data_type(), hipdnn_frontend::DataType::HALF);
+    EXPECT_EQ(graphAttributes.get_io_data_type(), hipdnn_frontend::DataType::BFLOAT16);
 }
 
 TEST(TestGraphAttributes, FillMissingPropertiesAllMissing)
@@ -103,17 +103,17 @@ TEST(TestGraphAttributes, FillMissingPropertiesAllMissing)
 
     // Set all properties in source
     source.set_name("SourceGraph")
-        .set_compute_data_type(hipdnn_frontend::DataType_t::FLOAT)
-        .set_intermediate_data_type(hipdnn_frontend::DataType_t::HALF)
-        .set_io_data_type(hipdnn_frontend::DataType_t::BFLOAT16);
+        .set_compute_data_type(hipdnn_frontend::DataType::FLOAT)
+        .set_intermediate_data_type(hipdnn_frontend::DataType::HALF)
+        .set_io_data_type(hipdnn_frontend::DataType::BFLOAT16);
 
     target.fill_missing_properties(source);
 
     // All properties should be copied from source
     EXPECT_EQ(target.get_name(), "SourceGraph");
-    EXPECT_EQ(target.get_compute_data_type(), hipdnn_frontend::DataType_t::FLOAT);
-    EXPECT_EQ(target.get_intermediate_data_type(), hipdnn_frontend::DataType_t::HALF);
-    EXPECT_EQ(target.get_io_data_type(), hipdnn_frontend::DataType_t::BFLOAT16);
+    EXPECT_EQ(target.get_compute_data_type(), hipdnn_frontend::DataType::FLOAT);
+    EXPECT_EQ(target.get_intermediate_data_type(), hipdnn_frontend::DataType::HALF);
+    EXPECT_EQ(target.get_io_data_type(), hipdnn_frontend::DataType::BFLOAT16);
 }
 
 TEST(TestGraphAttributes, FillMissingPropertiesPartialMissing)
@@ -122,24 +122,24 @@ TEST(TestGraphAttributes, FillMissingPropertiesPartialMissing)
     hipdnn_frontend::graph::GraphAttributes source;
 
     // Set some properties in target
-    target.set_name("TargetGraph").set_compute_data_type(hipdnn_frontend::DataType_t::DOUBLE);
+    target.set_name("TargetGraph").set_compute_data_type(hipdnn_frontend::DataType::DOUBLE);
 
     // Set all properties in source
     source.set_name("SourceGraph")
-        .set_compute_data_type(hipdnn_frontend::DataType_t::FLOAT)
-        .set_intermediate_data_type(hipdnn_frontend::DataType_t::HALF)
-        .set_io_data_type(hipdnn_frontend::DataType_t::BFLOAT16);
+        .set_compute_data_type(hipdnn_frontend::DataType::FLOAT)
+        .set_intermediate_data_type(hipdnn_frontend::DataType::HALF)
+        .set_io_data_type(hipdnn_frontend::DataType::BFLOAT16);
 
     // Fill missing properties
     target.fill_missing_properties(source);
 
     // Existing properties should not be overwritten
     EXPECT_EQ(target.get_name(), "TargetGraph");
-    EXPECT_EQ(target.get_compute_data_type(), hipdnn_frontend::DataType_t::DOUBLE);
+    EXPECT_EQ(target.get_compute_data_type(), hipdnn_frontend::DataType::DOUBLE);
 
     // Missing properties should be filled from source
-    EXPECT_EQ(target.get_intermediate_data_type(), hipdnn_frontend::DataType_t::HALF);
-    EXPECT_EQ(target.get_io_data_type(), hipdnn_frontend::DataType_t::BFLOAT16);
+    EXPECT_EQ(target.get_intermediate_data_type(), hipdnn_frontend::DataType::HALF);
+    EXPECT_EQ(target.get_io_data_type(), hipdnn_frontend::DataType::BFLOAT16);
 }
 
 TEST(TestGraphAttributes, FillMissingPropertiesNoneMissing)
@@ -149,24 +149,24 @@ TEST(TestGraphAttributes, FillMissingPropertiesNoneMissing)
 
     // Set all properties in target
     target.set_name("TargetGraph")
-        .set_compute_data_type(hipdnn_frontend::DataType_t::DOUBLE)
-        .set_intermediate_data_type(hipdnn_frontend::DataType_t::FLOAT)
-        .set_io_data_type(hipdnn_frontend::DataType_t::INT32);
+        .set_compute_data_type(hipdnn_frontend::DataType::DOUBLE)
+        .set_intermediate_data_type(hipdnn_frontend::DataType::FLOAT)
+        .set_io_data_type(hipdnn_frontend::DataType::INT32);
 
     // Set all properties in source with different values
     source.set_name("SourceGraph")
-        .set_compute_data_type(hipdnn_frontend::DataType_t::FLOAT)
-        .set_intermediate_data_type(hipdnn_frontend::DataType_t::HALF)
-        .set_io_data_type(hipdnn_frontend::DataType_t::BFLOAT16);
+        .set_compute_data_type(hipdnn_frontend::DataType::FLOAT)
+        .set_intermediate_data_type(hipdnn_frontend::DataType::HALF)
+        .set_io_data_type(hipdnn_frontend::DataType::BFLOAT16);
 
     // Fill missing properties (none are missing)
     target.fill_missing_properties(source);
 
     // No properties should be changed
     EXPECT_EQ(target.get_name(), "TargetGraph");
-    EXPECT_EQ(target.get_compute_data_type(), hipdnn_frontend::DataType_t::DOUBLE);
-    EXPECT_EQ(target.get_intermediate_data_type(), hipdnn_frontend::DataType_t::FLOAT);
-    EXPECT_EQ(target.get_io_data_type(), hipdnn_frontend::DataType_t::INT32);
+    EXPECT_EQ(target.get_compute_data_type(), hipdnn_frontend::DataType::DOUBLE);
+    EXPECT_EQ(target.get_intermediate_data_type(), hipdnn_frontend::DataType::FLOAT);
+    EXPECT_EQ(target.get_io_data_type(), hipdnn_frontend::DataType::INT32);
 }
 
 TEST(TestGraphAttributes, FillMissingPropertiesEmptyName)
@@ -175,9 +175,9 @@ TEST(TestGraphAttributes, FillMissingPropertiesEmptyName)
     hipdnn_frontend::graph::GraphAttributes source;
 
     // Set empty name in target and non-empty in source
-    target.set_name("").set_compute_data_type(hipdnn_frontend::DataType_t::FLOAT);
+    target.set_name("").set_compute_data_type(hipdnn_frontend::DataType::FLOAT);
 
-    source.set_name("SourceGraph").set_compute_data_type(hipdnn_frontend::DataType_t::DOUBLE);
+    source.set_name("SourceGraph").set_compute_data_type(hipdnn_frontend::DataType::DOUBLE);
 
     // Fill missing properties
     target.fill_missing_properties(source);
@@ -185,7 +185,7 @@ TEST(TestGraphAttributes, FillMissingPropertiesEmptyName)
     // Empty name should be filled from source
     EXPECT_EQ(target.get_name(), "SourceGraph");
     // Existing compute type should not change
-    EXPECT_EQ(target.get_compute_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(target.get_compute_data_type(), hipdnn_frontend::DataType::FLOAT);
 }
 
 TEST(TestGraphAttributes, FillMissingPropertiesChaining)
@@ -194,9 +194,9 @@ TEST(TestGraphAttributes, FillMissingPropertiesChaining)
     hipdnn_frontend::graph::GraphAttributes source;
 
     source.set_name("SourceGraph")
-        .set_compute_data_type(hipdnn_frontend::DataType_t::FLOAT)
-        .set_intermediate_data_type(hipdnn_frontend::DataType_t::HALF)
-        .set_io_data_type(hipdnn_frontend::DataType_t::BFLOAT16);
+        .set_compute_data_type(hipdnn_frontend::DataType::FLOAT)
+        .set_intermediate_data_type(hipdnn_frontend::DataType::HALF)
+        .set_io_data_type(hipdnn_frontend::DataType::BFLOAT16);
 
     // Test that fill_missing_properties returns reference for chaining
     auto& ref = target.fill_missing_properties(source);
@@ -206,5 +206,5 @@ TEST(TestGraphAttributes, FillMissingPropertiesChaining)
     ref.set_name("ModifiedAfterFill");
 
     EXPECT_EQ(target.get_name(), "ModifiedAfterFill");
-    EXPECT_EQ(target.get_compute_data_type(), hipdnn_frontend::DataType_t::FLOAT);
+    EXPECT_EQ(target.get_compute_data_type(), hipdnn_frontend::DataType::FLOAT);
 }

--- a/frontend/tests/TestPointwiseAttributes.cpp
+++ b/frontend/tests/TestPointwiseAttributes.cpp
@@ -13,7 +13,7 @@ TEST(TestPointwiseAttributes, CreatePointwiseAttributes)
 
     pointwiseAttributes.set_input_0(std::make_shared<TensorAttributes>());
     pointwiseAttributes.set_output_0(std::make_shared<TensorAttributes>());
-    pointwiseAttributes.set_mode(PointwiseMode_t::RELU_FWD)
+    pointwiseAttributes.set_mode(PointwiseMode::RELU_FWD)
         .set_relu_lower_clip(0.1f)
         .set_relu_upper_clip(6.0f)
         .set_relu_lower_clip_slope(0.01f)
@@ -24,7 +24,7 @@ TEST(TestPointwiseAttributes, CreatePointwiseAttributes)
 
     inputTensor->set_uid(1)
         .set_name("InputTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
@@ -33,23 +33,23 @@ TEST(TestPointwiseAttributes, CreatePointwiseAttributes)
 
     outputTensor->set_uid(2)
         .set_name("OutputTensor")
-        .set_data_type(DataType_t::HALF)
+        .set_data_type(DataType::HALF)
         .set_dim({5, 6, 7, 8})
         .set_stride({1, 2, 3, 4});
 
     EXPECT_EQ(inputTensor->get_uid(), 1);
     EXPECT_EQ(inputTensor->get_name(), "InputTensor");
-    EXPECT_EQ(inputTensor->get_data_type(), DataType_t::FLOAT);
+    EXPECT_EQ(inputTensor->get_data_type(), DataType::FLOAT);
     EXPECT_EQ(inputTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(inputTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
 
     EXPECT_EQ(outputTensor->get_uid(), 2);
     EXPECT_EQ(outputTensor->get_name(), "OutputTensor");
-    EXPECT_EQ(outputTensor->get_data_type(), DataType_t::HALF);
+    EXPECT_EQ(outputTensor->get_data_type(), DataType::HALF);
     EXPECT_EQ(outputTensor->get_dim(), (std::vector<int64_t>{5, 6, 7, 8}));
     EXPECT_EQ(outputTensor->get_stride(), (std::vector<int64_t>{1, 2, 3, 4}));
 
-    EXPECT_EQ(pointwiseAttributes.get_mode(), PointwiseMode_t::RELU_FWD);
+    EXPECT_EQ(pointwiseAttributes.get_mode(), PointwiseMode::RELU_FWD);
     EXPECT_EQ(pointwiseAttributes.get_relu_lower_clip(), 0.1f);
     EXPECT_EQ(pointwiseAttributes.get_relu_upper_clip(), 6.0f);
     EXPECT_EQ(pointwiseAttributes.get_relu_lower_slope(), 0.01f);
@@ -63,19 +63,19 @@ TEST(TestPointwiseAttributes, CreatePointwiseAttributesWithTwoInputs)
     pointwiseAttributes.set_input_0(std::make_shared<TensorAttributes>());
     pointwiseAttributes.set_input_1(std::make_shared<TensorAttributes>());
     pointwiseAttributes.set_output_0(std::make_shared<TensorAttributes>());
-    pointwiseAttributes.set_mode(PointwiseMode_t::RELU_FWD);
+    pointwiseAttributes.set_mode(PointwiseMode::RELU_FWD);
 
     auto inputTensor0 = pointwiseAttributes.get_input_0();
     inputTensor0->set_uid(1)
         .set_name("InputTensor0")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto inputTensor1 = pointwiseAttributes.get_input_1();
     inputTensor1->set_uid(2)
         .set_name("InputTensor1")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
@@ -88,7 +88,7 @@ TEST(TestPointwiseAttributes, CreatePointwiseAttributesWithTwoInputs)
     EXPECT_EQ(inputTensor1->get_name(), "InputTensor1");
     EXPECT_EQ(outputTensor->get_uid(), 3);
     EXPECT_EQ(outputTensor->get_name(), "OutputTensor");
-    EXPECT_EQ(pointwiseAttributes.get_mode(), PointwiseMode_t::RELU_FWD);
+    EXPECT_EQ(pointwiseAttributes.get_mode(), PointwiseMode::RELU_FWD);
 }
 
 TEST(TestPointwiseAttributes, SetInput0WithMove)
@@ -221,26 +221,26 @@ TEST(TestPointwiseAttributes, CreatePointwiseAttributesWithThreeInputs)
     pointwiseAttributes.set_input_1(std::make_shared<TensorAttributes>());
     pointwiseAttributes.set_input_2(std::make_shared<TensorAttributes>());
     pointwiseAttributes.set_output_0(std::make_shared<TensorAttributes>());
-    pointwiseAttributes.set_mode(PointwiseMode_t::RELU_FWD);
+    pointwiseAttributes.set_mode(PointwiseMode::RELU_FWD);
 
     auto inputTensor0 = pointwiseAttributes.get_input_0();
     inputTensor0->set_uid(1)
         .set_name("InputTensor0")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto inputTensor1 = pointwiseAttributes.get_input_1();
     inputTensor1->set_uid(2)
         .set_name("InputTensor1")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto inputTensor2 = pointwiseAttributes.get_input_2();
     inputTensor2->set_uid(3)
         .set_name("InputTensor2")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
@@ -255,5 +255,5 @@ TEST(TestPointwiseAttributes, CreatePointwiseAttributesWithThreeInputs)
     EXPECT_EQ(inputTensor2->get_name(), "InputTensor2");
     EXPECT_EQ(outputTensor->get_uid(), 4);
     EXPECT_EQ(outputTensor->get_name(), "OutputTensor");
-    EXPECT_EQ(pointwiseAttributes.get_mode(), PointwiseMode_t::RELU_FWD);
+    EXPECT_EQ(pointwiseAttributes.get_mode(), PointwiseMode::RELU_FWD);
 }

--- a/frontend/tests/TestPointwiseNode.cpp
+++ b/frontend/tests/TestPointwiseNode.cpp
@@ -16,12 +16,12 @@ TEST(TestPointwiseNode, SingleInput)
     PointwiseAttributes attributes;
     attributes.set_input_0(std::make_shared<TensorAttributes>());
     attributes.set_output_0(std::make_shared<TensorAttributes>());
-    attributes.set_mode(PointwiseMode_t::RELU_FWD);
+    attributes.set_mode(PointwiseMode::RELU_FWD);
 
     auto inputTensor = attributes.get_input_0();
     inputTensor->set_uid(1)
         .set_name("InputTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
@@ -32,7 +32,7 @@ TEST(TestPointwiseNode, SingleInput)
     PointwiseNode node(std::move(attributes), graphAttributes);
 
     auto error = node.infer_properties_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 
     EXPECT_EQ(outputTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(outputTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
@@ -44,19 +44,19 @@ TEST(TestPointwiseNode, TwoInputs)
     attributes.set_input_0(std::make_shared<TensorAttributes>());
     attributes.set_input_1(std::make_shared<TensorAttributes>());
     attributes.set_output_0(std::make_shared<TensorAttributes>());
-    attributes.set_mode(PointwiseMode_t::RELU_FWD);
+    attributes.set_mode(PointwiseMode::RELU_FWD);
 
     auto inputTensor0 = attributes.get_input_0();
     inputTensor0->set_uid(1)
         .set_name("InputTensor0")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto inputTensor1 = attributes.get_input_1();
     inputTensor1->set_uid(2)
         .set_name("InputTensor1")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
@@ -67,7 +67,7 @@ TEST(TestPointwiseNode, TwoInputs)
     PointwiseNode node(std::move(attributes), graphAttributes);
 
     auto error = node.infer_properties_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 
     EXPECT_EQ(outputTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(outputTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
@@ -80,26 +80,26 @@ TEST(TestPointwiseNode, ThreeInputs)
     attributes.set_input_1(std::make_shared<TensorAttributes>());
     attributes.set_input_2(std::make_shared<TensorAttributes>());
     attributes.set_output_0(std::make_shared<TensorAttributes>());
-    attributes.set_mode(PointwiseMode_t::RELU_FWD);
+    attributes.set_mode(PointwiseMode::RELU_FWD);
 
     auto inputTensor0 = attributes.get_input_0();
     inputTensor0->set_uid(1)
         .set_name("InputTensor0")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto inputTensor1 = attributes.get_input_1();
     inputTensor1->set_uid(2)
         .set_name("InputTensor1")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
     auto inputTensor2 = attributes.get_input_2();
     inputTensor2->set_uid(3)
         .set_name("InputTensor2")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
@@ -110,7 +110,7 @@ TEST(TestPointwiseNode, ThreeInputs)
     PointwiseNode node(std::move(attributes), graphAttributes);
 
     auto error = node.infer_properties_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 
     EXPECT_EQ(outputTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(outputTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
@@ -121,13 +121,13 @@ TEST(TestPointwiseNode, PreValidateNode)
     PointwiseAttributes attributes;
     attributes.set_input_0(std::make_shared<TensorAttributes>());
     attributes.set_output_0(std::make_shared<TensorAttributes>());
-    attributes.set_mode(PointwiseMode_t::RELU_FWD);
+    attributes.set_mode(PointwiseMode::RELU_FWD);
 
     GraphAttributes graphAttributes;
     PointwiseNode node(std::move(attributes), graphAttributes);
 
     auto error = node.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 }
 
 TEST(TestPointwiseNode, PreValidateNodeMissingValues)
@@ -138,28 +138,28 @@ TEST(TestPointwiseNode, PreValidateNodeMissingValues)
     PointwiseNode node(std::move(attributes), graphAttributes);
 
     auto error = node.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     attributes.set_input_0(std::make_shared<TensorAttributes>());
     auto attributesCopy = attributes;
     PointwiseNode nodeWithInput(std::move(attributesCopy), graphAttributes);
 
     error = nodeWithInput.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     attributes.set_output_0(std::make_shared<TensorAttributes>());
     attributesCopy = attributes;
     PointwiseNode nodeWithOutput(std::move(attributesCopy), graphAttributes);
 
     error = nodeWithOutput.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
-    attributes.set_mode(PointwiseMode_t::RELU_FWD);
+    attributes.set_mode(PointwiseMode::RELU_FWD);
     attributesCopy = attributes;
     PointwiseNode nodeWithAllValues(std::move(attributesCopy), graphAttributes);
 
     error = nodeWithAllValues.pre_validate_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 }
 
 TEST(TestPointwiseNode, InferPropertiesNode)
@@ -167,12 +167,12 @@ TEST(TestPointwiseNode, InferPropertiesNode)
     PointwiseAttributes attributes;
     attributes.set_input_0(std::make_shared<TensorAttributes>());
     attributes.set_output_0(std::make_shared<TensorAttributes>());
-    attributes.set_mode(PointwiseMode_t::RELU_FWD);
+    attributes.set_mode(PointwiseMode::RELU_FWD);
 
     auto inputTensor = attributes.get_input_0();
     inputTensor->set_uid(1)
         .set_name("InputTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({5, 6, 7, 8});
 
@@ -183,7 +183,7 @@ TEST(TestPointwiseNode, InferPropertiesNode)
     PointwiseNode node(std::move(attributes), graphAttributes);
 
     auto error = node.infer_properties_node();
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
 
     EXPECT_EQ(outputTensor->get_dim(), (std::vector<int64_t>{1, 2, 3, 4}));
     EXPECT_EQ(outputTensor->get_stride(), (std::vector<int64_t>{5, 6, 7, 8}));
@@ -197,7 +197,7 @@ TEST(TestPointwiseNode, PackNode)
     auto inputTensor = std::make_shared<TensorAttributes>();
     inputTensor->set_uid(1)
         .set_name("InputTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({4, 3, 2, 1});
     attributes.set_input_0(inputTensor);
@@ -205,12 +205,12 @@ TEST(TestPointwiseNode, PackNode)
     auto outputTensor = std::make_shared<TensorAttributes>();
     outputTensor->set_uid(2)
         .set_name("OutputTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_dim({1, 2, 3, 4})
         .set_stride({4, 3, 2, 1});
     attributes.set_output_0(outputTensor);
 
-    attributes.set_mode(PointwiseMode_t::RELU_FWD);
+    attributes.set_mode(PointwiseMode::RELU_FWD);
 
     GraphAttributes graphAttributes;
     PointwiseNode node(std::move(attributes), graphAttributes);
@@ -232,5 +232,5 @@ TEST(TestPointwiseNode, PackNode)
 
     EXPECT_EQ(packedAttributes->in_0_tensor_uid(), inputTensor->get_uid());
     EXPECT_EQ(packedAttributes->out_0_tensor_uid(), outputTensor->get_uid());
-    EXPECT_EQ(packedAttributes->operation(), static_cast<int>(PointwiseMode_t::RELU_FWD));
+    EXPECT_EQ(packedAttributes->operation(), static_cast<int>(PointwiseMode::RELU_FWD));
 }

--- a/frontend/tests/TestTensorAttributes.cpp
+++ b/frontend/tests/TestTensorAttributes.cpp
@@ -14,7 +14,7 @@ TEST(TestTensorAttributes, DefaultConstructor)
     TensorAttributes tensor;
     EXPECT_EQ(tensor.get_uid(), 0);
     EXPECT_EQ(tensor.get_name(), "");
-    EXPECT_EQ(tensor.get_data_type(), DataType_t::NOT_SET);
+    EXPECT_EQ(tensor.get_data_type(), DataType::NOT_SET);
     EXPECT_TRUE(tensor.get_stride().empty());
     EXPECT_TRUE(tensor.get_dim().empty());
     EXPECT_EQ(tensor.get_volume(), 1);
@@ -44,8 +44,8 @@ TEST(TestTensorAttributes, SetAndGetName)
 TEST(TestTensorAttributes, SetAndGetDataType)
 {
     TensorAttributes tensor;
-    tensor.set_data_type(DataType_t::FLOAT);
-    EXPECT_EQ(tensor.get_data_type(), DataType_t::FLOAT);
+    tensor.set_data_type(DataType::FLOAT);
+    EXPECT_EQ(tensor.get_data_type(), DataType::FLOAT);
 }
 
 TEST(TestTensorAttributes, SetAndGetStride)
@@ -86,16 +86,16 @@ TEST(TestTensorAttributes, SetOutput)
 TEST(TestTensorAttributes, SetFromGraphAttributes)
 {
     GraphAttributes graphAttributes;
-    graphAttributes.set_io_data_type(DataType_t::FLOAT);
-    graphAttributes.set_intermediate_data_type(DataType_t::HALF);
+    graphAttributes.set_io_data_type(DataType::FLOAT);
+    graphAttributes.set_intermediate_data_type(DataType::HALF);
 
     TensorAttributes tensor;
     tensor.set_is_virtual(false).fill_from_context(graphAttributes);
-    EXPECT_EQ(tensor.get_data_type(), DataType_t::FLOAT);
+    EXPECT_EQ(tensor.get_data_type(), DataType::FLOAT);
 
-    tensor.set_data_type(DataType_t::NOT_SET);
+    tensor.set_data_type(DataType::NOT_SET);
     tensor.set_is_virtual(true).fill_from_context(graphAttributes);
-    EXPECT_EQ(tensor.get_data_type(), DataType_t::HALF);
+    EXPECT_EQ(tensor.get_data_type(), DataType::HALF);
 }
 
 TEST(TestTensorAttributes, PackAttributes)
@@ -103,7 +103,7 @@ TEST(TestTensorAttributes, PackAttributes)
     TensorAttributes tensor;
     tensor.set_uid(1)
         .set_name("PackedTensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(DataType::FLOAT)
         .set_stride({1, 2, 3})
         .set_dim({4, 5, 6})
         .set_is_virtual(true);

--- a/frontend/tests/TestTensorValueAttributes.cpp
+++ b/frontend/tests/TestTensorValueAttributes.cpp
@@ -11,7 +11,6 @@
 #include <vector>
 
 // using namespace hipdnn_frontend::graph;
-using hipdnn_frontend::DataType_t;
 using namespace hipdnn_sdk::data_objects;
 
 TEST(TestTensorValueAttributes, SetGetClearFloat)
@@ -47,7 +46,7 @@ TEST(TestTensorValueAttributes, PackUnpackFloatValue)
     hipdnn_frontend::graph::TensorAttributes tensor;
     tensor.set_uid(7)
         .set_name("value_tensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_stride({1, 2})
         .set_dim({3, 4})
         .set_is_virtual(false)
@@ -95,7 +94,7 @@ TEST(TestTensorValueAttributes, PackUnpackHalfValue)
     hipdnn_frontend::graph::TensorAttributes tensor;
     tensor.set_uid(8)
         .set_name("half_tensor")
-        .set_data_type(DataType_t::HALF)
+        .set_data_type(hipdnn_frontend::DataType::HALF)
         .set_is_virtual(false)
         .set_value(1.0_h);
 
@@ -123,7 +122,7 @@ TEST(TestTensorValueAttributes, PackUnpackBFloat1Value)
     hipdnn_frontend::graph::TensorAttributes tensor;
     tensor.set_uid(8)
         .set_name("half_tensor")
-        .set_data_type(DataType_t::BFLOAT16)
+        .set_data_type(hipdnn_frontend::DataType::BFLOAT16)
         .set_is_virtual(false)
         .set_value(1.0_bf);
 
@@ -151,7 +150,7 @@ TEST(TestTensorValueAttributes, PackUnpackDoubleValue)
     hipdnn_frontend::graph::TensorAttributes tensor;
     tensor.set_uid(9)
         .set_name("double_tensor")
-        .set_data_type(DataType_t::DOUBLE)
+        .set_data_type(hipdnn_frontend::DataType::DOUBLE)
         .set_is_virtual(false)
         .set_value(std::numbers::pi_v<double>);
 
@@ -179,7 +178,7 @@ TEST(TestTensorValueAttributes, PackUnpackEmptyValue)
     hipdnn_frontend::graph::TensorAttributes tensor;
     tensor.set_uid(10)
         .set_name("empty_tensor")
-        .set_data_type(DataType_t::FLOAT)
+        .set_data_type(hipdnn_frontend::DataType::FLOAT)
         .set_stride({1, 2})
         .set_dim({3, 4})
         .set_is_virtual(true);

--- a/frontend/tests/TestTypes.cpp
+++ b/frontend/tests/TestTypes.cpp
@@ -9,25 +9,24 @@ TEST(TestTypes, DataTypeConversion)
 {
     using namespace hipdnn_frontend;
 
-    EXPECT_EQ(toSdkType(DataType_t::FLOAT), hipdnn_sdk::data_objects::DataType::DataType_FLOAT);
-    EXPECT_EQ(toSdkType(DataType_t::HALF), hipdnn_sdk::data_objects::DataType::DataType_HALF);
-    EXPECT_EQ(toSdkType(DataType_t::BFLOAT16),
-              hipdnn_sdk::data_objects::DataType::DataType_BFLOAT16);
-    EXPECT_EQ(toSdkType(DataType_t::DOUBLE), hipdnn_sdk::data_objects::DataType::DataType_DOUBLE);
-    EXPECT_EQ(toSdkType(DataType_t::UINT8), hipdnn_sdk::data_objects::DataType::DataType_UINT8);
-    EXPECT_EQ(toSdkType(DataType_t::INT32), hipdnn_sdk::data_objects::DataType::DataType_INT32);
-    EXPECT_EQ(toSdkType(DataType_t::NOT_SET), hipdnn_sdk::data_objects::DataType::DataType_UNSET);
+    EXPECT_EQ(toSdkType(DataType::FLOAT), hipdnn_sdk::data_objects::DataType::DataType_FLOAT);
+    EXPECT_EQ(toSdkType(DataType::HALF), hipdnn_sdk::data_objects::DataType::DataType_HALF);
+    EXPECT_EQ(toSdkType(DataType::BFLOAT16), hipdnn_sdk::data_objects::DataType::DataType_BFLOAT16);
+    EXPECT_EQ(toSdkType(DataType::DOUBLE), hipdnn_sdk::data_objects::DataType::DataType_DOUBLE);
+    EXPECT_EQ(toSdkType(DataType::UINT8), hipdnn_sdk::data_objects::DataType::DataType_UINT8);
+    EXPECT_EQ(toSdkType(DataType::INT32), hipdnn_sdk::data_objects::DataType::DataType_INT32);
+    EXPECT_EQ(toSdkType(DataType::NOT_SET), hipdnn_sdk::data_objects::DataType::DataType_UNSET);
 }
 
 TEST(TestTypes, ConvolutionModeConversion)
 {
     using namespace hipdnn_frontend;
 
-    EXPECT_EQ(toSdkType(ConvolutionMode_t::CROSS_CORRELATION),
+    EXPECT_EQ(toSdkType(ConvolutionMode::CROSS_CORRELATION),
               hipdnn_sdk::data_objects::ConvMode::ConvMode_CROSS_CORRELATION);
-    EXPECT_EQ(toSdkType(ConvolutionMode_t::CONVOLUTION),
+    EXPECT_EQ(toSdkType(ConvolutionMode::CONVOLUTION),
               hipdnn_sdk::data_objects::ConvMode::ConvMode_CONVOLUTION);
-    EXPECT_EQ(toSdkType(ConvolutionMode_t::NOT_SET),
+    EXPECT_EQ(toSdkType(ConvolutionMode::NOT_SET),
               hipdnn_sdk::data_objects::ConvMode::ConvMode_UNSET);
 }
 
@@ -35,9 +34,9 @@ TEST(TestTypes, PointwiseModeConversion)
 {
     using namespace hipdnn_frontend;
 
-    EXPECT_EQ(toSdkType(PointwiseMode_t::RELU_FWD),
+    EXPECT_EQ(toSdkType(PointwiseMode::RELU_FWD),
               hipdnn_sdk::data_objects::PointwiseMode::PointwiseMode_RELU_FWD);
-    EXPECT_EQ(toSdkType(PointwiseMode_t::NOT_SET),
+    EXPECT_EQ(toSdkType(PointwiseMode::NOT_SET),
               hipdnn_sdk::data_objects::PointwiseMode::PointwiseMode_UNSET);
 }
 
@@ -45,7 +44,7 @@ TEST(TestTypes, HeuristicModeConversion)
 {
     using namespace hipdnn_frontend;
 
-    EXPECT_EQ(toBackendType(HeurMode_t::FALLBACK),
+    EXPECT_EQ(toBackendType(HeuristicMode::FALLBACK),
               hipdnnBackendHeurMode_t::HIPDNN_HEUR_MODE_FALLBACK);
 }
 
@@ -53,28 +52,28 @@ TEST(TestTypes, GetDataTypeEnumFromType)
 {
     using namespace hipdnn_frontend;
 
-    EXPECT_EQ(getDataTypeEnumFromType<float>(), DataType_t::FLOAT);
-    EXPECT_EQ(getDataTypeEnumFromType<half>(), DataType_t::HALF);
-    EXPECT_EQ(getDataTypeEnumFromType<hip_bfloat16>(), DataType_t::BFLOAT16);
-    EXPECT_EQ(getDataTypeEnumFromType<double>(), DataType_t::DOUBLE);
-    EXPECT_EQ(getDataTypeEnumFromType<uint8_t>(), DataType_t::UINT8);
-    EXPECT_EQ(getDataTypeEnumFromType<int32_t>(), DataType_t::INT32);
+    EXPECT_EQ(getDataTypeEnumFromType<float>(), DataType::FLOAT);
+    EXPECT_EQ(getDataTypeEnumFromType<half>(), DataType::HALF);
+    EXPECT_EQ(getDataTypeEnumFromType<hip_bfloat16>(), DataType::BFLOAT16);
+    EXPECT_EQ(getDataTypeEnumFromType<double>(), DataType::DOUBLE);
+    EXPECT_EQ(getDataTypeEnumFromType<uint8_t>(), DataType::UINT8);
+    EXPECT_EQ(getDataTypeEnumFromType<int32_t>(), DataType::INT32);
 
-    EXPECT_EQ(getDataTypeEnumFromType<float*>(), DataType_t::NOT_SET);
-    EXPECT_EQ(getDataTypeEnumFromType<char>(), DataType_t::NOT_SET);
+    EXPECT_EQ(getDataTypeEnumFromType<float*>(), DataType::NOT_SET);
+    EXPECT_EQ(getDataTypeEnumFromType<char>(), DataType::NOT_SET);
 }
 
 TEST(TestTypes, DataTypeToString)
 {
     using namespace hipdnn_frontend;
 
-    EXPECT_STREQ(to_string(DataType_t::FLOAT), "fp32");
-    EXPECT_STREQ(to_string(DataType_t::HALF), "fp16");
-    EXPECT_STREQ(to_string(DataType_t::BFLOAT16), "bf16");
-    EXPECT_STREQ(to_string(DataType_t::DOUBLE), "fp64");
-    EXPECT_STREQ(to_string(DataType_t::UINT8), "uint8");
-    EXPECT_STREQ(to_string(DataType_t::INT32), "int32");
-    EXPECT_STREQ(to_string(DataType_t::NOT_SET), "unknown");
+    EXPECT_STREQ(to_string(DataType::FLOAT), "fp32");
+    EXPECT_STREQ(to_string(DataType::HALF), "fp16");
+    EXPECT_STREQ(to_string(DataType::BFLOAT16), "bf16");
+    EXPECT_STREQ(to_string(DataType::DOUBLE), "fp64");
+    EXPECT_STREQ(to_string(DataType::UINT8), "uint8");
+    EXPECT_STREQ(to_string(DataType::INT32), "int32");
+    EXPECT_STREQ(to_string(DataType::NOT_SET), "unknown");
 }
 
 TEST(TestTypes, DataTypeStreamOperator)
@@ -83,30 +82,30 @@ TEST(TestTypes, DataTypeStreamOperator)
 
     std::ostringstream oss;
 
-    oss << DataType_t::FLOAT;
+    oss << DataType::FLOAT;
     EXPECT_EQ(oss.str(), "fp32");
     oss.str("");
 
-    oss << DataType_t::HALF;
+    oss << DataType::HALF;
     EXPECT_EQ(oss.str(), "fp16");
     oss.str("");
 
-    oss << DataType_t::BFLOAT16;
+    oss << DataType::BFLOAT16;
     EXPECT_EQ(oss.str(), "bf16");
     oss.str("");
 
-    oss << DataType_t::DOUBLE;
+    oss << DataType::DOUBLE;
     EXPECT_EQ(oss.str(), "fp64");
     oss.str("");
 
-    oss << DataType_t::UINT8;
+    oss << DataType::UINT8;
     EXPECT_EQ(oss.str(), "uint8");
     oss.str("");
 
-    oss << DataType_t::INT32;
+    oss << DataType::INT32;
     EXPECT_EQ(oss.str(), "int32");
     oss.str("");
 
-    oss << DataType_t::NOT_SET;
+    oss << DataType::NOT_SET;
     EXPECT_EQ(oss.str(), "unknown");
 }

--- a/frontend/tests/TestUtilities.cpp
+++ b/frontend/tests/TestUtilities.cpp
@@ -14,7 +14,7 @@ TEST(TestUtilities, FindCommonShapeValid)
     std::vector<int64_t> commonShape;
 
     auto error = findCommonShape(inputShapes, commonShape);
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
     EXPECT_EQ(commonShape, (std::vector<int64_t>{1, 2, 3}));
 }
 
@@ -24,7 +24,7 @@ TEST(TestUtilities, FindCommonShapeEmptyInput)
     std::vector<int64_t> commonShape;
 
     auto error = findCommonShape(inputShapes, commonShape);
-    EXPECT_EQ(error.code, error_code_t::INVALID_VALUE);
+    EXPECT_EQ(error.code, ErrorCode::INVALID_VALUE);
 }
 
 TEST(TestUtilities, FindCommonShapeIncompatibleShapes)
@@ -33,7 +33,7 @@ TEST(TestUtilities, FindCommonShapeIncompatibleShapes)
     std::vector<int64_t> commonShape;
 
     auto error = findCommonShape(inputShapes, commonShape);
-    EXPECT_EQ(error.code, error_code_t::INVALID_VALUE);
+    EXPECT_EQ(error.code, ErrorCode::INVALID_VALUE);
 }
 
 TEST(TestUtilities, FindCommonShapeSingleInput)
@@ -42,6 +42,6 @@ TEST(TestUtilities, FindCommonShapeSingleInput)
     std::vector<int64_t> commonShape;
 
     auto error = findCommonShape(inputShapes, commonShape);
-    EXPECT_EQ(error.code, error_code_t::OK);
+    EXPECT_EQ(error.code, ErrorCode::OK);
     EXPECT_EQ(commonShape, (std::vector<int64_t>{1, 2, 3}));
 }

--- a/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackward.cpp
+++ b/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackward.cpp
@@ -149,8 +149,8 @@ protected:
     }
 
     void runMiopenBatchnormBwd(Batchnorm2dTensorBundle& graphTensorBundle,
-                               DataType_t inputDataType,
-                               DataType_t intermediateDataType)
+                               hipdnn_frontend::DataType inputDataType,
+                               hipdnn_frontend::DataType intermediateDataType)
     {
         auto graphObj = std::make_shared<hipdnn_frontend::graph::Graph>();
 
@@ -214,19 +214,19 @@ protected:
         dbiasTensorAttr->set_data_type(intermediateDataType);
 
         auto result = graphObj->validate();
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         result = graphObj->build_operation_graph(_handle);
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
-        result = graphObj->create_execution_plans(_handle);
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        result = graphObj->create_execution_plans();
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         result = graphObj->check_support();
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         result = graphObj->build_plans();
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         auto variantPack = createVariantPack(*xTensorAttr,
                                              *dyTensorAttr,
@@ -239,7 +239,7 @@ protected:
                                              graphTensorBundle);
 
         result = graphObj->execute(_handle, variantPack, _stream);
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
     }
 
     void runCpuBatchnormBwd(Batchnorm2dTensorBundle& cpuTensorBundle)

--- a/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
+++ b/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
@@ -143,8 +143,8 @@ protected:
     }
 
     void runMiopenBatchnormFwd(Batchnorm2dTensorBundle& graphTensorBundle,
-                               DataType_t inputDataType,
-                               DataType_t intermediateDataType)
+                               hipdnn_frontend::DataType inputDataType,
+                               hipdnn_frontend::DataType intermediateDataType)
     {
         auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
 
@@ -196,19 +196,19 @@ protected:
 
         // Validate and build graph
         auto result = graph->validate();
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         result = graph->build_operation_graph(_handle);
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
-        result = graph->create_execution_plans(_handle);
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        result = graph->create_execution_plans();
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         result = graph->check_support();
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         result = graph->build_plans();
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         auto variantPack = createVariantPack(*xTensorAttr,
                                              *yTensorAttr,
@@ -219,7 +219,7 @@ protected:
                                              graphTensorBundle);
 
         result = graph->execute(_handle, variantPack, _stream);
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
     }
 
     void runCpuBatchnormFwd(Batchnorm2dTensorBundle& cpuTensorBundle)

--- a/samples/batchnorm/BnBackward.cpp
+++ b/samples/batchnorm/BnBackward.cpp
@@ -60,7 +60,7 @@ void SampleRunner::operator()(const TensorLayout& layout)
     HIPDNN_FE_CHECK(graph->build_operation_graph(handle));
     std::cout << "Operation graph build successful.\n";
 
-    HIPDNN_FE_CHECK(graph->create_execution_plans(handle));
+    HIPDNN_FE_CHECK(graph->create_execution_plans());
     std::cout << "Execution plans created successfully.\n";
 
     HIPDNN_FE_CHECK(graph->check_support());

--- a/samples/batchnorm/BnInference.cpp
+++ b/samples/batchnorm/BnInference.cpp
@@ -55,7 +55,7 @@ void SampleRunner::operator()(const TensorLayout& layout)
     HIPDNN_FE_CHECK(graph->build_operation_graph(handle));
     std::cout << "Operation graph build successful.\n";
 
-    HIPDNN_FE_CHECK(graph->create_execution_plans(handle));
+    HIPDNN_FE_CHECK(graph->create_execution_plans());
     std::cout << "Execution plans created successfully.\n";
 
     HIPDNN_FE_CHECK(graph->check_support());

--- a/samples/batchnorm/BnTraining.cpp
+++ b/samples/batchnorm/BnTraining.cpp
@@ -66,7 +66,7 @@ void SampleRunner::operator()(const TensorLayout& layout)
     HIPDNN_FE_CHECK(graph->build_operation_graph(handle));
     std::cout << "Operation graph build successful.\n";
 
-    HIPDNN_FE_CHECK(graph->create_execution_plans(handle));
+    HIPDNN_FE_CHECK(graph->create_execution_plans());
     std::cout << "Execution plans created successfully.\n";
 
     HIPDNN_FE_CHECK(graph->check_support());

--- a/tests/frontend/FrontendIntegrationTest.cpp
+++ b/tests/frontend/FrontendIntegrationTest.cpp
@@ -161,14 +161,14 @@ protected:
         int64_t uid = 1;
         BatchnormTestTensors tensors;
 
-        auto xAttr = makeTensorAttributes("X", DataType_t::FLOAT, tensorBundle.xTensor);
+        auto xAttr = makeTensorAttributes("X", DataType::FLOAT, tensorBundle.xTensor);
         if(useManualUids)
         {
             xAttr.set_uid(uid++);
         }
         tensors.x = std::make_shared<TensorAttributes>(std::move(xAttr));
 
-        auto meanAttr = makeTensorAttributes("mean", DataType_t::FLOAT, tensorBundle.meanTensor);
+        auto meanAttr = makeTensorAttributes("mean", DataType::FLOAT, tensorBundle.meanTensor);
         if(useManualUids)
         {
             meanAttr.set_uid(uid++);
@@ -176,21 +176,21 @@ protected:
         tensors.mean = std::make_shared<TensorAttributes>(std::move(meanAttr));
 
         auto invVarianceAttr
-            = makeTensorAttributes("inv_variance", DataType_t::FLOAT, tensorBundle.varianceTensor);
+            = makeTensorAttributes("inv_variance", DataType::FLOAT, tensorBundle.varianceTensor);
         if(useManualUids)
         {
             invVarianceAttr.set_uid(uid++);
         }
         tensors.invVariance = std::make_shared<TensorAttributes>(std::move(invVarianceAttr));
 
-        auto scaleAttr = makeTensorAttributes("scale", DataType_t::FLOAT, tensorBundle.scaleTensor);
+        auto scaleAttr = makeTensorAttributes("scale", DataType::FLOAT, tensorBundle.scaleTensor);
         if(useManualUids)
         {
             scaleAttr.set_uid(uid++);
         }
         tensors.scale = std::make_shared<TensorAttributes>(std::move(scaleAttr));
 
-        auto biasAttr = makeTensorAttributes("bias", DataType_t::FLOAT, tensorBundle.biasTensor);
+        auto biasAttr = makeTensorAttributes("bias", DataType::FLOAT, tensorBundle.biasTensor);
         if(useManualUids)
         {
             biasAttr.set_uid(uid++);
@@ -207,7 +207,7 @@ protected:
         {
             tensors.y->set_uid(uid++);
         }
-        tensors.y->set_data_type(DataType_t::FLOAT);
+        tensors.y->set_data_type(DataType::FLOAT);
 
         return {graph, tensors};
     }
@@ -235,24 +235,24 @@ protected:
                                  FailurePoint expectedFailure = FailurePoint::NONE)
     {
         auto result = graph->validate();
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         result = graph->build_operation_graph(handle);
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
-        result = graph->create_execution_plans(handle);
+        result = graph->create_execution_plans();
         if(expectedFailure == FailurePoint::CREATE_EXECUTION_PLAN)
         {
-            ASSERT_NE(result.code, error_code_t::OK) << "create_execution_plans should fail";
+            ASSERT_NE(result.code, ErrorCode::OK) << "create_execution_plans should fail";
             return;
         }
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         result = graph->check_support();
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         result = graph->build_plans();
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         ASSERT_TRUE(tensors.x->has_uid());
         ASSERT_TRUE(tensors.mean->has_uid());
@@ -266,11 +266,11 @@ protected:
         result = graph->execute(handle, variantPack, nullptr);
         if(expectedFailure == FailurePoint::EXECUTE)
         {
-            ASSERT_NE(result.code, error_code_t::OK) << "Execute should fail";
+            ASSERT_NE(result.code, ErrorCode::OK) << "Execute should fail";
         }
         else
         {
-            ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+            ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
         }
     }
 

--- a/tests/frontend/IntegrationBatchnormForwardInference.cpp
+++ b/tests/frontend/IntegrationBatchnormForwardInference.cpp
@@ -235,24 +235,24 @@ protected:
                                  FailurePoint expectedFailure = FailurePoint::NONE)
     {
         auto result = graph->validate();
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         result = graph->build_operation_graph(handle);
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
-        result = graph->create_execution_plans(handle);
+        result = graph->create_execution_plans();
         if(expectedFailure == FailurePoint::CREATE_EXECUTION_PLAN)
         {
-            ASSERT_NE(result.code, error_code_t::OK) << "create_execution_plans should fail";
+            ASSERT_NE(result.code, ErrorCode::OK) << "create_execution_plans should fail";
             return;
         }
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         result = graph->check_support();
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         result = graph->build_plans();
-        ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+        ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
 
         ASSERT_TRUE(tensors.x->has_uid());
         ASSERT_TRUE(tensors.mean->has_uid());
@@ -266,11 +266,11 @@ protected:
         result = graph->execute(handle, variantPack, nullptr);
         if(expectedFailure == FailurePoint::EXECUTE)
         {
-            ASSERT_NE(result.code, error_code_t::OK) << "Execute should fail";
+            ASSERT_NE(result.code, ErrorCode::OK) << "Execute should fail";
         }
         else
         {
-            ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+            ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
         }
     }
 


### PR DESCRIPTION
## Proposed changes

 Update frontend types to match naming rules, and use typedefs for alternative names.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [X] I have added automated tests relevant to the introduced functionality
- [X] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [X] I have ran the tests, and they are all passing locally
- [] I have ran the tests with ASAN, and they are all passing locally
- [X] I have added relevant documentation for the changes
- [X] I have removed the stale documentation which is no longer relevant after this pull request
- [X] I have ran `make format` & `make check_format` to ensure the changes have been formatted
