### PR TITLE
Add clang format from apt-get instead of forcing /opt/rocm version

### DIFF
--- a/cmake/ClangCheck.cmake
+++ b/cmake/ClangCheck.cmake
@@ -2,7 +2,12 @@
 # SPDX-License-Identifier:  MIT
 
 set(CLANG_FORMAT_PRUNE -path "./build" -prune -o -path "./sdk/include/hipdnn_sdk/data_objects" -prune -o)
-set(CLANG_FORMAT_BINARY clang-format)
+find_program(CLANG_FORMAT_BINARY NAMES clang-format /opt/rocm/llvm/bin/clang-format)
+
+if(NOT CLANG_FORMAT_BINARY)
+    message(FATAL_ERROR "clang-format not found in PATH or /opt/rocm/llvm/bin")
+endif()
+
 add_custom_target(
     check_format
     COMMAND  find . ${CLANG_FORMAT_PRUNE} -regex ".*\\.\\(cpp\\|hpp\\|c\\|h\\)" -exec ${CLANG_FORMAT_BINARY} --dry-run --Werror {} +

--- a/cmake/ClangCheck.cmake
+++ b/cmake/ClangCheck.cmake
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier:  MIT
 
 set(CLANG_FORMAT_PRUNE -path "./build" -prune -o -path "./sdk/include/hipdnn_sdk/data_objects" -prune -o)
-set(CLANG_FORMAT_BINARY /opt/rocm/llvm/bin/clang-format)
+set(CLANG_FORMAT_BINARY clang-format)
 add_custom_target(
     check_format
     COMMAND  find . ${CLANG_FORMAT_PRUNE} -regex ".*\\.\\(cpp\\|hpp\\|c\\|h\\)" -exec ${CLANG_FORMAT_BINARY} --dry-run --Werror {} +

--- a/dockerfiles/Dockerfile.ubuntu24
+++ b/dockerfiles/Dockerfile.ubuntu24
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV HIP_PLATFORM=amd
 
 RUN apt-get update && apt-get install -y \
-    clang-format \
+    clang-format-18 \
     git \
     gdb \
     gfortran \

--- a/dockerfiles/Dockerfile.ubuntu24
+++ b/dockerfiles/Dockerfile.ubuntu24
@@ -13,6 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV HIP_PLATFORM=amd
 
 RUN apt-get update && apt-get install -y \
+    clang-format \
     git \
     gdb \
     gfortran \

--- a/tests/frontend/FrontendIntegrationTest.cpp
+++ b/tests/frontend/FrontendIntegrationTest.cpp
@@ -39,9 +39,9 @@ struct IntegrationTestCase
 
     friend std::ostream& operator<<(std::ostream& os, const IntegrationTestCase& tc)
     {
-        os << "BatchnormTestCase{"
-           << "plugin_path: " << tc.pluginPath << ", description: " << tc.description
-           << ", graph_name: " << tc.graphName << ", expected_failure: ";
+        os << "BatchnormTestCase{" << "plugin_path: " << tc.pluginPath
+           << ", description: " << tc.description << ", graph_name: " << tc.graphName
+           << ", expected_failure: ";
 
         switch(tc.expectedFailure)
         {

--- a/tests/frontend/IntegrationBatchnormForwardInference.cpp
+++ b/tests/frontend/IntegrationBatchnormForwardInference.cpp
@@ -39,9 +39,9 @@ struct IntegrationTestCase
 
     friend std::ostream& operator<<(std::ostream& os, const IntegrationTestCase& tc)
     {
-        os << "BatchnormTestCase{"
-           << "plugin_path: " << tc.pluginPath << ", description: " << tc.description
-           << ", graph_name: " << tc.graphName << ", expected_failure: ";
+        os << "BatchnormTestCase{" << "plugin_path: " << tc.pluginPath
+           << ", description: " << tc.description << ", graph_name: " << tc.graphName
+           << ", expected_failure: ";
 
         switch(tc.expectedFailure)
         {


### PR DESCRIPTION
## Proposed changes

With swapping docker to use TheRock version, clang-format is no longer included in /opt/rocm/llvm/bin. 
Swapping to instead use installed clang-format in the environment, and provide the apt-get version when installing.

Note:

May need to see how clang-format works in CI, and see if it flags these new fixes as problematic.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [X] I have added automated tests relevant to the introduced functionality
- [X] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [X] I have ran the tests, and they are all passing locally
- [X] I have ran the tests with ASAN, and they are all passing locally
- [X] I have added relevant documentation for the changes
- [X] I have removed the stale documentation which is no longer relevant after this pull request
- [X] I have ran `make format` & `make check_format` to ensure the changes have been formatted
