### PR TITLE
Remove optional tensors from BN inference

### DIFF
--- a/frontend/include/hipdnn_frontend/attributes/BatchnormInferenceAttributes.hpp
+++ b/frontend/include/hipdnn_frontend/attributes/BatchnormInferenceAttributes.hpp
@@ -132,15 +132,13 @@ public:
         auto mean = get_mean();
         auto invVariance = get_inv_variance();
 
-        return hipdnn_sdk::data_objects::CreateBatchnormInferenceAttributes(
-            builder,
-            get_x()->get_uid(),
-            mean ? flatbuffers::Optional<int64_t>(mean->get_uid()) : flatbuffers::nullopt,
-            invVariance ? flatbuffers::Optional<int64_t>(invVariance->get_uid())
-                        : flatbuffers::nullopt,
-            get_scale()->get_uid(),
-            get_bias()->get_uid(),
-            get_y()->get_uid());
+        return hipdnn_sdk::data_objects::CreateBatchnormInferenceAttributes(builder,
+                                                                            get_x()->get_uid(),
+                                                                            mean->get_uid(),
+                                                                            invVariance->get_uid(),
+                                                                            get_scale()->get_uid(),
+                                                                            get_bias()->get_uid(),
+                                                                            get_y()->get_uid());
     }
 
 private:

--- a/frontend/include/hipdnn_frontend/node/BatchnormInferenceNode.hpp
+++ b/frontend/include/hipdnn_frontend/node/BatchnormInferenceNode.hpp
@@ -44,6 +44,16 @@ public:
             return {ErrorCode::ATTRIBUTE_NOT_SET,
                     "BatchnormInferenceNode missing y for pre-validation"};
         }
+        if(!attributes.get_mean())
+        {
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
+                    "BatchnormInferenceNode missing mean for pre-validation"};
+        }
+        if(!attributes.get_inv_variance())
+        {
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
+                    "BatchnormInferenceNode missing inv_variance for pre-validation"};
+        }
 
         return {};
     }

--- a/frontend/tests/TestBatchnormInferenceNode.cpp
+++ b/frontend/tests/TestBatchnormInferenceNode.cpp
@@ -42,6 +42,8 @@ TEST(TestBatchnormInferenceNode, PreValidateNode)
     batchnormAttributes.set_y(std::make_shared<TensorAttributes>());
     batchnormAttributes.set_scale(std::make_shared<TensorAttributes>());
     batchnormAttributes.set_bias(std::make_shared<TensorAttributes>());
+    batchnormAttributes.set_mean(std::make_shared<TensorAttributes>());
+    batchnormAttributes.set_inv_variance(std::make_shared<TensorAttributes>());
 
     GraphAttributes graphAttributes;
     BatchnormInferenceNode node(std::move(batchnormAttributes), graphAttributes);
@@ -82,6 +84,20 @@ TEST(TestBatchnormInferenceNode, PreValidateNodeMissingValues)
     EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
     batchnormAttributes.set_bias(std::make_shared<TensorAttributes>());
+    batchnormAttributesCopy = batchnormAttributes;
+    BatchnormInferenceNode nodeWithBias(std::move(batchnormAttributesCopy), graphAttributes);
+
+    error = nodeWithBias.pre_validate_node();
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
+
+    batchnormAttributes.set_mean(std::make_shared<TensorAttributes>());
+    batchnormAttributesCopy = batchnormAttributes;
+    BatchnormInferenceNode nodeWithMean(std::move(batchnormAttributesCopy), graphAttributes);
+
+    error = nodeWithMean.pre_validate_node();
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
+
+    batchnormAttributes.set_inv_variance(std::make_shared<TensorAttributes>());
     batchnormAttributesCopy = batchnormAttributes;
     BatchnormInferenceNode nodeWithAllValues(std::move(batchnormAttributesCopy), graphAttributes);
 
@@ -194,72 +210,6 @@ TEST(TestBatchnormInferenceNode, PackNode)
     EXPECT_EQ(packedAttributes->y_tensor_uid(), yTensor->get_uid());
     EXPECT_EQ(packedAttributes->mean_tensor_uid(), meanTensor->get_uid());
     EXPECT_EQ(packedAttributes->inv_variance_tensor_uid(), invVarianceTensor->get_uid());
-    EXPECT_EQ(packedAttributes->scale_tensor_uid(), scaleTensor->get_uid());
-    EXPECT_EQ(packedAttributes->bias_tensor_uid(), biasTensor->get_uid());
-}
-
-TEST(TestBatchnormInferenceNode, PackNodeWithoutMeanAndInvVariance)
-{
-    BatchnormInferenceAttributes batchnormAttributes;
-    batchnormAttributes.set_name("BatchnormInference");
-
-    auto xTensor = std::make_shared<TensorAttributes>();
-    xTensor->set_uid(1)
-        .set_name("XTensor")
-        .set_data_type(DataType::FLOAT)
-        .set_dim({1, 2, 3, 4})
-        .set_stride({4, 3, 2, 1});
-    batchnormAttributes.set_x(xTensor);
-
-    auto yTensor = std::make_shared<TensorAttributes>();
-    yTensor->set_uid(2)
-        .set_name("YTensor")
-        .set_data_type(DataType::FLOAT)
-        .set_dim({1, 2, 3, 4})
-        .set_stride({4, 3, 2, 1});
-    batchnormAttributes.set_y(yTensor);
-
-    auto scaleTensor = std::make_shared<TensorAttributes>();
-    scaleTensor->set_uid(3)
-        .set_name("ScaleTensor")
-        .set_data_type(DataType::FLOAT)
-        .set_dim({1, 2, 1, 1})
-        .set_stride({2, 1, 1, 1});
-    batchnormAttributes.set_scale(scaleTensor);
-
-    auto biasTensor = std::make_shared<TensorAttributes>();
-    biasTensor->set_uid(4)
-        .set_name("BiasTensor")
-        .set_data_type(DataType::FLOAT)
-        .set_dim({1, 2, 1, 1})
-        .set_stride({2, 1, 1, 1});
-    batchnormAttributes.set_bias(biasTensor);
-
-    // Do not set mean and inv_variance
-
-    GraphAttributes graphAttributes;
-    BatchnormInferenceNode node(std::move(batchnormAttributes), graphAttributes);
-
-    flatbuffers::FlatBufferBuilder builder;
-    auto offset = node.pack_node(builder);
-    EXPECT_NE(offset.o, 0);
-
-    builder.Finish(offset);
-    auto bufferPointer = builder.GetBufferPointer();
-    auto nodeFlatbuffer = flatbuffers::GetRoot<hipdnn_sdk::data_objects::Node>(bufferPointer);
-
-    EXPECT_STREQ(nodeFlatbuffer->name()->c_str(), "BatchnormInference");
-    EXPECT_EQ(nodeFlatbuffer->attributes_type(),
-              hipdnn_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes);
-
-    auto packedAttributes = nodeFlatbuffer->attributes_as_BatchnormInferenceAttributes();
-    ASSERT_NE(packedAttributes, nullptr);
-
-    EXPECT_EQ(packedAttributes->x_tensor_uid(), xTensor->get_uid());
-    EXPECT_EQ(packedAttributes->y_tensor_uid(), yTensor->get_uid());
-    EXPECT_EQ(packedAttributes->mean_tensor_uid(), flatbuffers::nullopt); // Verify mean is null
-    EXPECT_EQ(packedAttributes->inv_variance_tensor_uid(),
-              flatbuffers::nullopt); // Verify inv_variance is null
     EXPECT_EQ(packedAttributes->scale_tensor_uid(), scaleTensor->get_uid());
     EXPECT_EQ(packedAttributes->bias_tensor_uid(), biasTensor->get_uid());
 }

--- a/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormFwdInferencePlan.cpp
+++ b/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormFwdInferencePlan.cpp
@@ -18,16 +18,9 @@ BatchnormFwdInferenceParams::BatchnormFwdInferenceParams(
     , _y(miopen_utils::createTensor(tensorMap, attributes.y_tensor_uid()))
     , _scale(miopen_utils::createTensor(tensorMap, attributes.scale_tensor_uid()))
     , _bias(miopen_utils::createTensor(tensorMap, attributes.bias_tensor_uid()))
+    , _estMean(miopen_utils::createTensor(tensorMap, attributes.mean_tensor_uid()))
+    , _estVariance(miopen_utils::createTensor(tensorMap, attributes.inv_variance_tensor_uid()))
 {
-    if(attributes.mean_tensor_uid().has_value())
-    {
-        _estMean = miopen_utils::createTensor(tensorMap, attributes.mean_tensor_uid().value());
-    }
-    if(attributes.inv_variance_tensor_uid().has_value())
-    {
-        _estVariance
-            = miopen_utils::createTensor(tensorMap, attributes.inv_variance_tensor_uid().value());
-    }
 }
 
 const MiopenTensor& BatchnormFwdInferenceParams::x() const
@@ -50,12 +43,12 @@ const MiopenTensor& BatchnormFwdInferenceParams::bias() const
     return _bias;
 }
 
-const std::optional<MiopenTensor>& BatchnormFwdInferenceParams::estMean() const
+const MiopenTensor& BatchnormFwdInferenceParams::estMean() const
 {
     return _estMean;
 }
 
-const std::optional<MiopenTensor>& BatchnormFwdInferenceParams::estVariance() const
+const MiopenTensor& BatchnormFwdInferenceParams::estVariance() const
 {
     return _estVariance;
 }
@@ -84,20 +77,10 @@ void BatchnormFwdInferencePlan::execute(const HipdnnEnginePluginHandle& handle,
         _inferenceParams->scale().uid(), deviceBuffers, numDeviceBuffers);
     auto biasBuffer = miopen_utils::findDeviceBuffer(
         _inferenceParams->bias().uid(), deviceBuffers, numDeviceBuffers);
-
-    hipdnnPluginDeviceBuffer_t estMeanBuffer = {0, nullptr};
-    if(_inferenceParams->estMean().has_value())
-    {
-        estMeanBuffer = miopen_utils::findDeviceBuffer(
-            _inferenceParams->estMean().value().uid(), deviceBuffers, numDeviceBuffers);
-    }
-
-    hipdnnPluginDeviceBuffer_t estVarianceBuffer = {0, nullptr};
-    if(_inferenceParams->estVariance().has_value())
-    {
-        estVarianceBuffer = miopen_utils::findDeviceBuffer(
-            _inferenceParams->estVariance().value().uid(), deviceBuffers, numDeviceBuffers);
-    }
+    auto estMeanBuffer = miopen_utils::findDeviceBuffer(
+        _inferenceParams->estMean().uid(), deviceBuffers, numDeviceBuffers);
+    auto estVarianceBuffer = miopen_utils::findDeviceBuffer(
+        _inferenceParams->estVariance().uid(), deviceBuffers, numDeviceBuffers);
 
     THROW_ON_MIOPEN_FAILURE(miopenBatchNormalizationForwardInference_V2(
         handle.miopenHandle,
@@ -110,12 +93,8 @@ void BatchnormFwdInferencePlan::execute(const HipdnnEnginePluginHandle& handle,
         yBuffer.ptr,
         _inferenceParams->scale().tensorDescriptor(),
         _inferenceParams->bias().tensorDescriptor(),
-        _inferenceParams->estMean().has_value()
-            ? _inferenceParams->estMean().value().tensorDescriptor()
-            : nullptr,
-        _inferenceParams->estVariance().has_value()
-            ? _inferenceParams->estVariance().value().tensorDescriptor()
-            : nullptr,
+        _inferenceParams->estMean().tensorDescriptor(),
+        _inferenceParams->estVariance().tensorDescriptor(),
         scaleBuffer.ptr,
         biasBuffer.ptr,
         estMeanBuffer.ptr,

--- a/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormFwdInferencePlan.hpp
+++ b/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormFwdInferencePlan.hpp
@@ -24,18 +24,16 @@ public:
     const MiopenTensor& y() const;
     const MiopenTensor& scale() const;
     const MiopenTensor& bias() const;
-
-    const std::optional<MiopenTensor>& estMean() const;
-    const std::optional<MiopenTensor>& estVariance() const;
+    const MiopenTensor& estMean() const;
+    const MiopenTensor& estVariance() const;
 
 private:
     MiopenTensor _x;
     MiopenTensor _y;
     MiopenTensor _scale;
     MiopenTensor _bias;
-
-    std::optional<MiopenTensor> _estMean;
-    std::optional<MiopenTensor> _estVariance;
+    MiopenTensor _estMean;
+    MiopenTensor _estVariance;
 };
 
 class BatchnormFwdInferencePlan : public IPlan

--- a/plugins/miopen_legacy_plugin/tests/TestMiopenBatchnormFwdInferenceOperations.cpp
+++ b/plugins/miopen_legacy_plugin/tests/TestMiopenBatchnormFwdInferenceOperations.cpp
@@ -94,7 +94,7 @@ protected:
                                                            testCase.seed));
 
         auto batchnormBuilder = hipdnn_backend::test_utilities::createValidBatchnormGraph(
-            xTensor.strides(), xTensor.dims(), true, inputDataType);
+            xTensor.strides(), xTensor.dims(), inputDataType);
 
         hipdnnPluginConstData_t opGraph;
         opGraph.ptr = batchnormBuilder.GetBufferPointer();

--- a/plugins/miopen_legacy_plugin/tests/engines/plans/TestMiopenBatchnormFwdInferencePlan.cpp
+++ b/plugins/miopen_legacy_plugin/tests/engines/plans/TestMiopenBatchnormFwdInferencePlan.cpp
@@ -27,31 +27,6 @@ TEST(TestMiopenBatchnormFwdInferenceParams, InitializesAllTensorsFromValidGraph)
     EXPECT_NO_THROW(params.y());
     EXPECT_NO_THROW(params.scale());
     EXPECT_NO_THROW(params.bias());
-
-    // Optional tensors should be present
-    auto& meanOpt = params.estMean();
-    auto& varOpt = params.estVariance();
-    EXPECT_TRUE(meanOpt.has_value());
-    EXPECT_TRUE(varOpt.has_value());
-}
-
-TEST(TestMiopenBatchnormFwdInferenceParams, HandlesMissingOptionalTensors)
-{
-    // Create a valid batchnorm graph and remove mean/variance from tensor map
-    auto builder = hipdnn_backend::test_utilities::createValidBatchnormGraph(
-        {1, 1, 1, 1}, {1, 1, 1, 1}, false // Set has_optional_attributes to false
-    );
-    hipdnn_plugin::GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
-
-    // Get the batchnorm node and attributes
-    const auto& node = graph.getNode(0);
-    auto* attrs = node.attributes_as_BatchnormInferenceAttributes();
-    ASSERT_NE(attrs, nullptr);
-
-    const auto& tensorMap = graph.getTensorMap();
-    BatchnormFwdInferenceParams params(*attrs, tensorMap);
-
-    // Optional tensors should not be present
-    EXPECT_FALSE(params.estMean().has_value());
-    EXPECT_FALSE(params.estVariance().has_value());
+    EXPECT_NO_THROW(params.estMean());
+    EXPECT_NO_THROW(params.estVariance());
 }

--- a/sdk/include/hipdnn_sdk/data_objects/batchnorm_inference_attributes_generated.h
+++ b/sdk/include/hipdnn_sdk/data_objects/batchnorm_inference_attributes_generated.h
@@ -26,8 +26,8 @@ bool operator!=(const BatchnormInferenceAttributesT &lhs, const BatchnormInferen
 struct BatchnormInferenceAttributesT : public ::flatbuffers::NativeTable {
   typedef BatchnormInferenceAttributes TableType;
   int64_t x_tensor_uid = 0;
-  ::flatbuffers::Optional<int64_t> mean_tensor_uid = ::flatbuffers::nullopt;
-  ::flatbuffers::Optional<int64_t> inv_variance_tensor_uid = ::flatbuffers::nullopt;
+  int64_t mean_tensor_uid = 0;
+  int64_t inv_variance_tensor_uid = 0;
   int64_t scale_tensor_uid = 0;
   int64_t bias_tensor_uid = 0;
   int64_t y_tensor_uid = 0;
@@ -50,17 +50,17 @@ struct BatchnormInferenceAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuff
   bool mutate_x_tensor_uid(int64_t _x_tensor_uid = 0) {
     return SetField<int64_t>(VT_X_TENSOR_UID, _x_tensor_uid, 0);
   }
-  ::flatbuffers::Optional<int64_t> mean_tensor_uid() const {
-    return GetOptional<int64_t, int64_t>(VT_MEAN_TENSOR_UID);
+  int64_t mean_tensor_uid() const {
+    return GetField<int64_t>(VT_MEAN_TENSOR_UID, 0);
   }
-  bool mutate_mean_tensor_uid(int64_t _mean_tensor_uid) {
-    return SetField<int64_t>(VT_MEAN_TENSOR_UID, _mean_tensor_uid);
+  bool mutate_mean_tensor_uid(int64_t _mean_tensor_uid = 0) {
+    return SetField<int64_t>(VT_MEAN_TENSOR_UID, _mean_tensor_uid, 0);
   }
-  ::flatbuffers::Optional<int64_t> inv_variance_tensor_uid() const {
-    return GetOptional<int64_t, int64_t>(VT_INV_VARIANCE_TENSOR_UID);
+  int64_t inv_variance_tensor_uid() const {
+    return GetField<int64_t>(VT_INV_VARIANCE_TENSOR_UID, 0);
   }
-  bool mutate_inv_variance_tensor_uid(int64_t _inv_variance_tensor_uid) {
-    return SetField<int64_t>(VT_INV_VARIANCE_TENSOR_UID, _inv_variance_tensor_uid);
+  bool mutate_inv_variance_tensor_uid(int64_t _inv_variance_tensor_uid = 0) {
+    return SetField<int64_t>(VT_INV_VARIANCE_TENSOR_UID, _inv_variance_tensor_uid, 0);
   }
   int64_t scale_tensor_uid() const {
     return GetField<int64_t>(VT_SCALE_TENSOR_UID, 0);
@@ -103,10 +103,10 @@ struct BatchnormInferenceAttributesBuilder {
     fbb_.AddElement<int64_t>(BatchnormInferenceAttributes::VT_X_TENSOR_UID, x_tensor_uid, 0);
   }
   void add_mean_tensor_uid(int64_t mean_tensor_uid) {
-    fbb_.AddElement<int64_t>(BatchnormInferenceAttributes::VT_MEAN_TENSOR_UID, mean_tensor_uid);
+    fbb_.AddElement<int64_t>(BatchnormInferenceAttributes::VT_MEAN_TENSOR_UID, mean_tensor_uid, 0);
   }
   void add_inv_variance_tensor_uid(int64_t inv_variance_tensor_uid) {
-    fbb_.AddElement<int64_t>(BatchnormInferenceAttributes::VT_INV_VARIANCE_TENSOR_UID, inv_variance_tensor_uid);
+    fbb_.AddElement<int64_t>(BatchnormInferenceAttributes::VT_INV_VARIANCE_TENSOR_UID, inv_variance_tensor_uid, 0);
   }
   void add_scale_tensor_uid(int64_t scale_tensor_uid) {
     fbb_.AddElement<int64_t>(BatchnormInferenceAttributes::VT_SCALE_TENSOR_UID, scale_tensor_uid, 0);
@@ -131,8 +131,8 @@ struct BatchnormInferenceAttributesBuilder {
 inline ::flatbuffers::Offset<BatchnormInferenceAttributes> CreateBatchnormInferenceAttributes(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     int64_t x_tensor_uid = 0,
-    ::flatbuffers::Optional<int64_t> mean_tensor_uid = ::flatbuffers::nullopt,
-    ::flatbuffers::Optional<int64_t> inv_variance_tensor_uid = ::flatbuffers::nullopt,
+    int64_t mean_tensor_uid = 0,
+    int64_t inv_variance_tensor_uid = 0,
     int64_t scale_tensor_uid = 0,
     int64_t bias_tensor_uid = 0,
     int64_t y_tensor_uid = 0) {
@@ -140,8 +140,8 @@ inline ::flatbuffers::Offset<BatchnormInferenceAttributes> CreateBatchnormInfere
   builder_.add_y_tensor_uid(y_tensor_uid);
   builder_.add_bias_tensor_uid(bias_tensor_uid);
   builder_.add_scale_tensor_uid(scale_tensor_uid);
-  if(inv_variance_tensor_uid) { builder_.add_inv_variance_tensor_uid(*inv_variance_tensor_uid); }
-  if(mean_tensor_uid) { builder_.add_mean_tensor_uid(*mean_tensor_uid); }
+  builder_.add_inv_variance_tensor_uid(inv_variance_tensor_uid);
+  builder_.add_mean_tensor_uid(mean_tensor_uid);
   builder_.add_x_tensor_uid(x_tensor_uid);
   return builder_.Finish();
 }

--- a/sdk/include/hipdnn_sdk/test_utilities/FlatbufferGraphTestUtils.hpp
+++ b/sdk/include/hipdnn_sdk/test_utilities/FlatbufferGraphTestUtils.hpp
@@ -32,7 +32,6 @@ inline flatbuffers::FlatBufferBuilder createEmptyValidGraph()
 inline flatbuffers::FlatBufferBuilder
     createValidBatchnormGraph(std::vector<int64_t> strides = {1, 3, 224, 224},
                               std::vector<int64_t> dims = {1, 3, 224, 224},
-                              bool hasOptionalAttributes = true,
                               hipdnn_sdk::data_objects::DataType inputDataType = DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
@@ -63,36 +62,31 @@ inline flatbuffers::FlatBufferBuilder
         &derivedStrides,
         &derivedDims));
 
-    if(hasOptionalAttributes)
-    {
-        tensorAttributes.push_back(hipdnn_sdk::data_objects::CreateTensorAttributesDirect(
-            builder,
-            5,
-            "est_mean",
-            hipdnn_sdk::data_objects::DataType::FLOAT,
-            &derivedStrides,
-            &derivedDims));
-
-        tensorAttributes.push_back(hipdnn_sdk::data_objects::CreateTensorAttributesDirect(
-            builder,
-            6,
-            "est_variance",
-            hipdnn_sdk::data_objects::DataType::FLOAT,
-            &derivedStrides,
-            &derivedDims));
-    }
-
-    auto bnormAttributes = hipdnn_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    tensorAttributes.push_back(hipdnn_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
-        1, // x uid
-        hasOptionalAttributes ? flatbuffers::Optional<int64_t>(5)
-                              : flatbuffers::nullopt, // mean uid
-        hasOptionalAttributes ? flatbuffers::Optional<int64_t>(6)
-                              : flatbuffers::nullopt, // inv_variance uid
-        3, // scale uid
-        4, // bias uid
-        2 // y uid
-    );
+        5,
+        "est_mean",
+        hipdnn_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+
+    tensorAttributes.push_back(hipdnn_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        6,
+        "est_variance",
+        hipdnn_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+
+    auto bnormAttributes
+        = hipdnn_sdk::data_objects::CreateBatchnormInferenceAttributes(builder,
+                                                                       1, // x uid
+                                                                       5, // mean uid
+                                                                       6, // inv_variance uid
+                                                                       3, // scale uid
+                                                                       4, // bias uid
+                                                                       2 // y uid
+        );
 
     std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::Node>> nodes;
     auto node = hipdnn_sdk::data_objects::CreateNodeDirect(

--- a/sdk/schemas/batchnorm_inference_attributes.fbs
+++ b/sdk/schemas/batchnorm_inference_attributes.fbs
@@ -6,8 +6,8 @@ namespace hipdnn_sdk.data_objects;
 // The long attributes are keys to the tensor_attributes->uid 
 table BatchnormInferenceAttributes {
     x_tensor_uid: long;
-    mean_tensor_uid: long = null;
-    inv_variance_tensor_uid: long = null;
+    mean_tensor_uid: long;
+    inv_variance_tensor_uid: long;
     scale_tensor_uid: long;
     bias_tensor_uid: long;
     y_tensor_uid: long;


### PR DESCRIPTION
## Proposed changes

Remove optional tensors from BN fwd inference schema, and update relevant areas.
Frontend API was treating them as non-optional, and having them optional was left over from the original POC work.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [X] I have added automated tests relevant to the introduced functionality
- [X] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [X] I have ran the tests, and they are all passing locally
- [X] I have ran the tests with ASAN, and they are all passing locally
- [X] I have added relevant documentation for the changes
- [X] I have removed the stale documentation which is no longer relevant after this pull request
- [X] I have ran `make format` & `make check_format` to ensure the changes have been formatted
