### PR TITLE
`HIP_DNN_SKIP_TESTS=ON` misses some testing code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,14 +132,16 @@ endif()
 # keep this after all build folder have been added so they have a chance to register their tests
 # using append_test_to_check_target
 
-create_test_name_validation_target()
+if(NOT HIP_DNN_SKIP_TESTS)
+    create_test_name_validation_target()
 
-finalize_custom_check_target()
-finalize_unit_check_target()
-finalize_integration_check_target()
+    finalize_custom_check_target()
+    finalize_unit_check_target()
+    finalize_integration_check_target()
 
-add_dependencies(check validate_test_names)
-add_dependencies(check_ctest validate_test_names)
+    add_dependencies(check validate_test_names)
+    add_dependencies(check_ctest validate_test_names)
+endif()
 
 if(CODE_COVERAGE)
     if(HIP_DNN_BUILD_PLUGINS)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -85,7 +85,7 @@ macro(_build_local)
         message(STATUS "=========== Adding ${dep_name} ===========")
     endif()
     _pushstate()
-    set(CMAKE_MESSAGE_INDENT "[${dep_name}] ")
+    set(CMAKE_MESSAGE_INDENT "${CMAKE_MESSAGE_INDENT}[${dep_name}] ")
     cmake_language(
         CALL _fetch_${dep_name} "${PARSE_VERSION}" "${PARSE_HASH}"
     )

--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -1,6 +1,10 @@
 # Copyright © Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier:  MIT
 
+if(HIP_DNN_SKIP_TESTS)
+    return()
+endif()
+
 hipdnn_add_dependency(GTest v1.16.0)
 include(GoogleTest)
 


### PR DESCRIPTION
## Proposed changes

This PR skips a few places in the build only needed for testing code `HIP_DNN_SKIP_TESTS=ON`. It also adds a small logging nicety while installing dependencies.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [ ] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [ ] I have ran the tests, and they are all passing locally
- [ ] I have ran the tests with ASAN, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] I have ran `make format` & `make check_format` to ensure the changes have been formatted
