### PR TITLE
Cleanup remaining usage of maybe_unused to match standards

### DIFF
--- a/backend/src/descriptors/EngineDescriptor.cpp
+++ b/backend/src/descriptors/EngineDescriptor.cpp
@@ -42,10 +42,10 @@ void EngineDescriptor::finalize()
 }
 
 void EngineDescriptor::getAttribute(hipdnnBackendAttributeName_t attributeName,
-                                    [[maybe_unused]] hipdnnBackendAttributeType_t attributeType,
-                                    [[maybe_unused]] int64_t requestedElementCount,
-                                    [[maybe_unused]] int64_t* elementCount,
-                                    [[maybe_unused]] void* arrayOfElements) const
+                                    hipdnnBackendAttributeType_t attributeType,
+                                    int64_t requestedElementCount,
+                                    int64_t* elementCount,
+                                    void* arrayOfElements) const
 {
     THROW_IF_FALSE(isFinalized(),
                    HIPDNN_STATUS_NOT_INITIALIZED,

--- a/backend/src/descriptors/GraphDescriptor.hpp
+++ b/backend/src/descriptors/GraphDescriptor.hpp
@@ -27,16 +27,16 @@ private:
 public:
     void finalize() override;
 
-    void getAttribute([[maybe_unused]] hipdnnBackendAttributeName_t attributeName,
-                      [[maybe_unused]] hipdnnBackendAttributeType_t attributeType,
-                      [[maybe_unused]] int64_t requestedElementCount,
-                      [[maybe_unused]] int64_t* elementCount,
-                      [[maybe_unused]] void* arrayOfElements) const override;
+    void getAttribute(hipdnnBackendAttributeName_t attributeName,
+                      hipdnnBackendAttributeType_t attributeType,
+                      int64_t requestedElementCount,
+                      int64_t* elementCount,
+                      void* arrayOfElements) const override;
 
-    void setAttribute([[maybe_unused]] hipdnnBackendAttributeName_t attributeName,
-                      [[maybe_unused]] hipdnnBackendAttributeType_t attributeType,
-                      [[maybe_unused]] int64_t elementCount,
-                      [[maybe_unused]] const void* arrayOfElements) override;
+    void setAttribute(hipdnnBackendAttributeName_t attributeName,
+                      hipdnnBackendAttributeType_t attributeType,
+                      int64_t elementCount,
+                      const void* arrayOfElements) override;
 
     void deserializeGraph(const uint8_t* serializedGraph, size_t graphByteSize);
 

--- a/frontend/include/hipdnn_frontend/Types.hpp
+++ b/frontend/include/hipdnn_frontend/Types.hpp
@@ -78,7 +78,7 @@ DataType getDataTypeEnumFromType()
     }
 }
 
-[[maybe_unused]] static hipdnn_sdk::data_objects::ConvMode toSdkType(const ConvolutionMode& type)
+inline hipdnn_sdk::data_objects::ConvMode toSdkType(const ConvolutionMode& type)
 {
     switch(type)
     {
@@ -91,7 +91,7 @@ DataType getDataTypeEnumFromType()
     }
 }
 
-[[maybe_unused]] static hipdnn_sdk::data_objects::DataType toSdkType(const DataType& type)
+inline hipdnn_sdk::data_objects::DataType toSdkType(const DataType& type)
 {
     switch(type)
     {
@@ -112,7 +112,7 @@ DataType getDataTypeEnumFromType()
     }
 }
 
-[[maybe_unused]] static hipdnn_sdk::data_objects::PointwiseMode toSdkType(const PointwiseMode& type)
+inline hipdnn_sdk::data_objects::PointwiseMode toSdkType(const PointwiseMode& type)
 {
     switch(type)
     {
@@ -123,7 +123,7 @@ DataType getDataTypeEnumFromType()
     }
 }
 
-[[maybe_unused]] static hipdnnBackendHeurMode_t toBackendType(const HeuristicMode& type)
+inline hipdnnBackendHeurMode_t toBackendType(const HeuristicMode& type)
 {
     switch(type)
     {
@@ -135,7 +135,7 @@ DataType getDataTypeEnumFromType()
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-[[maybe_unused]] static const char* to_string(const DataType& type)
+inline const char* to_string(const DataType& type)
 {
     switch(type)
     {
@@ -156,7 +156,7 @@ DataType getDataTypeEnumFromType()
     }
 }
 
-[[maybe_unused]] static std::ostream& operator<<(std::ostream& os, const DataType& type)
+inline std::ostream& operator<<(std::ostream& os, const DataType& type)
 {
     return os << to_string(type);
 }

--- a/frontend/include/hipdnn_frontend/backend/ScopedHipdnnBackendDescriptor.hpp
+++ b/frontend/include/hipdnn_frontend/backend/ScopedHipdnnBackendDescriptor.hpp
@@ -18,10 +18,7 @@ private:
     hipdnnBackendDescriptor_t _descriptor;
     bool _valid;
 
-    // For some reason clang isnt picking up the usage of the two variables correctly.
-    // Ive marked them as [[maybe_unused]] to avoid warnings.
-    static void logBackendError([[maybe_unused]] const std::string& errorString,
-                                [[maybe_unused]] const hipdnnStatus_t status)
+    static void logBackendError(const std::string& errorString, const hipdnnStatus_t status)
     {
         std::array<char, HIPDNN_ERROR_STRING_MAX_LENGTH> backendErrMsg;
         hipdnn_frontend::hipdnnBackend()->getLastErrorString(backendErrMsg.data(),

--- a/sdk/tests/utilities/TestCallbackLogger.cpp
+++ b/sdk/tests/utilities/TestCallbackLogger.cpp
@@ -17,7 +17,7 @@ static std::mutex s_logMutex; //NOLINT
 
 // Custom callback for testing. It doesn't fully simulate the real logging behavior,
 // but the backend tests use the true callback function. The test could use the backend callback, but then it has to link against the backend.
-void testLoggingCallback(hipdnnSeverity_t severity [[maybe_unused]], const char* msg)
+void testLoggingCallback([[maybe_unused]] hipdnnSeverity_t severity, const char* msg)
 {
     std::lock_guard<std::mutex> lock(s_logMutex);
     if(msg != nullptr)

--- a/tests/backend/TestUtil.hpp
+++ b/tests/backend/TestUtil.hpp
@@ -49,10 +49,10 @@ void populateTestExecutionPlan(hipdnnBackendDescriptor_t* executionPlan,
 
 flatbuffers::FlatBufferBuilder createAndPopulateBatchnormNode();
 
-void* allocateTensorMemory([[maybe_unused]] const int64_t* dims,
-                           [[maybe_unused]] size_t dimsCount,
-                           [[maybe_unused]] hipdnnBackendAttributeType_t dataType,
-                           [[maybe_unused]] bool initialize);
+void* allocateTensorMemory(const int64_t* dims,
+                           size_t dimsCount,
+                           hipdnnBackendAttributeType_t dataType,
+                           bool initialize);
 
 void freeTensorMemory(void* dataPtr);
 


### PR DESCRIPTION
## Proposed changes

A few places using [[maybe_unused]] were not needed, or were not follow our recommendations.
Updated to follow recommendations.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [X] I have added automated tests relevant to the introduced functionality
- [X] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [X] I have ran the tests, and they are all passing locally
- [X] I have ran the tests with ASAN, and they are all passing locally
- [X] I have added relevant documentation for the changes
- [X] I have removed the stale documentation which is no longer relevant after this pull request
- [X] I have ran `make format` & `make check_format` to ensure the changes have been formatted
